### PR TITLE
fix(auth): fix bug in `has_oauth`

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,4 +2,4 @@
 coverage:
   enabled: true
   exclude_paths:
-    - tests
+    - 'tests/**'

--- a/fence/blueprints/user.py
+++ b/fence/blueprints/user.py
@@ -1,7 +1,6 @@
 import flask
 from ..auth import login_required
 from flask import jsonify, g, make_response
-from flask_oauthlib.provider import OAuth2Provider
 from ..errors import UserError, NotFound
 from userdatamodel.models import *  # noqa
 from ..resources.user import send_mail, get_current_user_info
@@ -9,11 +8,6 @@ from flask import current_app as capp
 from flask import request
 from flask_sqlalchemy_session import current_session
 
-oauth = OAuth2Provider()
-
-
-def init_oauth(app):
-    oauth.init_app(app)
 
 
 REQUIRED_CERTIFICATES = {

--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -59,7 +59,8 @@ def get_user_info(user, session):
         'project_access': dict(user.project_access),
         'certificates_uploaded': [],
         'email': user.email,
-        'message': ""}
+        'message': ''
+    }
     if user.application:
         info['resources_granted'] = user.application.resources_granted
         info['certificates_uploaded'] = [

--- a/fence/settings.py
+++ b/fence/settings.py
@@ -7,7 +7,6 @@ APPLICATION_ROOT = '/user'
 DEBUG = True
 OAUTH2_PROVIDER_ERROR_URI = "/api/oauth2/errors"
 
-
 HOST_NAME = 'http://localhost:8000'
 SHIBBOLETH_HEADER = 'persistent_id'
 SSO_URL = 'https://itrusteauth.nih.gov/affwebservices/public/saml2sso?SPID=https://bionimbus-pdc.opensciencedatacloud.org/shibboleth&RelayState='

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3",
         "git+https://github.com/uc-cdis/storage-client.git@b4ae32788754bf399a13ee67eeecc822cabd85ae#egg=storageclient-0.1.4",
         "git+https://github.com/uc-cdis/userdatamodel.git@1.0.2#egg=userdatamodel",
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@9ce2843cc472b7b0f5c1e531e8473a7d9433e39c#egg=cdispyutils",
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@4112a98ff0e5bc45a4c86981cf051eab2fb9578a#egg=cdispyutils",
     ],
     scripts=[
         "bin/fence-create",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,8 +140,18 @@ def app(request):
         for tbl in reversed(Base.metadata.sorted_tables):
             fence.app.db.engine.execute(tbl.delete())
         mocker.unmock_functions()
+
     request.addfinalizer(fin)
     return fence.app
+
+
+@fence.app.route('/protected')
+@fence.auth.login_required({'access'})
+def protected_endpoint(methods=['GET']):
+    """
+    Add a protected endpoint to the app for testing.
+    """
+    return 'Got to protected endpoint'
 
 
 @pytest.fixture(scope='function')
@@ -180,7 +190,7 @@ def token_response(client, oauth_client):
     Return the token response from the end of the OAuth procedure from
     ``/oauth2/token``.
     """
-    return utils.get_token_response(client, oauth_client)
+    return utils.oauth2.get_token_response(client, oauth_client)
 
 
 @pytest.fixture(scope='function')
@@ -188,7 +198,7 @@ def access_token(client, oauth_client):
     """
     Return just an access token obtained from ``/oauth2/token``.
     """
-    token_response = utils.get_token_response(client, oauth_client)
+    token_response = utils.oauth2.get_token_response(client, oauth_client)
     return token_response.json['access_token']
 
 
@@ -197,5 +207,5 @@ def refresh_token(client, oauth_client):
     """
     Return just a refresh token obtained from ``/oauth2/token``.
     """
-    token_response = utils.get_token_response(client, oauth_client)
+    token_response = utils.oauth2.get_token_response(client, oauth_client)
     return token_response.json['refresh_token']

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -1,6 +1,14 @@
+"""
+Test the endpoints in the ``/oauth2`` blueprint.
+"""
+
+from cdispyutils import auth
+import pytest
 import urllib
 
-from .utils import oauth2 as utils
+import fence
+
+from . import utils
 
 
 def test_oauth2_authorize_get(client, oauth_client):
@@ -26,7 +34,7 @@ def test_oauth2_authorize_post(client, oauth_client):
     """
     Test ``POST /oauth2/authorize``.
     """
-    response = utils.oauth_post_authorize(client, oauth_client)
+    response = utils.oauth.oauth_post_authorize(client, oauth_client)
     assert response.status_code == 302
     location = response.headers['Location']
     assert location.startswith(oauth_client.url)
@@ -36,20 +44,18 @@ def test_oauth2_token_post(client, oauth_client):
     """
     Test ``POST /oauth2/token`` with a code from ``POST /oauth2/authorize``.
     """
-    code = utils.get_access_code(client, oauth_client)
-    response = utils.oauth_post_token(client, oauth_client, code)
+    code = utils.oauth.get_access_code(client, oauth_client)
+    response = utils.oauth.oauth_post_token(client, oauth_client, code)
     assert 'access_token' in response.json
     assert 'refresh_token' in response.json
 
 
-def test_oauth2_token_refresh(client, oauth_client):
+def test_oauth2_token_refresh(client, oauth_client, refresh_token):
     """
     Obtain refresh and access tokens, and test using the refresh token to
     obtain a new access token.
     """
-    token_response = utils.get_token_response(client, oauth_client)
-    refresh_token = token_response.json['refresh_token']
-    code = utils.get_access_code(client, oauth_client)
+    code = utils.oauth.get_access_code(client, oauth_client)
     data = {
         'client_id': oauth_client.client_id,
         'client_secret': oauth_client.client_secret,
@@ -61,7 +67,7 @@ def test_oauth2_token_refresh(client, oauth_client):
     assert response.status_code == 200, response.json
 
 
-def test_oauth2_token_post_revoke(client, oauth_client):
+def test_oauth2_token_post_revoke(client, oauth_client, refresh_token):
     """
     Test the following procedure:
     - ``POST /oauth2/authorize`` successfully to obtain code
@@ -69,13 +75,10 @@ def test_oauth2_token_post_revoke(client, oauth_client):
     - ``POST /oauth2/revoke`` to revoke the refresh token
     - Refresh token should no longer be usable at this point.
     """
-    # Get code and get refresh token.
-    token_response = utils.get_token_response(client, oauth_client)
-    refresh_token = token_response.json['refresh_token']
     # Revoke refresh token.
     client.post('/oauth2/revoke', data={'token': refresh_token})
     # Try to use refresh token.
-    code = utils.get_access_code(client, oauth_client)
+    code = utils.oauth.get_access_code(client, oauth_client)
     data = {
         'client_id': oauth_client.client_id,
         'client_secret': oauth_client.client_secret,
@@ -87,12 +90,43 @@ def test_oauth2_token_post_revoke(client, oauth_client):
     assert response.status_code == 401
 
 
-def test_validate_oauth2_token(client, oauth_client):
+def test_validate_oauth2_token(app, client, access_token, monkeypatch):
     """
     Get an access token from going through the OAuth procedure and try to use
     it to access a protected endpoint, ``/user``.
     """
-    token_response = utils.get_token_response(client, oauth_client)
-    access_token = token_response.json['access_token']
-    response = client.get('/user', headers={'Authorization': access_token})
-    assert response
+    monkeypatch.setitem(app.config, 'MOCK_AUTH', False)
+    headers = {'Authorization': 'bearer ' + access_token}
+    response = client.get('/user/', headers=headers)
+    assert response.status_code == 200, response.json
+
+
+def test_protected_endpoint(app, client, monkeypatch):
+    """
+    Try to make a request to a (fake) protected endpoint without an access
+    token and test that it fails.
+    """
+
+    @app.route('/protected')
+    @fence.auth.login_required({'access'})
+    def protected_endpoint(methods=['GET']):
+        """Should not get here."""
+        return 'foo'
+
+    monkeypatch.setitem(app.config, 'MOCK_AUTH', False)
+    response = client.get('/protected')
+    assert response.status_code == 401
+
+
+def test_malformed_auth_header_fails(app, client, access_token, monkeypatch):
+
+    @app.route('/protected')
+    @fence.auth.login_required({'access'})
+    def protected_endpoint(methods=['GET']):
+        """Should not get here."""
+        return 'foo'
+
+    monkeypatch.setitem(app.config, 'MOCK_AUTH', False)
+    headers = {'Authorization': access_token}
+    response = client.get('/protected', headers=headers)
+    assert response.status_code == 401

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -3,6 +3,8 @@ import tests
 from datetime import datetime, timedelta
 import uuid
 
+import tests.utils.oauth2
+
 
 def read_file(filename):
     """Read the contents of a file in the tests directory."""


### PR DESCRIPTION
- Fix call to `validate_request_jwt` to include `user_api` argument to specify the desired issuer (since fence needs to use its own hostname, not the `USER_API` config variable)
- Add regression tests