### PR TITLE
feat(google): temporary key expiration handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 
-python: 2.7
+python:
+  - "2.7"
+  - "3.6"
+
+matrix:
+ allow_failures:
+   - python: "3.6"
 
 sudo: false
 

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -24,19 +24,22 @@ from fence.utils import create_client, drop_client
 from fence.sync.sync_dbgap import DbGapSyncer
 
 
-def create_client_action(DB, username=None, client=None, urls=None, auto_approve=True):
+def create_client_action(
+        DB, username=None, client=None, urls=None, auto_approve=True):
     try:
-        print create_client(username, urls, DB, name=client, auto_approve=auto_approve)
+        print(
+            create_client(
+                username, urls, DB, name=client, auto_approve=auto_approve))
     except Exception as e:
-        print e.message
+        print(e.message)
 
 
 def delete_client_action(DB, client):
     try:
         drop_client(client, DB)
-        print 'Client {} deleted'.format(client)
+        print('Client {} deleted'.format(client))
     except Exception as e:
-        print e.message
+        print(e.message)
 
 
 def sync_dbgap(projects):
@@ -67,7 +70,7 @@ def sync_dbgap(projects):
         project_mapping = yaml.load(f)
     syncer = DbGapSyncer(
         dbGaP, DB, project_mapping, storage_credentials=STORAGE_CREDENTIALS)
-    print 'sycn'
+    print('sycn')
     syncer.sync()
 
 
@@ -121,23 +124,22 @@ def create_project(s, project_data):
                     CloudProvider).filter_by(name=provider).first()
                 sa = StorageAccess(provider=c_provider, project=project)
                 s.add(sa)
-                print ('created storage access for {} to {}'
-                       .format(project.name, c_provider.name))
+                print('created storage access for {} to {}'
+                      .format(project.name, c_provider.name))
             for bucket in buckets:
                 b = (
                     s.query(Bucket)
                     .filter_by(name=bucket)
                     .join(Bucket.provider)
-                    .filter(CloudProvider.name==provider)
+                    .filter(CloudProvider.name == provider)
                     .first()
                 )
-                print b
+                print(b)
                 if not b:
                     b = Bucket(name=bucket)
                     b.provider = c_provider
                     s.add(b)
-                    print ('created bucket {} in db'.format(bucket))
-
+                    print('created bucket {} in db'.format(bucket))
 
     return project
 
@@ -148,29 +150,34 @@ def grant_project_to_group_or_user(s, project_data, group=None, user=None):
     if group:
         ap = s.query(AccessPrivilege).join(AccessPrivilege.project)\
             .join(AccessPrivilege.research_group)\
-            .filter(Project.name == project.name, Group.name == group.name).first()
+            .filter(
+                Project.name == project.name, Group.name == group.name).first()
         name = group.name
     elif user:
         ap = s.query(AccessPrivilege).join(AccessPrivilege.project)\
             .join(AccessPrivilege.user)\
-            .filter(Project.name == project.name, User.username == user.username).first()
+            .filter(
+                Project.name == project.name,
+                User.username == user.username).first()
         name = user.username
     else:
         raise Exception("need to provide either a user or group")
     if not ap:
         if group:
-            ap = AccessPrivilege(project=project, research_group=group, privilege=privilege)
+            ap = AccessPrivilege(
+                project=project, research_group=group, privilege=privilege)
         elif user:
-            ap = AccessPrivilege(project=project, user=user, privilege=privilege)
+            ap = AccessPrivilege(
+                project=project, user=user, privilege=privilege)
         else:
             raise Exception("need to provide either a user or group")
         s.add(ap)
-        print ('created access privilege {} of project {} to {}'
-               .format(privilege, project.name, name))
+        print('created access privilege {} of project {} to {}'
+              .format(privilege, project.name, name))
     else:
         ap.privilege = privilege
-        print ('updated access privilege {} of project {} to {}'
-               .format(privilege, project.name, name))
+        print('updated access privilege {} of project {} to {}'
+              .format(privilege, project.name, name))
 
 
 def create_cloud_providers(s, data):
@@ -180,7 +187,9 @@ def create_cloud_providers(s, data):
             CloudProvider.name == name
         ).first()
         if not cloud_provider:
-            cloud_provider = CloudProvider(name=name, backend=fields.get('backend', 'cleversafe'), service=fields.get('service', 'storage'))
+            cloud_provider = CloudProvider(
+                name=name, backend=fields.get('backend', 'cleversafe'),
+                service=fields.get('service', 'storage'))
             s.add(cloud_provider)
 
 
@@ -277,14 +286,6 @@ if __name__ == '__main__':
     dbgap_sync.add_argument('--projects', required=True)
 
     manage_google_keys = subparsers.add_parser('google-manage-keys')
-    manage_google_keys.add_argument(
-        '--db', type=str, required=True, help='database name')
-    manage_google_keys.add_argument(
-        '--username', default='postgres', help='database username')
-    manage_google_keys.add_argument(
-        '--password', default='', help='database password')
-    manage_google_keys.add_argument(
-        '--host', default='localhost', help='database hostname')
 
     args = parser.parse_args()
 
@@ -307,14 +308,7 @@ if __name__ == '__main__':
         sync_dbgap(args.__dict__['projects'])
 
     elif args.action == 'google-manage-keys':
-        db = (
-            "postgresql://{username}:{password}@{host}/{db}"
-            .format(
-                username=args.username, password=args.password,
-                host=args.host, db=args.db)
-        )
-
-        remove_expired_google_service_account_keys(db)
+        remove_expired_google_service_account_keys(DB)
 
     else:
         pass

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -15,6 +15,10 @@ from userdatamodel.models import (
     User,
     Bucket,
 )
+from cirrus import GoogleCloudManager
+
+from fence.models import GoogleServiceAccount
+from fence.models import Client
 
 from fence.utils import create_client, drop_client
 from fence.sync.sync_dbgap import DbGapSyncer
@@ -225,6 +229,20 @@ def assign_group_to_user(s, user, group_name, group_data):
         user.groups.append(group)
 
 
+def remove_expired_google_service_account_keys(db):
+    db = SQLAlchemyDriver(db)
+    with db.session as s:
+        client_service_accounts = (
+            s.query(GoogleServiceAccount, Client).filter(
+                GoogleServiceAccount.client_id == Client.client_id)
+        )
+
+        with GoogleCloudManager() as g_mgr:
+            for service_account, client in client_service_accounts:
+                g_mgr.handle_expired_service_account_keys(
+                    service_account.google_unique_id)
+
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
@@ -257,6 +275,17 @@ if __name__ == '__main__':
 
     dbgap_sync = subparsers.add_parser('sync-dbgap')
     dbgap_sync.add_argument('--projects', required=True)
+
+    manage_google_keys = subparsers.add_parser('google-manage-keys')
+    manage_google_keys.add_argument(
+        '--db', type=str, required=True, help='database name')
+    manage_google_keys.add_argument(
+        '--username', default='postgres', help='database username')
+    manage_google_keys.add_argument(
+        '--password', default='', help='database password')
+    manage_google_keys.add_argument(
+        '--host', default='localhost', help='database hostname')
+
     args = parser.parse_args()
 
     sys.path.append(args.path)
@@ -276,3 +305,16 @@ if __name__ == '__main__':
         delete_client_action(DB, args.client)
     elif args.action == 'sync-dbgap':
         sync_dbgap(args.__dict__['projects'])
+
+    elif args.action == 'google-manage-keys':
+        db = (
+            "postgresql://{username}:{password}@{host}/{db}"
+            .format(
+                username=args.username, password=args.password,
+                host=args.host, db=args.db)
+        )
+
+        remove_expired_google_service_account_keys(db)
+
+    else:
+        pass

--- a/fence/auth.py
+++ b/fence/auth.py
@@ -1,6 +1,8 @@
 from functools import wraps
 
 from authutils.errors import JWTError, JWTExpiredError
+from authutils.token.validate import require_auth_header
+from authutils.token.validate import current_token
 import flask
 from flask_sqlalchemy_session import current_session
 

--- a/fence/blueprints/storage_creds.py
+++ b/fence/blueprints/storage_creds.py
@@ -119,7 +119,7 @@ def list_keypairs(provider):
         }
 
     """
-    client_id = current_token["azp"] or None
+    client_id = current_token.get("azp")
     user_id = current_token["sub"]
 
     if provider == 'cdis':
@@ -220,7 +220,7 @@ def create_keypairs(provider):
             "secret_key": "1lnkGScEH8Vr4EC6QnoqLK1PqRWPNqIBJkH6Vpgx"
         }
     """
-    client_id = current_token["azp"] or None
+    client_id = current_token.get("azp")
     user_id = current_token["sub"]
 
     if provider == 'cdis':
@@ -255,7 +255,7 @@ def create_keypairs(provider):
         return flask.jsonify(dict(key_id=claims['jti'], api_key=api_key))
     elif provider == 'google':
         with GoogleCloudManager() as g_cloud:
-            client_id = current_token["azp"] or None
+            client_id = current_token.get("azp")
             key = _get_google_access_key_for_client(g_cloud, client_id, user_id)
         return flask.jsonify(key)
     else:
@@ -352,7 +352,7 @@ def delete_keypair(provider, access_key):
         blacklist_token(jti, api_key.expires)
     elif provider == 'google':
         with GoogleCloudManager() as g_cloud:
-            client_id = current_token["azp"] or None
+            client_id = current_token.get("azp")
             service_account = _get_google_service_account_for_client(
                 g_cloud, client_id, user_id)
 
@@ -458,14 +458,13 @@ def _get_google_service_account_for_client(
     # prioritize oauth client id over user id
     service_account = None
 
-    if client_id:
-        service_account = (
-            current_session
-            .query(GoogleServiceAccount)
-            .filter_by(client_id=client_id,
-                       user_id=user_id)
-            .first()
-        )
+    service_account = (
+        current_session
+        .query(GoogleServiceAccount)
+        .filter_by(client_id=client_id,
+                   user_id=user_id)
+        .first()
+    )
 
     return service_account
 

--- a/fence/blueprints/storage_creds.py
+++ b/fence/blueprints/storage_creds.py
@@ -119,7 +119,7 @@ def list_keypairs(provider):
         }
 
     """
-    client_id = current_token.get("azp")
+    client_id = current_token.get("azp") or None
     user_id = current_token["sub"]
 
     if provider == 'cdis':
@@ -220,7 +220,7 @@ def create_keypairs(provider):
             "secret_key": "1lnkGScEH8Vr4EC6QnoqLK1PqRWPNqIBJkH6Vpgx"
         }
     """
-    client_id = current_token.get("azp")
+    client_id = current_token.get("azp") or None
     user_id = current_token["sub"]
 
     if provider == 'cdis':
@@ -255,7 +255,7 @@ def create_keypairs(provider):
         return flask.jsonify(dict(key_id=claims['jti'], api_key=api_key))
     elif provider == 'google':
         with GoogleCloudManager() as g_cloud:
-            client_id = current_token.get("azp")
+            client_id = current_token.get("azp") or None
             key = _get_google_access_key_for_client(g_cloud, client_id, user_id)
         return flask.jsonify(key)
     else:
@@ -352,7 +352,7 @@ def delete_keypair(provider, access_key):
         blacklist_token(jti, api_key.expires)
     elif provider == 'google':
         with GoogleCloudManager() as g_cloud:
-            client_id = current_token.get("azp")
+            client_id = current_token.get("azp") or None
             service_account = _get_google_service_account_for_client(
                 g_cloud, client_id, user_id)
 
@@ -427,7 +427,6 @@ def _get_google_access_key_for_client(g_cloud_manager, client_id, user_id):
 
     if not service_account:
         if client_id:
-            user_id = current_token["sub"]
             service_account = _create_google_service_account_for_client(
                 g_cloud_manager, client_id, user_id)
         else:
@@ -455,9 +454,6 @@ def _get_google_service_account_for_client(
     Returns:
         fence.models.GoogleServiceAccount: Client's service account
     """
-    # prioritize oauth client id over user id
-    service_account = None
-
     service_account = (
         current_session
         .query(GoogleServiceAccount)

--- a/fence/blueprints/storage_creds.py
+++ b/fence/blueprints/storage_creds.py
@@ -1,9 +1,10 @@
 import json
 
 from cirrus import GoogleCloudManager
+from cirrus.google_cloud import get_valid_service_account_id_for_client
+
 from flask_sqlalchemy_session import current_session
 import flask
-from userdatamodel.models import User
 
 from fence.auth import require_auth_header
 from fence.auth import current_token
@@ -493,9 +494,12 @@ def _create_google_service_account_for_client(
     )
 
     if proxy_group:
+        service_account_id = get_valid_service_account_id_for_client(
+            client_id, user_id)
+
         new_service_account = (
             g_cloud_manager.create_service_account_for_proxy_group(
-                proxy_group.id, account_id=client_id)
+                proxy_group.id, account_id=service_account_id)
         )
 
         service_account = GoogleServiceAccount(
@@ -504,6 +508,7 @@ def _create_google_service_account_for_client(
             user_id=user_id,
             email=new_service_account['email']
         )
+
         current_session.add(service_account)
         current_session.commit()
     else:

--- a/fence/blueprints/storage_creds.py
+++ b/fence/blueprints/storage_creds.py
@@ -482,8 +482,6 @@ def _create_google_service_account_for_client(
     Returns:
         fence.models.GoogleServiceAccount: New service account
     """
-    # create service account, add to db
-    # TODO eventually proxy group id should be in the token
     proxy_group_id = (
         current_token.get('context', {})
         .get('user', {})

--- a/fence/blueprints/storage_creds.py
+++ b/fence/blueprints/storage_creds.py
@@ -344,7 +344,7 @@ def delete_keypair(provider, access_key):
             api_key = (
                 session
                 .query(UserRefreshToken)
-                .filter_by(jti=jti)
+                .filter_by(jti=jti, userid=user_id)
                 .first()
             )
         if not api_key:

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -246,7 +246,7 @@ def generate_signed_id_token(
 
 
 def generate_signed_refresh_token(
-        kid, private_key, user, expires_in, scopes):
+        kid, private_key, user, expires_in, scopes, client_id=None):
     """
     Generate a JWT refresh token and output a UTF-8
     string of the encoded JWT signed with the private key.
@@ -273,6 +273,7 @@ def generate_signed_refresh_token(
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': client_id or ''
     }
     flask.current_app.logger.info(
         'issuing JWT refresh token with id [{}] to [{}]'.format(jti, sub)
@@ -314,6 +315,7 @@ def generate_api_key(
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': client_id or ''
     }
     flask.current_app.logger.info(
         'issuing JWT API key with id [{}] to [{}]'.format(jti, sub)
@@ -328,7 +330,8 @@ def generate_api_key(
 
 
 def generate_signed_access_token(
-        kid, private_key, user, expires_in, scopes, forced_exp_time=None):
+        kid, private_key, user, expires_in, scopes, forced_exp_time=None,
+        client_id=None):
     """
     Generate a JWT access token and output a UTF-8
     string of the encoded JWT signed with the private key.
@@ -366,6 +369,7 @@ def generate_signed_access_token(
                 'projects': dict(user.project_access),
             },
         },
+        'azp': client_id or ''
     }
     flask.current_app.logger.info(
         'issuing JWT access token with id [{}] to [{}]'.format(jti, sub)

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -288,7 +288,7 @@ def generate_signed_refresh_token(
 
 
 def generate_api_key(
-        kid, private_key, user, expires_in, scopes, client_id):
+        kid, private_key, user_id, expires_in, scopes, client_id):
     """
     Generate a JWT refresh token and output a UTF-8
     string of the encoded JWT signed with the private key.
@@ -296,9 +296,9 @@ def generate_api_key(
     Args:
         kid (str): key id of the keypair used to generate token
         private_key (str): RSA private key to sign and encode the JWT with
-        user (user id): User id to generate token for
+        user_id (user id): User id to generate token for
         expires_in (int): seconds until expiration
-        scopes (List[str]): oauth scopes for user
+        scopes (List[str]): oauth scopes for user_id
 
     Return:
         str: encoded JWT refresh token signed with ``private_key``
@@ -306,7 +306,7 @@ def generate_api_key(
     headers = {'kid': kid}
     iat, exp = issued_and_expiration_times(expires_in)
     jti = str(uuid.uuid4())
-    sub = str(user)
+    sub = str(user_id)
     claims = {
         'pur': 'api_key',
         'aud': scopes,

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -367,6 +367,9 @@ def generate_signed_access_token(
                 'name': user.username,
                 'is_admin': user.is_admin,
                 'projects': dict(user.project_access),
+                'google': {
+                    'proxy_group': user.google_proxy_group_id,
+                }
             },
         },
         'azp': client_id or ''
@@ -425,6 +428,9 @@ def generate_id_token(
                 'name': user.username,
                 'is_admin': user.is_admin,
                 'projects': dict(user.project_access),
+                'google': {
+                    'proxy_group': user.google_proxy_group_id,
+                }
             },
         },
         'pur': 'id',

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -427,10 +427,7 @@ def generate_id_token(
             'user': {
                 'name': user.username,
                 'is_admin': user.is_admin,
-                'projects': dict(user.project_access),
-                'google': {
-                    'proxy_group': user.google_proxy_group_id,
-                }
+                'projects': dict(user.project_access)
             },
         },
         'pur': 'id',

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -296,7 +296,7 @@ def generate_api_key(
     Args:
         kid (str): key id of the keypair used to generate token
         private_key (str): RSA private key to sign and encode the JWT with
-        user (fence.models.User): User to generate token for
+        user (user id): User id to generate token for
         expires_in (int): seconds until expiration
         scopes (List[str]): oauth scopes for user
 
@@ -306,7 +306,7 @@ def generate_api_key(
     headers = {'kid': kid}
     iat, exp = issued_and_expiration_times(expires_in)
     jti = str(uuid.uuid4())
-    sub = str(user.id)
+    sub = str(user)
     claims = {
         'pur': 'api_key',
         'aud': scopes,

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -99,6 +99,7 @@ class JWTGenerator(BearerToken):
             user=user,
             expires_in=self.ACCESS_TOKEN_EXPIRES_IN,
             scopes=scope,
+            client_id=client.client_id,
         )
         # If ``refresh_token`` was passed (for instance from the refresh
         # grant), use that instead of generating a new one.
@@ -109,6 +110,7 @@ class JWTGenerator(BearerToken):
                 user=user,
                 expires_in=self.REFRESH_TOKEN_EXPIRES_IN,
                 scopes=scope,
+                client_id=client.client_id,
             )
         # ``expires_in`` is just the access token expiration time.
         expires_in = self.ACCESS_TOKEN_EXPIRES_IN

--- a/fence/resources/storage/cdis_jwt.py
+++ b/fence/resources/storage/cdis_jwt.py
@@ -44,7 +44,7 @@ def create_api_key(user, keypair, expires_in, scopes, client_id):
     with flask.current_app.db.session as session:
         session.add(
             UserRefreshToken(
-                jti=claims['jti'], userid=user.id, expires=claims['exp']
+                jti=claims['jti'], userid=user, expires=claims['exp']
             )
         )
         session.commit()

--- a/fence/resources/storage/cdis_jwt.py
+++ b/fence/resources/storage/cdis_jwt.py
@@ -37,14 +37,14 @@ def create_access_token(user, keypair, api_key, expires_in, scopes):
     )
 
 
-def create_api_key(user, keypair, expires_in, scopes, client_id):
+def create_api_key(user_id, keypair, expires_in, scopes, client_id):
     return_token, claims = token.generate_api_key(
-        keypair.kid, keypair.private_key, user, expires_in, scopes, client_id
+        keypair.kid, keypair.private_key, user_id, expires_in, scopes, client_id
     )
     with flask.current_app.db.session as session:
         session.add(
             UserRefreshToken(
-                jti=claims['jti'], userid=user, expires=claims['exp']
+                jti=claims['jti'], userid=user_id, expires=claims['exp']
             )
         )
         session.commit()

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -20,19 +20,21 @@ from fence.utils import create_client, drop_client
 from fence.sync.sync_dbgap import DbGapSyncer
 
 
-def create_client_action(DB, username=None, client=None, urls=None):
+def create_client_action(
+        DB, username=None, client=None, urls=None, auto_approve=True):
     try:
-        print create_client(username, urls, DB, name=client, auto_approve=True)
+        print(create_client(
+            username, urls, DB, name=client, auto_approve=auto_approve))
     except Exception as e:
-        print e.message
+        print(e.message)
 
 
 def delete_client_action(DB, client):
     try:
         drop_client(client, DB)
-        print 'Client {} deleted'.format(client)
+        print('Client {} deleted'.format(client))
     except Exception as e:
-        print e.message
+        print(e.message)
 
 
 def sync_dbgap(projects):
@@ -135,12 +137,12 @@ def create_project(s, project_data):
                     .filter(CloudProvider.name == provider)
                     .first()
                 )
-                print b
+                print(b)
                 if not b:
                     b = Bucket(name=bucket)
                     b.provider = c_provider
                     s.add(b)
-                    print ('created bucket {} in db'.format(bucket))
+                    print('created bucket {} in db'.format(bucket))
 
     return project
 
@@ -185,14 +187,14 @@ def grant_project_to_group_or_user(s, project_data, group=None, user=None):
         else:
             raise Exception('need to provide either a user or group')
         s.add(ap)
-        print (
+        print(
             'created access privilege {} of project {} to {}'
             .format(privilege, project.name, name)
         )
     else:
         ap.privilege = privilege
-        print ('updated access privilege {} of project {} to {}'
-               .format(privilege, project.name, name))
+        print('updated access privilege {} of project {} to {}'
+              .format(privilege, project.name, name))
 
 
 def create_cloud_providers(s, data):

--- a/fence/settings.py
+++ b/fence/settings.py
@@ -33,7 +33,7 @@ ACCESS_TOKEN_COOKIE_NAME = 'access_token'
 
 #: ``REFRESH_TOKEN_EXPIRES_IN: int``
 #: The number of seconds after a refresh token is issued until it expires.
-REFRESH_TOKEN_EXPIRES_IN = 1728000
+REFRESH_TOKEN_EXPIRES_IN = 2592000
 
 #: ``SESSION_TIMEOUT: int``
 #: The number of seconds after which a browser session is considered stale.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ pyyaml
 -e git+https://github.com/uc-cdis/userdatamodel.git@1.1.0#egg=userdatamodel
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
--e git+https://github.com/uc-cdis/cirrus.git@b4bde8b836fd1c6a529a9f0f2daec26eaa9703d6#egg=cirrus
+-e git+https://github.com/uc-cdis/cirrus.git@0.0.3#egg=cirrus-0.0.3
 -e git+https://github.com/uc-cdis/authutils.git@2.0.0#egg=authutils-2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ pyyaml
 -e git+https://github.com/uc-cdis/userdatamodel.git@1.1.0#egg=userdatamodel
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
--e git+https://github.com/uc-cdis/cirrus.git@0.0.2#egg=cirrus-0.0.2
+-e git+https://github.com/uc-cdis/cirrus.git@b4bde8b836fd1c6a529a9f0f2daec26eaa9703d6#egg=cirrus
 -e git+https://github.com/uc-cdis/authutils.git@1.1.4#egg=authutils-1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.1#egg=cirrus-0.0.1
--e git+https://github.com/uc-cdis/authutils.git@1b8544b20fd64b38a70a6abd78456532ee27d08f#egg=authutils-1.1.2
+-e git+https://github.com/uc-cdis/authutils.git@1.1.4#egg=authutils-1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ pyyaml
 -e git+https://github.com/uc-cdis/userdatamodel.git@1.0.5#egg=userdatamodel
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
--e git+https://github.com/uc-cdis/cirrus.git@a4967035818cc024e49fdc19551ac3bddad96e52#egg=cirrus-0.0.0
+-e git+https://github.com/uc-cdis/cirrus.git@0.0.1#egg=cirrus-0.0.1
 -e git+https://github.com/uc-cdis/authutils.git@1.1.3#egg=authutils-1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.1#egg=cirrus-0.0.1
--e git+https://github.com/uc-cdis/authutils.git@1.1.3#egg=authutils-1.1.2
+-e git+https://github.com/uc-cdis/authutils.git@1b8544b20fd64b38a70a6abd78456532ee27d08f#egg=authutils-1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ pyyaml
 -e git+https://github.com/uc-cdis/userdatamodel.git@1.0.5#egg=userdatamodel
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
--e git+https://github.com/uc-cdis/cirrus.git@0.0.0#egg=cirrus-0.0.0
+-e git+https://github.com/uc-cdis/cirrus.git@a4967035818cc024e49fdc19551ac3bddad96e52#egg=cirrus-0.0.0
 -e git+https://github.com/uc-cdis/authutils.git@1.1.3#egg=authutils-1.1.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,6 +450,22 @@ def oauth_client_public(app, db_session, oauth_user):
 
 
 @pytest.fixture(scope='function')
+def google_proxy_group(app, db_session, user_client):
+    group_id = 'test-proxy-group-0'
+    email = fence.utils.random_str(40) + "@test.com"
+    test_user = (
+        db_session
+        .query(models.User)
+        .filter_by(id=user_client.user_id)
+        .first()
+    )
+    test_user.google_proxy_group_id = group_id
+    db_session.add(models.GoogleProxyGroup(id=group_id, email=email))
+    db_session.commit()
+    return Dict(id=group_id, email=email)
+
+
+@pytest.fixture(scope='function')
 def cloud_manager():
     manager = MagicMock()
     patch('fence.blueprints.storage_creds.GoogleCloudManager', manager).start()
@@ -494,7 +510,8 @@ def mock_get(monkeypatch, example_keys_response):
 
 
 @pytest.fixture(scope='function')
-def encoded_creds_jwt_user_id_client_id(private_key, user_client, oauth_client):
+def encoded_creds_jwt(
+        private_key, user_client, oauth_client, google_proxy_group):
     """
     Return a JWT and user_id for a new user containing the claims and
     encoded with the private key.
@@ -508,11 +525,46 @@ def encoded_creds_jwt_user_id_client_id(private_key, user_client, oauth_client):
     """
     kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
     headers = {'kid': kid}
-    return jwt.encode(
-        utils.authorized_download_credentials_context_claims(
-            user_client['username'], user_client['user_id'],
-            oauth_client['client_id']),
-        key=private_key,
-        headers=headers,
-        algorithm='RS256',
-    ), user_client['user_id'], oauth_client['client_id']
+    return Dict(
+        jwt=jwt.encode(
+            utils.authorized_download_credentials_context_claims(
+                user_client['username'], user_client['user_id'],
+                oauth_client['client_id'], google_proxy_group['id']),
+            key=private_key,
+            headers=headers,
+            algorithm='RS256',
+        ),
+        user_id=user_client['user_id'],
+        client_id=oauth_client['client_id'],
+        proxy_group_id=google_proxy_group['id']
+    )
+
+
+@pytest.fixture(scope='function')
+def encoded_jwt_no_proxy_group(
+        private_key, user_client, oauth_client):
+    """
+    Return a JWT and user_id for a new user containing the claims and
+    encoded with the private key.
+
+    Args:
+        claims (dict): fixture
+        private_key (str): fixture
+
+    Return:
+        str: JWT containing claims encoded with private key
+    """
+    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
+    headers = {'kid': kid}
+    return Dict(
+        jwt=jwt.encode(
+            utils.authorized_download_credentials_context_claims(
+                user_client['username'], user_client['user_id'],
+                oauth_client['client_id']),
+            key=private_key,
+            headers=headers,
+            algorithm='RS256',
+        ),
+        user_id=user_client['user_id'],
+        client_id=oauth_client['client_id']
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -491,3 +491,28 @@ def mock_get(monkeypatch, example_keys_response):
         monkeypatch.setattr('requests.get', mock.MagicMock(side_effect=get))
 
     return do_patch
+
+
+@pytest.fixture(scope='function')
+def encoded_creds_jwt_user_id_client_id(private_key, user_client, oauth_client):
+    """
+    Return a JWT and user_id for a new user containing the claims and
+    encoded with the private key.
+
+    Args:
+        claims (dict): fixture
+        private_key (str): fixture
+
+    Return:
+        str: JWT containing claims encoded with private key
+    """
+    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
+    headers = {'kid': kid}
+    return jwt.encode(
+        utils.authorized_download_credentials_context_claims(
+            user_client['username'], user_client['user_id'],
+            oauth_client['client_id']),
+        key=private_key,
+        headers=headers,
+        algorithm='RS256',
+    ), user_client['user_id'], oauth_client['client_id']

--- a/tests/credentials/api_key/test_access.py
+++ b/tests/credentials/api_key/test_access.py
@@ -7,25 +7,30 @@ import json
 from tests.utils.api_key import get_api_key
 
 
-def test_cdis_get_access_token(client, oauth_client):
+def test_cdis_get_access_token(client, oauth_client, encoded_creds_jwt_user_id_client_id):
     """
     Test ``POST /credentials/cdis/access_token``.
     """
-    response = get_api_key(client)
+    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    response = get_api_key(client, encoded_credentials_jwt)
     api_key = response.json['api_key']
     path = '/credentials/cdis/access_token'
     data = {'api_key': api_key}
-    response = client.post(path, data=data)
+    response = client.post(path, data=data,
+        headers={'Authorization': 'Bearer ' + str(encoded_credentials_jwt)})
     assert 'access_token' in response.json
 
 
-def test_cdis_get_access_token_with_formdata(client, oauth_client):
+def test_cdis_get_access_token_with_formdata(
+        client, oauth_client, encoded_creds_jwt_user_id_client_id):
     """
     Test ``POST /credentials/cdis``.
     """
-    response = get_api_key(client)
+    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    response = get_api_key(client, encoded_credentials_jwt)
     api_key = response.json['api_key']
     path = '/credentials/cdis/access_token'
     data = {'api_key': api_key}
-    response = client.post(path, data=data)
+    response = client.post(path, data=data,
+        headers={'Authorization': 'Bearer ' + str(encoded_credentials_jwt)})
     assert 'access_token' in response.json

--- a/tests/credentials/api_key/test_access.py
+++ b/tests/credentials/api_key/test_access.py
@@ -7,11 +7,11 @@ import json
 from tests.utils.api_key import get_api_key
 
 
-def test_cdis_get_access_token(client, oauth_client, encoded_creds_jwt_user_id_client_id):
+def test_cdis_get_access_token(client, oauth_client, encoded_creds_jwt):
     """
     Test ``POST /credentials/cdis/access_token``.
     """
-    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    encoded_credentials_jwt = encoded_creds_jwt["jwt"]
     response = get_api_key(client, encoded_credentials_jwt)
     api_key = response.json['api_key']
     path = '/credentials/cdis/access_token'
@@ -22,11 +22,11 @@ def test_cdis_get_access_token(client, oauth_client, encoded_creds_jwt_user_id_c
 
 
 def test_cdis_get_access_token_with_formdata(
-        client, oauth_client, encoded_creds_jwt_user_id_client_id):
+        client, oauth_client, encoded_creds_jwt):
     """
     Test ``POST /credentials/cdis``.
     """
-    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    encoded_credentials_jwt = encoded_creds_jwt["jwt"]
     response = get_api_key(client, encoded_credentials_jwt)
     api_key = response.json['api_key']
     path = '/credentials/cdis/access_token'

--- a/tests/credentials/api_key/test_api_key.py
+++ b/tests/credentials/api_key/test_api_key.py
@@ -1,28 +1,33 @@
 from tests.utils.api_key import get_api_key, get_api_key_with_json
 
 
-def test_cdis_create_api_key(client, oauth_client):
+def test_cdis_create_api_key(client, oauth_client, encoded_creds_jwt_user_id_client_id):
     """
     Test ``POST /credentials/cdis``.
     """
-    response = get_api_key_with_json(client).json
+    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    response = get_api_key_with_json(client, encoded_credentials_jwt).json
     assert 'key_id' in response
     assert 'api_key' in response
 
 
-def test_cdis_create_api_key_with_disallowed_scope(client, oauth_client):
+def test_cdis_create_api_key_with_disallowed_scope(
+        client, oauth_client, encoded_creds_jwt_user_id_client_id):
     """
     Test ``POST /credentials/cdis``.
     """
-    response = get_api_key(client, scope=['credentials'])
+    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    response = get_api_key(client, encoded_credentials_jwt, scope=['credentials'])
     assert response.status_code == 400
 
 
-def test_cdis_list_api_key(client, oauth_client):
+def test_cdis_list_api_key(client, oauth_client, encoded_creds_jwt_user_id_client_id):
+    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
     n_keys = 3
     for _ in range(n_keys):
-        get_api_key(client)
-    response = client.get('/credentials/cdis/')
+        get_api_key(client, encoded_credentials_jwt)
+    response = client.get('/credentials/cdis/',
+        headers={'Authorization': 'Bearer ' + str(encoded_credentials_jwt)})
     assert 'jtis' in response.json
     assert len(response.json['jtis']) == n_keys
     assert response.status_code == 200

--- a/tests/credentials/api_key/test_api_key.py
+++ b/tests/credentials/api_key/test_api_key.py
@@ -1,28 +1,28 @@
 from tests.utils.api_key import get_api_key, get_api_key_with_json
 
 
-def test_cdis_create_api_key(client, oauth_client, encoded_creds_jwt_user_id_client_id):
+def test_cdis_create_api_key(client, oauth_client, encoded_creds_jwt):
     """
     Test ``POST /credentials/cdis``.
     """
-    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    encoded_credentials_jwt = encoded_creds_jwt["jwt"]
     response = get_api_key_with_json(client, encoded_credentials_jwt).json
     assert 'key_id' in response
     assert 'api_key' in response
 
 
 def test_cdis_create_api_key_with_disallowed_scope(
-        client, oauth_client, encoded_creds_jwt_user_id_client_id):
+        client, oauth_client, encoded_creds_jwt):
     """
     Test ``POST /credentials/cdis``.
     """
-    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+    encoded_credentials_jwt = encoded_creds_jwt["jwt"]
     response = get_api_key(client, encoded_credentials_jwt, scope=['credentials'])
     assert response.status_code == 400
 
 
-def test_cdis_list_api_key(client, oauth_client, encoded_creds_jwt_user_id_client_id):
-    encoded_credentials_jwt, _, _ = encoded_creds_jwt_user_id_client_id
+def test_cdis_list_api_key(client, oauth_client, encoded_creds_jwt):
+    encoded_credentials_jwt = encoded_creds_jwt["jwt"]
     n_keys = 3
     for _ in range(n_keys):
         get_api_key(client, encoded_credentials_jwt)

--- a/tests/credentials/google/test_credentials.py
+++ b/tests/credentials/google/test_credentials.py
@@ -27,13 +27,15 @@ def _populate_test_identity(session, **kwargs):
 
 
 def test_google_access_token_new_service_account(
-        app, oauth_client, db_session, cloud_manager):
+        app, client, oauth_client, db_session, encoded_creds_jwt_user_id_client_id, cloud_manager):
     """
     Test that ``POST /credentials/google`` creates a new service
     account for the user if one doesn't exist.
     """
+    encoded_credentials_jwt, user_id, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     _populate_test_identity(db_session, name=IdentityProvider.itrust)
-    client_id = oauth_client['client_id']
     new_service_account = {
         'uniqueId': '987654321',
         'email': '987654321@test.com'
@@ -48,61 +50,49 @@ def test_google_access_token_new_service_account(
         .create_service_account_for_proxy_group.return_value
     ) = new_service_account
 
-    with app.test_client() as app_client:
+    service_accounts_before = (
+        db_session
+        .query(GoogleServiceAccount)
+        .filter_by(client_id=client_id)
+    ).count()
 
-        # set global client context
-        flask.g.client_id = client_id
+    # create a  proxy group for user
+    proxy_group = GoogleProxyGroup(
+        id=proxy_group_id,
+        user_id=user_id,
+    )
+    db_session.add(proxy_group)
 
-        service_accounts_before = (
-            db_session
-            .query(GoogleServiceAccount)
-            .filter_by(client_id=client_id)
-        ).count()
+    response = client.post(
+        path,
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        # get test user info
-        user = (
-            db_session
-            .query(User)
-            .filter_by(username='test')
-            .first()
-        )
-        user_id = user.id
+    service_accounts_after = (
+        db_session
+        .query(GoogleServiceAccount)
+        .filter_by(client_id=client_id)
+    ).count()
 
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        db_session.add(user)
-        db_session.add(proxy_group)
-        db_session.commit()
-
-        response = app_client.post(path)
-
-        service_accounts_after = (
-            db_session
-            .query(GoogleServiceAccount)
-            .filter_by(client_id=client_id)
-        ).count()
-
-        # make sure we created a new service account for the user's proxy
-        # group and added it to the db
-        assert (
-            cloud_manager.return_value
-            .__enter__.return_value
-            .create_service_account_for_proxy_group
-        ).called
-        assert service_accounts_after == service_accounts_before + 1
-        assert response.status_code == 200
+    # make sure we created a new service account for the user's proxy
+    # group and added it to the db
+    assert (
+        cloud_manager.return_value
+        .__enter__.return_value
+        .create_service_account_for_proxy_group
+    ).called
+    assert service_accounts_after == service_accounts_before + 1
+    assert response.status_code == 200
 
 
 def test_google_access_token_no_proxy_group(
-        app, oauth_client, cloud_manager, db_session):
+        app, client, oauth_client, cloud_manager, db_session, encoded_creds_jwt_user_id_client_id):
     """
     Test that ``POST /credentials/google`` return error when user
     has no proxy group and no service account.
     """
-    client_id = oauth_client["client_id"]
+    encoded_credentials_jwt, _, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     new_service_account = {
         "uniqueId": "987654321",
         "email": "987654321@test.com"
@@ -119,95 +109,84 @@ def test_google_access_token_no_proxy_group(
         .create_service_account_for_proxy_group.return_value
     ) = new_service_account
 
-    with app.test_client() as app_client:
+    service_accounts_before = (
+        db_session
+        .query(GoogleServiceAccount)
+        .filter_by(client_id=client_id)
+    ).count()
 
-        # set global client context
-        flask.g.client_id = client_id
+    response = client.post(
+        path, data=data,
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        service_accounts_before = (
-            db_session
-            .query(GoogleServiceAccount)
-            .filter_by(client_id=client_id)
-        ).count()
+    service_accounts_after = (
+        db_session
+        .query(GoogleServiceAccount)
+        .filter_by(client_id=client_id)
+    ).count()
 
-        response = app_client.post(path, data=data)
-
-        service_accounts_after = (
-            db_session
-            .query(GoogleServiceAccount)
-            .filter_by(client_id=client_id)
-        ).count()
-
-        # make sure we created a new service account for the user's proxy
-        # group and added it to the db
-        assert (cloud_manager.return_value
-                .__enter__.return_value
-                .create_service_account_for_proxy_group).called is False
-        assert service_accounts_after == service_accounts_before
-        assert response.status_code == 404
+    # make sure we created a new service account for the user's proxy
+    # group and added it to the db
+    assert (cloud_manager.return_value
+            .__enter__.return_value
+            .create_service_account_for_proxy_group).called is False
+    assert service_accounts_after == service_accounts_before
+    assert response.status_code == 404
 
 
 def test_google_create_access_token_post(
-        app, oauth_client, cloud_manager, db_session):
+        app, client, oauth_client, cloud_manager, db_session, encoded_creds_jwt_user_id_client_id):
     """
     Test ``POST /credentials/google`` gets a new access key.
     """
-    client_id = oauth_client['client_id']
+    encoded_credentials_jwt, user_id, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     service_account_id = '123456789'
     proxy_group_id = 'proxy_group_0'
     path = '/credentials/google/'
     data = {}
-    with app.test_client() as app_client:
 
-        # set global client context
-        flask.g.client_id = client_id
+    # create a  proxy group for user
+    proxy_group = GoogleProxyGroup(
+        id=proxy_group_id,
+        user_id=user_id,
+    )
+    db_session.add(proxy_group)
 
-        # get test user info
-        user = (
-            db_session
-            .query(User)
-            .filter_by(username='test')
-            .first()
-        )
-        user_id = user.id
+    # create a service account for client for user
+    service_account = GoogleServiceAccount(
+        google_unique_id=service_account_id,
+        client_id=client_id,
+        user_id=user_id,
+        email=(client_id + '-' + str(user_id) + '@test.com')
+    )
+    db_session.add(service_account)
+    db_session.commit()
 
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        db_session.add(proxy_group)
+    response = client.post(
+        path, data=data,
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        # create a service account for client for user
-        service_account = GoogleServiceAccount(
-            google_unique_id=service_account_id,
-            client_id=client_id,
-            user_id=user_id,
-            email=(client_id + '-' + str(user_id) + '@test.com')
-        )
-        db_session.add(user)
-        db_session.add(service_account)
-        db_session.commit()
+    # check that the service account id was included in a
+    # call to cloud_manager
+    (
+        cloud_manager.return_value
+        .__enter__.return_value
+        .get_access_key
+    ).assert_called_with(service_account_id)
 
-        response = app_client.post(path, data=data)
-
-        # check that the service account id was included in a
-        # call to cloud_manager
-        (
-            cloud_manager.return_value
-            .__enter__.return_value
-            .get_access_key
-        ).assert_called_with(service_account_id)
-
-        assert response.status_code == 200
+    assert response.status_code == 200
 
 
 def test_google_delete_owned_access_token(
-        app, client, oauth_client, cloud_manager, db_session):
+        app, client, oauth_client, cloud_manager, db_session, encoded_creds_jwt_user_id_client_id):
     """
     Test ``DELETE /credentials/google``.
     """
-    client_id = oauth_client["client_id"]
+    encoded_credentials_jwt, user_id, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     service_account_key = "some_key_321"
     service_account_id = "123456789"
     proxy_group_id = "proxy_group_0"
@@ -236,126 +215,104 @@ def test_google_delete_owned_access_token(
      .__enter__.return_value
      .get_service_account_keys_info.side_effect) = get_account_keys
 
-    with app.test_client() as app_client:
+    # create a  proxy group for user
+    proxy_group = GoogleProxyGroup(
+        id=proxy_group_id,
+        user_id=user_id,
+    )
+    db_session.add(proxy_group)
 
-        # set global client context
-        flask.g.client_id = client_id
+    # create a service account for client for user
+    service_account = GoogleServiceAccount(
+        google_unique_id=service_account_id,
+        client_id=client_id,
+        user_id=user_id,
+        email=(client_id + "-" + str(user_id) + "@test.com")
+    )
+    db_session.add(service_account)
+    db_session.commit()
 
-        # get test user info
-        user = (
-            db_session
-            .query(User)
-            .filter_by(username="test")
-            .first()
-        )
-        user_id = user.id
+    response = client.delete(
+        path, data={},
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        db_session.add(proxy_group)
+    # check that the service account id was included in a call to
+    # cloud_manager
+    assert any([
+        str(mock_call)
+        for mock_call in cloud_manager.mock_calls
+        if service_account_id in str(mock_call)
+    ])
+    assert response.status_code == 204
 
-        # create a service account for client for user
-        service_account = GoogleServiceAccount(
-            google_unique_id=service_account_id,
-            client_id=client_id,
-            user_id=user_id,
-            email=(client_id + "-" + str(user_id) + "@test.com")
-        )
-        db_session.add(user)
-        db_session.add(service_account)
-        db_session.commit()
-
-        response = app_client.delete(path, data={})
-
-        # check that the service account id was included in a call to
-        # cloud_manager
-        assert any([
-            str(mock_call)
-            for mock_call in cloud_manager.mock_calls
-            if service_account_id in str(mock_call)
-        ])
-        assert response.status_code == 204
-
-        # check that we actually requested to delete the correct service key
-        (cloud_manager.return_value
-         .__enter__.return_value
-         .delete_service_account_key).assert_called_with(service_account_id,
-                                                         service_account_key)
+    # check that we actually requested to delete the correct service key
+    (cloud_manager.return_value
+     .__enter__.return_value
+     .delete_service_account_key).assert_called_with(service_account_id,
+                                                     service_account_key)
 
 
 def test_google_attempt_delete_unowned_access_token(
-        app, client, oauth_client, cloud_manager, db_session):
+        app, client, oauth_client, cloud_manager, db_session, encoded_creds_jwt_user_id_client_id):
     """
     Test ``DELETE /credentials/google``.
     """
-    client_id = oauth_client["client_id"]
+    encoded_credentials_jwt, user_id, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     service_account_key = "some_key_321"
     proxy_group_id = "proxy_group_0"
     path = (
         "/credentials/google/" + service_account_key + "/"
     )
 
-    with app.test_client() as app_client:
+    # create a  proxy group for user
+    proxy_group = GoogleProxyGroup(
+        id=proxy_group_id,
+        user_id=user_id,
+    )
+    db_session.add(proxy_group)
 
-        # set global client context
-        flask.g.client_id = client_id
+    # create a service account for A DIFFERENT CLIENT
+    client_entry = Client(
+        client_id="NOT_THIS_GUY", client_secret="a0987u23on192y",
+        name="NOT_THIS_GUY",
+    )
+    service_account = GoogleServiceAccount(
+        google_unique_id="123456789",
+        client_id="NOT_THIS_GUY",
+        user_id=user_id,
+        email=("NOT_THIS_GUY" + "-" + str(user_id) + "@test.com")
+    )
+    db_session.add(client_entry)
+    db_session.add(service_account)
+    db_session.commit()
 
-        # get test user info
-        user = (
-            db_session
-            .query(User)
-            .filter_by(username="test")
-            .first()
-        )
-        user_id = user.id
+    response = client.delete(
+        path, data={},
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        db_session.add(proxy_group)
+    # check that we didn't try to get key info or delete,
+    # since the current user/client doesn't have the key
+    assert (cloud_manager.return_value
+            .__enter__.return_value
+            .get_service_account_keys_info).called is False
 
-        # create a service account for A DIFFERENT CLIENT
-        client = Client(
-            client_id="NOT_THIS_GUY", client_secret="a0987u23on192y",
-            name="NOT_THIS_GUY",
-        )
-        service_account = GoogleServiceAccount(
-            google_unique_id="123456789",
-            client_id="NOT_THIS_GUY",
-            user_id=user_id,
-            email=("NOT_THIS_GUY" + "-" + str(user_id) + "@test.com")
-        )
-        db_session.add(user)
-        db_session.add(client)
-        db_session.add(service_account)
-        db_session.commit()
+    assert (cloud_manager.return_value
+            .__enter__.return_value
+            .delete_service_account_key).called is False
 
-        response = app_client.delete(path, data={})
-
-        # check that we didn't try to get key info or delete,
-        # since the current user/client doesn't have the key
-        assert (cloud_manager.return_value
-                .__enter__.return_value
-                .get_service_account_keys_info).called is False
-
-        assert (cloud_manager.return_value
-                .__enter__.return_value
-                .delete_service_account_key).called is False
-
-        assert response.status_code == 404
+    assert response.status_code == 404
 
 
 def test_google_delete_invalid_access_token(
-        app, client, oauth_client, cloud_manager, db_session):
+        app, client, oauth_client, cloud_manager, db_session, encoded_creds_jwt_user_id_client_id):
     """
     Test ``DELETE /credentials/google``.
     """
-    client_id = oauth_client["client_id"]
+    encoded_credentials_jwt, user_id, client_id = (
+        encoded_creds_jwt_user_id_client_id
+    )
     service_account_key = "some_key_321"
     service_account_id = "123456789"
     proxy_group_id = "proxy_group_0"
@@ -382,43 +339,30 @@ def test_google_delete_invalid_access_token(
      .__enter__.return_value
      .get_service_account_keys_info.side_effect) = get_account_keys
 
-    with app.test_client() as app_client:
+    # create a  proxy group for user
+    proxy_group = GoogleProxyGroup(
+        id=proxy_group_id,
+        user_id=user_id,
+    )
+    db_session.add(proxy_group)
 
-        # set global client context
-        flask.g.client_id = client_id
+    # create a service account for client for user
+    service_account = GoogleServiceAccount(
+        google_unique_id=service_account_id,
+        client_id=client_id,
+        user_id=user_id,
+        email=(client_id + "-" + str(user_id) + "@test.com")
+    )
+    db_session.add(service_account)
+    db_session.commit()
 
-        # get test user info
-        user = (
-            db_session
-            .query(User)
-            .filter_by(username="test")
-            .first()
-        )
-        user_id = user.id
+    response = client.delete(
+        path, data={},
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
 
-        # create a  proxy group for user
-        proxy_group = GoogleProxyGroup(
-            id=proxy_group_id,
-            user_id=user_id,
-        )
-        db_session.add(proxy_group)
+    # check that we didn't try to delete, since the key doesn't exist
+    assert (cloud_manager.return_value
+            .__enter__.return_value
+            .delete_service_account_key).called is False
 
-        # create a service account for client for user
-        service_account = GoogleServiceAccount(
-            google_unique_id=service_account_id,
-            client_id=client_id,
-            user_id=user_id,
-            email=(client_id + "-" + str(user_id) + "@test.com")
-        )
-        db_session.add(user)
-        db_session.add(service_account)
-        db_session.commit()
-
-        response = app_client.delete(path, data={})
-
-        # check that we didn't try to delete, since the key doesn't exist
-        assert (cloud_manager.return_value
-                .__enter__.return_value
-                .delete_service_account_key).called is False
-
-        assert response.status_code == 404
+    assert response.status_code == 404

--- a/tests/oidc/core/token/test_token_response.py
+++ b/tests/oidc/core/token/test_token_response.py
@@ -73,5 +73,6 @@ def test_access_token_correct_fields(token_response):
         'iat',
         'jti',
         'context',
+        'azp'
     }
     assert access_token_fields == expected_fields

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -94,6 +94,9 @@ def default_claims():
                 'name': 'test-user',
                 'projects': [
                 ],
+                'google': {
+                    'proxy_group': None,
+                }
             },
         },
     }
@@ -126,6 +129,9 @@ def unauthorized_context_claims(user_name, user_id):
                     "phs000178": ["read"],
                     "phs000234": ["read", "read-storage"],
                 },
+                'google': {
+                    'proxy_group': None,
+                }
             },
         },
     }
@@ -158,12 +164,16 @@ def authorized_download_context_claims(user_name, user_id):
                     "phs000178": ["read"],
                     "phs000218": ["read", "read-storage"],
                 },
+                'google': {
+                    'proxy_group': None,
+                }
             },
         },
     }
 
 
-def authorized_download_credentials_context_claims(user_name, user_id, client_id):
+def authorized_download_credentials_context_claims(
+        user_name, user_id, client_id, google_proxy_group_id=None):
     """
     Return a generic claims dictionary to put in a JWT.
 
@@ -190,6 +200,9 @@ def authorized_download_credentials_context_claims(user_name, user_id, client_id
                     "phs000178": ["read"],
                     "phs000218": ["read", "read-storage"],
                 },
+                'google': {
+                    'proxy_group': google_proxy_group_id,
+                }
             },
         },
     }
@@ -222,6 +235,9 @@ def authorized_upload_context_claims(user_name, user_id):
                     "phs000178": ["read"],
                     "phs000218": ["read", "write-storage"],
                 },
+                'google': {
+                    'proxy_group': None,
+                }
             },
         },
     }

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -88,6 +88,7 @@ def default_claims():
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': '',
         'context': {
             'user': {
                 'name': 'test-user',
@@ -117,6 +118,7 @@ def unauthorized_context_claims(user_name, user_id):
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': '',
         'context': {
             'user': {
                 'name': 'test',
@@ -147,6 +149,39 @@ def authorized_download_context_claims(user_name, user_id):
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': '',
+        'pur': 'access',
+        'context': {
+            'user': {
+                'name': user_name,
+                'projects': {
+                    "phs000178": ["read"],
+                    "phs000218": ["read", "read-storage"],
+                },
+            },
+        },
+    }
+
+
+def authorized_download_credentials_context_claims(user_name, user_id, client_id):
+    """
+    Return a generic claims dictionary to put in a JWT.
+
+    Return:
+        dict: dictionary of claims
+    """
+    aud = ['access', 'data', 'user', 'openid', 'credentials']
+    iss = current_app.config['BASE_URL']
+    jti = new_jti()
+    iat, exp = iat_and_exp()
+    return {
+        'aud': aud,
+        'sub': user_id,
+        'iss': iss,
+        'iat': iat,
+        'exp': exp,
+        'jti': jti,
+        'azp': client_id,
         'pur': 'access',
         'context': {
             'user': {
@@ -179,6 +214,7 @@ def authorized_upload_context_claims(user_name, user_id):
         'iat': iat,
         'exp': exp,
         'jti': jti,
+        'azp': 'test-client',
         'context': {
             'user': {
                 'name': user_name,

--- a/tests/utils/api_key.py
+++ b/tests/utils/api_key.py
@@ -4,7 +4,7 @@ import json
 DEFAULT_SCOPE = ['fence', 'data', 'user']
 
 
-def get_api_key(client, scope=None):
+def get_api_key(client, encoded_credentials_jwt, scope=None):
     """
     Args:
         client: client fixture
@@ -13,13 +13,16 @@ def get_api_key(client, scope=None):
         pytest_flask.plugin.JSONResponse: the response from /oauth2/authorize
     """
     path = '/credentials/cdis/'
-    headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+    headers = {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': 'Bearer ' + str(encoded_credentials_jwt)
+    }
     scope = scope or DEFAULT_SCOPE
     response = client.post(path, data={'scope': scope}, headers=headers)
     return response
 
 
-def get_api_key_with_json(client, scope=None):
+def get_api_key_with_json(client, encoded_credentials_jwt, scope=None):
     """
     Args:
         client: client fixture
@@ -29,7 +32,8 @@ def get_api_key_with_json(client, scope=None):
     """
     scope = scope or DEFAULT_SCOPE
     headers = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + str(encoded_credentials_jwt)
     }
     response = client.post(
         '/credentials/cdis/',


### PR DESCRIPTION
- Script to manage expired google account keys
- refactoring in fence-create for style and Python3 compatibility
- ensure tokens have 'azp' (authorized party field) to determine the client we're talking to
    - I think this got lost at some point during the oidc merging
- make storage cred endpoints use information from token 
- fix tests to send token in header so storage creds endpoint tests pass


Relies on some fixes in cirrus for service account id validation:
https://github.com/uc-cdis/cirrus/pull/8
