### PR TITLE
fix(swagger-link): add link to swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ exchange external token to internal token
 
 ## Documentation
 
-OpenAPI documentation is found in the `openapi` folder (in the root directory);
-see the README in that folder for more information.
+[OpenAPI documentation available here.](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/fence/master/openapi/swagger.yaml)
+
+YAML file for the OpenAPI documentation is found in the `openapi` folder (in
+the root directory); see the README in that folder for more details.


### PR DESCRIPTION
Add link to the swagger UI page in README.