### PR TITLE
fix/client: allow public client to use refresh token grant

### DIFF
--- a/fence/jwt/blacklist.py
+++ b/fence/jwt/blacklist.py
@@ -94,7 +94,7 @@ def blacklist_encoded_token(encoded_token, public_key=None):
     public_key = public_key or keys.default_public_key()
     try:
         claims = jwt.decode(
-            encoded_token, public_key, algorithm='RS256', audience='fence'
+            encoded_token, public_key, algorithm='RS256', audience='openid'
         )
     except jwt.InvalidTokenError as e:
         raise BlacklistingError('failed to decode token: {}'.format(e))

--- a/fence/models.py
+++ b/fence/models.py
@@ -35,7 +35,7 @@ class Client(Base, OAuth2ClientMixin):
 
     client_id = Column(String(40), primary_key=True)
     # this is hashed secret
-    client_secret = Column(String(60), unique=True, index=True, nullable=False)
+    client_secret = Column(String(60), unique=True, index=True, nullable=True)
 
     # human readable name
     name = Column(String(40), unique=True, nullable=False)
@@ -51,7 +51,7 @@ class Client(Base, OAuth2ClientMixin):
     auto_approve = Column(Boolean, default=False)
 
     # public or confidential
-    is_confidential = Column(Boolean)
+    is_confidential = Column(Boolean, default=True)
 
     _allowed_scopes = Column(Text, nullable=False, default='')
 
@@ -74,9 +74,15 @@ class Client(Base, OAuth2ClientMixin):
 
     @property
     def client_type(self):
-        if self.is_confidential:
-            return 'confidential'
-        return 'public'
+        """
+        The client should be considered confidential either if it is actually
+        marked confidential, *or* if the confidential setting was left empty.
+        Only in the case where ``is_confidential`` is deliberately set to
+        ``False`` should the client be considered public.
+        """
+        if self.is_confidential is False:
+            return 'public'
+        return 'confidential'
 
     @property
     def redirect_uris(self):

--- a/fence/oidc/grants/authorization_code_grant.py
+++ b/fence/oidc/grants/authorization_code_grant.py
@@ -101,12 +101,10 @@ class AuthorizationCodeGrant(AuthlibAuthorizationCodeGrant):
             Tuple[int, dict, dict]: tuple of (status_code, body, headers)
         """
         client = self._authenticated_client
-        is_confidential = client.check_client_type('confidential')
         token = self.token_generator(
             client,
             self.GRANT_TYPE,
             scope=get_obj_value(self._authorization_code, 'scope'),
-            include_refresh_token=is_confidential,
             nonce=self._authorization_code.nonce,
         )
         self.create_access_token(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,8 +390,8 @@ def oauth_client(app, db_session, oauth_user):
     )
     db_session.add(models.Client(
         client_id=client_id, client_secret=hashed_secret, user=test_user,
-        allowed_scopes=['openid', 'user'], _redirect_uris=url, description='',
-        is_confidential=True, name='testclient'
+        allowed_scopes=['openid', 'user', 'fence'], _redirect_uris=url,
+        description='', is_confidential=True, name='testclient'
     ))
     db_session.commit()
     return Dict(client_id=client_id, client_secret=client_secret, url=url)
@@ -400,8 +400,8 @@ def oauth_client(app, db_session, oauth_user):
 @pytest.fixture(scope='function')
 def oauth_client_B(app, request, db_session):
     """
-    Create a second, different OAuth2 client and add it to the database along
-    with a test user for the client.
+    Create a second, different OAuth2 (confidential) client and add it to the
+    database along with a test user for the client.
     """
     url = 'https://oauth-test-client-B.net'
     client_id = 'test-client-B'
@@ -419,12 +419,34 @@ def oauth_client_B(app, request, db_session):
         db_session.add(test_user)
     db_session.add(models.Client(
         client_id=client_id, client_secret=hashed_secret, user=test_user,
-        allowed_scopes=['openid', 'user'], _redirect_uris=url, description='',
-        is_confidential=True, name='testclientb'
+        allowed_scopes=['openid', 'user', 'fence'], _redirect_uris=url,
+        description='', is_confidential=True, name='testclientb'
     ))
     db_session.commit()
 
     return Dict(client_id=client_id, client_secret=client_secret, url=url)
+
+
+@pytest.fixture(scope='function')
+def oauth_client_public(app, db_session, oauth_user):
+    """
+    Create a public OAuth2 client.
+    """
+    url = 'https://oauth-test-client-public.net'
+    client_id = 'test-client-public'
+    test_user = (
+        db_session
+        .query(models.User)
+        .filter_by(id=oauth_user.user_id)
+        .first()
+    )
+    db_session.add(models.Client(
+        client_id=client_id, user=test_user,
+        allowed_scopes=['openid', 'user', 'fence'], _redirect_uris=url,
+        description='', is_confidential=False, name='testclient-public'
+    ))
+    db_session.commit()
+    return Dict(client_id=client_id, url=url)
 
 
 @pytest.fixture(scope='function')

--- a/tests/rfc6749/conftest.py
+++ b/tests/rfc6749/conftest.py
@@ -30,7 +30,10 @@ def refresh_token(client, oauth_client):
     """
     Return just a refresh token obtained from ``/oauth2/token``.
     """
+    data = {
+        'scope': 'openid user fence'
+    }
     token_response = tests.utils.oauth2.get_token_response(
-        client, oauth_client
+        client, oauth_client, code_request_data=data
     )
     return token_response.json['refresh_token']

--- a/tests/rfc6749/test_oauth2.py
+++ b/tests/rfc6749/test_oauth2.py
@@ -27,14 +27,47 @@ def test_oauth2_authorize_get(client, oauth_client):
     assert response.status_code == 200
 
 
+def test_oauth2_authorize_get_public_client(client, oauth_client_public):
+    """
+    Test ``GET /oauth2/authorize`` with a public client.
+    """
+    path = (
+        '/oauth2/authorize'
+        '?client_id={client_id}'
+        '&response_type=code'
+        '&scope=user'
+        '&redirect_uri={redirect_uri}'
+    )
+    path = path.format(
+        client_id=oauth_client_public.client_id,
+        redirect_uri=urllib.quote_plus(oauth_client_public.url)
+    )
+    response = client.get(path)
+    assert response.status_code == 200
+
+
 def test_oauth2_authorize_post(client, oauth_client):
     """
     Test ``POST /oauth2/authorize``.
     """
-    response = tests.utils.oauth2.post_authorize(client, oauth_client, confirm=True)
+    response = tests.utils.oauth2.post_authorize(
+        client, oauth_client, confirm=True
+    )
     assert response.status_code == 302, response
     location = response.headers['Location']
     assert location.startswith(oauth_client.url), location
+
+
+def test_oauth2_authorize_post_public_client(client, oauth_client_public):
+    """
+    Test ``POST /oauth2/authorize`` with a public client.
+    """
+    response = tests.utils.oauth2.post_authorize(
+        client, oauth_client_public, confirm=True
+    )
+    assert response.status_code == 302, response
+    location = response.headers['Location']
+    assert location.startswith(oauth_client_public.url), location
 
 
 def test_oauth2_token_post(client, oauth_client):
@@ -45,6 +78,22 @@ def test_oauth2_token_post(client, oauth_client):
     response = tests.utils.oauth2.post_token(client, oauth_client, code)
     assert 'access_token' in response.json
     assert 'refresh_token' in response.json
+
+
+def test_oauth2_token_post_public_client(client, oauth_client_public):
+    """
+    Test ``POST /oauth2/token`` with a code from ``POST /oauth2/authorize``.
+    """
+    code = tests.utils.oauth2.get_access_code(client, oauth_client_public)
+    data = {
+        'client_id': oauth_client_public.client_id,
+        'code': code,
+        'grant_type': 'authorization_code',
+        'redirect_uri': oauth_client_public.url,
+    }
+    token_response = client.post('/oauth2/token', data=data)
+    assert 'access_token' in token_response.json
+    assert 'refresh_token' in token_response.json
 
 
 def test_oauth2_token_refresh(client, oauth_client, refresh_token):
@@ -65,6 +114,23 @@ def test_oauth2_token_refresh(client, oauth_client, refresh_token):
     assert response.status_code == 200, response.json
 
 
+def test_oauth2_token_refresh_public_client(
+        client, oauth_client_public, refresh_token):
+    """
+    Obtain refresh and access tokens, and test using the refresh token to
+    obtain a new access token.
+    """
+    code = tests.utils.oauth2.get_access_code(client, oauth_client_public)
+    data = {
+        'client_id': oauth_client_public.client_id,
+        'code': code,
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token,
+    }
+    response = client.post('/oauth2/token', data=data)
+    assert response.status_code == 200, response.json
+
+
 def test_oauth2_token_post_revoke(client, oauth_client, refresh_token):
     """
     Test the following procedure:
@@ -73,8 +139,12 @@ def test_oauth2_token_post_revoke(client, oauth_client, refresh_token):
     - ``POST /oauth2/revoke`` to revoke the refresh token
     - Refresh token should no longer be usable at this point.
     """
+    headers = tests.utils.oauth2.create_basic_header_for_client(oauth_client)
     # Revoke refresh token.
-    client.post('/oauth2/revoke', data={'token': refresh_token})
+    revocation_response = client.post(
+        '/oauth2/revoke', headers=headers, data={'token': refresh_token}
+    )
+    assert revocation_response.status_code == 204
     # Try to use refresh token.
     code = tests.utils.oauth2.get_access_code(client, oauth_client)
     data = {
@@ -84,8 +154,9 @@ def test_oauth2_token_post_revoke(client, oauth_client, refresh_token):
         'grant_type': 'refresh_token',
         'refresh_token': refresh_token,
     }
-    response = client.post('/oauth2/token', data=data)
-    assert response.status_code == 401
+    response = client.post('/oauth2/token', headers=headers, data=data)
+    assert response.status_code == 400
+    assert response.json['error'] == 'invalid_request'
 
 
 def test_all_scopes_have_description():

--- a/tests/rfc6749/test_oauth2.py
+++ b/tests/rfc6749/test_oauth2.py
@@ -101,12 +101,10 @@ def test_oauth2_token_refresh(client, oauth_client, refresh_token):
     Obtain refresh and access tokens, and test using the refresh token to
     obtain a new access token.
     """
-    code = tests.utils.oauth2.get_access_code(client, oauth_client)
     headers = tests.utils.oauth2.create_basic_header_for_client(oauth_client)
     data = {
         'client_id': oauth_client.client_id,
         'client_secret': oauth_client.client_secret,
-        'code': code,
         'grant_type': 'refresh_token',
         'refresh_token': refresh_token,
     }


### PR DESCRIPTION
Resolves #148.

Key points:
- [Override authlib method](https://github.com/uc-cdis/fence/compare/fix/client?expand=1#diff-fb722da188e9b9f3342328c53791e416R89) which failed immediately on non-confidential (i.e. public) clients.
- Add some very basic regression tests.