### PR TITLE
fix(coverage): ignore tests directory

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+coverage:
+  enabled: true
+  exclude_paths:
+    - tests


### PR DESCRIPTION
Adds `.codacy.yml` configuration file. Don't count the tests directory in coverage reporting.