### PR TITLE
fix(deployment): fix settings import

### DIFF
--- a/bin/fence-create
+++ b/bin/fence-create
@@ -167,7 +167,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--path',
-        default='/var/www/fence-api/',
+        default='/var/www/fence/',
         help='path to find local_settings.py',
     )
     subparsers = parser.add_subparsers(title='action', dest='action')

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -5,8 +5,8 @@ import flask
 from flask.ext.cors import CORS
 from flask_postgres_session import PostgresSessionInterface
 from flask_sqlalchemy_session import flask_scoped_session
+import importlib
 
-from . import settings as fence_settings
 from .auth import logout
 from .blueprints.admin import blueprint as admin
 from .blueprints.login import blueprint as login
@@ -32,13 +32,15 @@ app.register_blueprint(admin, url_prefix='/admin')
 app.register_blueprint(login, url_prefix='/login')
 
 
-def app_config(app, settings=fence_settings):
+def app_config(app, settings='fence.settings', root_dir=None):
     """
     Set up the config for the Flask app.
     """
     app.config.from_object(settings)
     app.keypairs = []
-    root_dir = os.path.dirname(os.path.realpath(settings.__file__))
+    if root_dir is None:
+        root_dir = os.path.dirname(
+                os.path.dirname(os.path.realpath(__file__)))
     for kid, (public, private) in app.config['JWT_KEYPAIR_FILES'].iteritems():
         public_filepath = os.path.join(root_dir, public)
         private_filepath = os.path.join(root_dir, private)
@@ -75,8 +77,8 @@ def app_sessions(app):
     app.session_interface = PostgresSessionInterface(UserSession)  # noqa
 
 
-def app_init(app, settings='fence.settings'):
-    app_config(app, settings=settings)
+def app_init(app, settings='fence.settings', root_dir=None):
+    app_config(app, settings=settings, root_dir=root_dir)
     init_oauth(app)
     app_sessions(app)
 

--- a/fence/settings.py
+++ b/fence/settings.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from datetime import timedelta
 
-from .local_settings import *
+from local_settings import *
 
 APPLICATION_ROOT = '/user'
 DEBUG = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from addict import Dict
 import jwt
 from mock import patch
 import pytest
+import os
 
 
 from cdisutilstest.code.storage_client_mock import get_client
@@ -134,7 +135,8 @@ class Mocker(object):
 def app(request):
     mocker = Mocker()
     mocker.mock_functions()
-    app_init(fence.app, test_settings)
+    root_dir = os.path.dirname(os.path.realpath(__file__))
+    app_init(fence.app, test_settings, root_dir=root_dir)
 
     def fin():
         for tbl in reversed(Base.metadata.sorted_tables):


### PR DESCRIPTION
- resolve #22 
- app_config expects a module and app_init passes a string, switch to not depend on the parameter to be a string and allow root_dir to be passed as a parameter