### PR TITLE
chore(api_key): rename user refresh token to api_key

### DIFF
--- a/fence/blueprints/data.py
+++ b/fence/blueprints/data.py
@@ -105,7 +105,7 @@ def resolve_url(url, location, expires, action):
 
 def return_link(action, urls):
     protocol = request.args.get('protocol', None)
-    expires = request.args.get('expires_in', None)
+    expires = min(int(request.args.get('expires_in', 3600)), 3600)
     if (protocol is not None) and (protocol not in SUPPORTED_PROTOCOLS):
         raise NotSupported("The specified protocol is not supported")
     if len(urls) == 0:

--- a/fence/blueprints/data.py
+++ b/fence/blueprints/data.py
@@ -105,7 +105,7 @@ def resolve_url(url, location, expires, action):
 
 def return_link(action, urls):
     protocol = request.args.get('protocol', None)
-    expires = request.args.get('expires', None)
+    expires = request.args.get('expires_in', None)
     if (protocol is not None) and (protocol not in SUPPORTED_PROTOCOLS):
         raise NotSupported("The specified protocol is not supported")
     if len(urls) == 0:

--- a/fence/blueprints/login.py
+++ b/fence/blueprints/login.py
@@ -32,8 +32,6 @@ def login_from_google():
         session['username'] = email
         session['provider'] = IdentityProvider.google
         login_user(request, email, IdentityProvider.google)
-        # print session['redirect']
-        print session
         if session.get('redirect'):
             return redirect(session.get('redirect'))
         return jsonify({'username': email})

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -13,7 +13,11 @@ from fence.jwt.blacklist import BlacklistedToken
 
 # Allowed scopes for user requested token and oauth2 client requested token
 # TODO: this should be more discoverable and configurable
-USER_ALLOWED_SCOPES = ['user', 'credentials', 'data']
+#
+# Only allow web session based auth access credentials so that user
+# can't create a long-lived API key using a short lived access_token
+SESSION_ALLOWED_SCOPES = ['user', 'credentials', 'data']
+USER_ALLOWED_SCOPES = ['user', 'data']
 CLIENT_ALLOWED_SCOPES = ['user', 'data']
 
 

--- a/fence/resources/user/user_session.py
+++ b/fence/resources/user/user_session.py
@@ -36,7 +36,7 @@ import time
 from cdispyutils.auth.jwt_validation import validate_jwt
 from fence.jwt.keys import default_public_key
 from fence.jwt.token import generate_signed_access_token
-from fence.jwt.token import USER_ALLOWED_SCOPES
+from fence.jwt.token import SESSION_ALLOWED_SCOPES
 from fence.resources.storage.cdis_jwt import create_session_token
 from fence.errors import Unauthorized
 from fence import auth
@@ -219,7 +219,7 @@ def _clear_session_if_expired(app, session):
 
 def _create_access_token_cookie(app, response, user):
     keypair = app.keypairs[0]
-    scopes = USER_ALLOWED_SCOPES
+    scopes = SESSION_ALLOWED_SCOPES
 
     now = datetime.now()
     expiration = int(

--- a/openapi/swagger.yaml
+++ b/openapi/swagger.yaml
@@ -230,7 +230,7 @@ paths:
           in: query
           description: a protocol provided by storage provider, currently supports 'http' and 's3' protocols
           enum: [http, s3]
-        - name: expires
+        - name: expires_in
           required: false
           type: int
           in: query
@@ -264,7 +264,7 @@ paths:
           in: query
           description: a protocol provided by storage provider, currently supports 'http' and 's3' protocols
           enum: [http, s3]
-        - name: expires
+        - name: expires_in
           required: false
           type: int
           in: query

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     dependency_links=[
         "git+https://github.com/uc-cdis/storage-client.git@0.1.7#egg=storageclient-0.1.4",
         "git+https://github.com/uc-cdis/userdatamodel.git@1.0.2#egg=userdatamodel",
-        "git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.4#egg=cdispyutils",
+        "git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.5#egg=cdispyutils",
         "git+https://github.com/uc-cdis/cirrus.git@0.0.0#egg=cirrus-0.0.0",
     ],
     scripts=[

--- a/tests/test_cdis.py
+++ b/tests/test_cdis.py
@@ -2,57 +2,57 @@ import json
 from .utils import cdis as utils
 
 
-def test_cdis_create_refresh_token(client, oauth_client):
+def test_cdis_create_api_key(client, oauth_client):
     """
     Test ``POST /credentials/cdis``.
     """
-    res = utils.get_refresh_token_with_json(client).json
-    assert 'token_id' in res
-    assert 'refresh_token' in res
+    res = utils.get_api_key_with_json(client).json
+    assert 'key_id' in res
+    assert 'api_key' in res
 
 
 def test_cdis_get_access_token(client, oauth_client):
     """
-    Test ``PUT /credentials/cdis``.
+    Test ``POST /credentials/cdis/access_token``.
     """
-    response = utils.get_refresh_token(client)
-    refresh_token = response.json['refresh_token']
+    response = utils.get_api_key(client)
+    api_key = response.json['api_key']
     path = (
-        '/credentials/cdis/'
+        '/credentials/cdis/access_token'
     )
     data = {
-        'refresh_token': refresh_token,
+        'api_key': api_key,
     }
     headers = {
         'Content-Type': 'application/json'
     }
-    response = client.put(path, data=json.dumps(data), headers=headers)
+    response = client.post(path, data=json.dumps(data), headers=headers)
     assert 'access_token' in response.json
 
 
 def test_cdis_get_access_token_with_formdata(client, oauth_client):
     """
-    Test ``PUT /credentials/cdis``.
+    Test ``POST /credentials/cdis``.
     """
-    response = utils.get_refresh_token(client)
-    refresh_token = response.json['refresh_token']
+    response = utils.get_api_key(client)
+    api_key = response.json['api_key']
     path = (
-        '/credentials/cdis/'
+        '/credentials/cdis/access_token'
     )
     data = {
-        'refresh_token': refresh_token,
+        'api_key': api_key,
     }
     headers = {
         'Content-Type': 'application/x-www-form-urlencoded'
     }
-    response = client.put(path, data=data, headers=headers)
+    response = client.post(path, data=data, headers=headers)
     assert 'access_token' in response.json
 
 
-def test_cdis_list_refresh_token(client, oauth_client):
-    utils.get_refresh_token(client)
-    utils.get_refresh_token(client)
-    utils.get_refresh_token(client)
+def test_cdis_list_api_key(client, oauth_client):
+    utils.get_api_key(client)
+    utils.get_api_key(client)
+    utils.get_api_key(client)
     path = (
         '/credentials/cdis/'
     )

--- a/tests/test_cdis.py
+++ b/tests/test_cdis.py
@@ -11,6 +11,14 @@ def test_cdis_create_api_key(client, oauth_client):
     assert 'api_key' in res
 
 
+def test_cdis_create_api_key_with_disallowed_scope(client, oauth_client):
+    """
+    Test ``POST /credentials/cdis``.
+    """
+    res = utils.get_api_key(client, scopes=['credentials'])
+    assert res.status_code == 400
+
+
 def test_cdis_get_access_token(client, oauth_client):
     """
     Test ``POST /credentials/cdis/access_token``.

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -191,59 +191,6 @@ def test_google_create_access_token_post(app, oauth_client,
         assert response.status_code == 200
 
 
-def test_google_create_access_token_put(app, client,
-                                        oauth_client,
-                                        cloud_manager):
-    """
-    Test ``PUT /credentials/google``.
-    """
-    client_id = oauth_client["client_id"]
-    service_account_id = "123456789"
-    proxy_group_id = "proxy_group_0"
-    path = (
-        "/credentials/google/"
-    )
-    data = {}
-    with app.test_client() as app_client:
-
-        # set global client context
-        g.client_id = client_id
-
-        # get test user info
-        user = (
-            current_session
-                .query(User)
-                .filter_by(username="test")
-                .first()
-        )
-        user_id = user.id
-
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        current_session.add(proxy_group)
-
-        # create a service account for client for user
-        service_account = GoogleServiceAccount(
-            google_unique_id=service_account_id,
-            client_id=client_id,
-            user_id=user_id,
-            email=(client_id + "-" + str(user_id) + "@test.com")
-        )
-        current_session.add(user)
-        current_session.add(service_account)
-        current_session.commit()
-
-        response = app_client.put(path, data=data)
-
-        # check that the service account id was included in a call
-        # to cloud_manager
-
-        assert response.status_code == 400
-
-
 def test_google_delete_owned_access_token(app, client,
                                           oauth_client,
                                           cloud_manager):

--- a/tests/utils/cdis.py
+++ b/tests/utils/cdis.py
@@ -1,7 +1,7 @@
 import json
 
 
-def get_refresh_token(client):
+def get_api_key(client):
     """
     Args:
         client: client fixture
@@ -19,7 +19,7 @@ def get_refresh_token(client):
     return response
 
 
-def get_refresh_token_with_json(client):
+def get_api_key_with_json(client):
     """
     Args:
         client: client fixture

--- a/tests/utils/cdis.py
+++ b/tests/utils/cdis.py
@@ -1,7 +1,7 @@
 import json
 
 
-def get_api_key(client):
+def get_api_key(client, scopes=None):
     """
     Args:
         client: client fixture
@@ -15,7 +15,9 @@ def get_api_key(client):
     headers = {
         'Content-Type': 'application/x-www-form-urlencoded'
     }
-    response = client.post(path, data={'scopes': ['data', 'user']}, headers=headers)
+    if scopes is None:
+        scopes = ['data', 'user']
+    response = client.post(path, data={'scopes': scopes}, headers=headers)
     return response
 
 


### PR DESCRIPTION
resolve #48 
- rename user's refresh_token to api_key, it introduces unecessary confusion to call user's token as refresh_token because people would think this is Oauth2/OIDC but it's not.
- use 'expires_in' for both user credentials and data endpoint for consistency with oauth
- restrict `/credentials/cdis/access_token` endpoint only accessable by user's API key whose `azp` == `sub`
- fix how expiration param is handled - convert to int and max to 30 days for api key and 1h for access_token


need to merge https://github.com/uc-cdis/cdis-python-utils/pull/23 first