### PR TITLE
refactor(test-fixtures): add RSA key fixtures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.3#egg=cirrus-0.0.3
--e git+https://github.com/uc-cdis/authutils.git@2.0.0#egg=authutils-2.0.0
+-e git+https://github.com/uc-cdis/authutils.git@fd906f96b6e4d62a46b9152146fbbe546d7575cf#egg=authutils-2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.3.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.8#egg=cdispyutils
 -e git+https://github.com/uc-cdis/cirrus.git@0.0.3#egg=cirrus-0.0.3
--e git+https://github.com/uc-cdis/authutils.git@fd906f96b6e4d62a46b9152146fbbe546d7575cf#egg=authutils-2.0.0
+-e git+https://github.com/uc-cdis/authutils.git@079981a809382a14e17f5af4749f50e56410a8ad#egg=authutils-2.0.0

--- a/tests/jwt/conftest.py
+++ b/tests/jwt/conftest.py
@@ -1,8 +1,6 @@
 import jwt
 import pytest
 
-from tests import test_settings, utils
-
 
 @pytest.fixture(scope='session')
 def encoded_jwt(kid, rsa_private_key):

--- a/tests/jwt/conftest.py
+++ b/tests/jwt/conftest.py
@@ -5,83 +5,63 @@ from tests import test_settings, utils
 
 
 @pytest.fixture(scope='session')
-def public_key():
-    """
-    Return a public key for testing.
-    """
-    return utils.read_file('resources/keys/test_public_key.pem')
-
-
-@pytest.fixture(scope='session')
-def private_key():
-    """
-    Return a private key for testing. (Use only a private key that is
-    specifically set aside for testing, and never actually used for auth.)
-    """
-    return utils.read_file('resources/keys/test_private_key.pem')
-
-
-@pytest.fixture(scope='session')
-def encoded_jwt(private_key):
+def encoded_jwt(kid, rsa_private_key):
     """
     Return an example JWT containing the claims and encoded with the private
     key.
 
     Args:
         claims (dict): fixture
-        private_key (str): fixture
+        rsa_private_key (str): fixture
 
     Return:
         str: JWT containing claims encoded with private key
     """
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
     headers = {'kid': kid}
     return jwt.encode(
         utils.default_claims(),
-        key=private_key,
+        key=rsa_private_key,
         headers=headers,
         algorithm='RS256',
     )
 
 
 @pytest.fixture(scope='session')
-def encoded_jwt_expired(claims, private_key):
+def encoded_jwt_expired(claims, kid, rsa_private_key):
     """
     Return an example JWT that has already expired.
 
     Args:
         claims (dict): fixture
-        private_key (str): fixture
+        rsa_private_key (str): fixture
 
     Return:
         str: JWT containing claims encoded with private key
     """
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
     headers = {'kid': kid}
     claims_expired = utils.default_claims()
     # Move `exp` and `iat` into the past.
     claims_expired['exp'] -= 10000
     claims_expired['iat'] -= 10000
     return jwt.encode(
-        claims_expired, key=private_key, headers=headers, algorithm='RS256'
+        claims_expired, key=rsa_private_key, headers=headers, algorithm='RS256'
     )
 
 
 @pytest.fixture(scope='session')
-def encoded_jwt_refresh_token(claims_refresh, private_key):
+def encoded_jwt_refresh_token(claims_refresh, kid, rsa_private_key):
     """
     Return an example JWT refresh token containing the claims and encoded with
     the private key.
 
     Args:
         claims_refresh (dict): fixture
-        private_key (str): fixture
+        rsa_private_key (str): fixture
 
     Return:
         str: JWT refresh token containing claims encoded with private key
     """
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
     headers = {'kid': kid}
     return jwt.encode(
-        claims_refresh, key=private_key, headers=headers, algorithm='RS256'
+        claims_refresh, key=rsa_private_key, headers=headers, algorithm='RS256'
     )

--- a/tests/jwt/test_keys.py
+++ b/tests/jwt/test_keys.py
@@ -5,11 +5,11 @@ Do a couple basic tests to check that the default keys are returned correctly.
 from fence import keys
 
 
-def test_default_public_key(app, public_key):
+def test_default_public_key(app, rsa_public_key):
     """Test that the default public key is correct."""
-    assert keys.default_public_key() == public_key
+    assert keys.default_public_key() == rsa_public_key
 
 
-def test_default_private_key(app, private_key):
+def test_default_private_key(app, rsa_private_key):
     """Test that the default private key is correct."""
-    assert keys.default_private_key() == private_key
+    assert keys.default_private_key() == rsa_private_key

--- a/tests/multi_tenant/conftest.py
+++ b/tests/multi_tenant/conftest.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os
 
 from addict import Dict
@@ -8,6 +9,7 @@ import pytest
 
 from fence import models
 from fence import app_init
+from fence.jwt.keys import Keypair
 import fence.blueprints.login
 
 from tests import test_settings
@@ -48,7 +50,8 @@ def fence_oauth_client(app, db_session, oauth_user, fence_oauth_client_url):
 
 @pytest.fixture(scope='function')
 def fence_client_app(
-        app, fence_oauth_client, fence_oauth_client_url, db_session):
+        app, fence_oauth_client, fence_oauth_client_url, db_session,
+        kid_2, rsa_private_key_2, rsa_public_key_2):
     """
     A Flask application fixture which acts as a client of the original ``app``
     in a multi-tenant configuration.
@@ -57,9 +60,14 @@ def fence_client_app(
     client_app = flask.Flask('client_app')
     app_init(client_app, test_settings, root_dir=root_dir)
 
-    client_app.jwt_public_keys['/'] = client_app.jwt_public_keys.pop(
-        client_app.config['BASE_URL']
-    )
+    client_app.keypairs.append(Keypair(
+        kid=kid_2, public_key=rsa_public_key_2,
+        private_key=rsa_private_key_2
+    ))
+
+    client_app.jwt_public_keys['/'] = OrderedDict([
+        (kid_2, rsa_public_key_2)
+    ])
 
     client_app.config['BASE_URL'] = '/'
     client_app.config['MOCK_AUTH'] = False
@@ -87,13 +95,13 @@ def fence_client_app(
 
 
 @pytest.fixture(scope='session')
-def example_keys_response(public_key):
+def example_keys_response(kid, rsa_public_key):
     """
     Return an example response JSON returned from the ``/jwt/keys`` endpoint in
     fence.
     """
     return {
         'keys': [
-            ['key-test', public_key],
+            [kid, rsa_public_key],
         ]
     }

--- a/tests/oidc/core/token/test_id_token.py
+++ b/tests/oidc/core/token/test_id_token.py
@@ -9,8 +9,6 @@ from fence.jwt.validate import validate_jwt
 from fence.models import User
 from fence.utils import random_str
 
-from tests import test_settings
-
 
 def test_create_id_token(app):
     """
@@ -31,12 +29,11 @@ def test_create_id_token(app):
     assert token is not None
 
 
-def test_recode_id_token(app, private_key):
+def test_recode_id_token(app, kid, rsa_private_key):
     """
     Test that after signing, unsigning, re-signing, and unsigning again,
     the contents of the ID Token that should be the same, are.
     """
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
     issuer = app.config.get('BASE_URL')
     keypair = app.keypairs[0]
     client_id = "client_12345"
@@ -55,7 +52,7 @@ def test_recode_id_token(app, private_key):
         max_age=max_age, nonce=nonce)
 
     new_signed_token = original_unsigned_token.get_signed_and_encoded_token(
-        kid, private_key
+        kid, rsa_private_key
     )
     new_unsigned_token = UnsignedIDToken.from_signed_and_encoded_token(
         new_signed_token, client_id=client_id, issuer=issuer,

--- a/tests/scripting/conftest.py
+++ b/tests/scripting/conftest.py
@@ -18,21 +18,20 @@ def patch_driver(db, monkeypatch):
         lambda _: db,
     )
 
-#fence.settings import DB, BASE_URL
 
 @pytest.fixture(scope='function', autouse=True)
-def mock_keypairs(monkeypatch):
+def mock_keypairs(monkeypatch, kid, kid_2):
     """
-    Change the keypair configureation in ``fence.settings.JWT_KEYPAIR_FILES``.
+    Change the keypair configuration in ``fence.settings.JWT_KEYPAIR_FILES``.
     """
 
     JWT_KEYPAIR_FILES = OrderedDict([
         (
-            'key-test',
+            kid,
             ('tests/resources/keys/test_public_key.pem', 'tests/resources/keys/test_private_key.pem'),
         ),
         (
-            'key-test-2',
+            kid_2,
             ('tests/resources/keys/test_public_key_2.pem', 'tests/resources/keys/test_private_key_2.pem'),
     ),
     ])

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,4 @@
-from . import utils, test_settings
+from . import utils
 import jwt
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,35 +2,36 @@ from . import utils, test_settings
 import jwt
 
 
-def test_indexd_download_file(client, oauth_client, user_client, indexd_client):
+def test_indexd_download_file(
+        client, oauth_client, user_client, indexd_client, kid,
+        rsa_private_key):
     """
     Test ``GET /data/download/1``.
     """
-    path = '/data/download/1?protocol=s3'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
+    path = '/data/download/1'
+    query_string = {'protocol': 's3'}
     headers = {'Authorization': 'Bearer ' + jwt.encode(
         utils.authorized_download_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}
-    response = client.get(path, headers=headers)
+    response = client.get(path, headers=headers, query_string=query_string)
     print response.json
     assert response.status_code == 200
     assert 'url' in response.json.keys()
 
 
-def test_indexd_upload_file(client, oauth_client, user_client, indexd_client):
+def test_indexd_upload_file(
+        client, oauth_client, user_client, indexd_client, kid,
+        rsa_private_key):
     """
     Test ``GET /data/download/1``.
     """
     path = '/data/upload/1?protocol=s3'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
     headers = {'Authorization': 'Bearer ' + jwt.encode(
         utils.authorized_upload_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}
@@ -39,16 +40,16 @@ def test_indexd_upload_file(client, oauth_client, user_client, indexd_client):
     assert 'url' in response.json.keys()
 
 
-def test_indexd_download_file_no_protocol(client, oauth_client, user_client, indexd_client):
+def test_indexd_download_file_no_protocol(
+        client, oauth_client, user_client, indexd_client, kid,
+        rsa_private_key):
     """
     Test ``GET /data/download/1``.
     """
     path = '/data/download/1'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
     headers = {'Authorization': 'Bearer ' + jwt.encode(
         utils.authorized_download_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}
@@ -77,16 +78,18 @@ def test_indexd_unauthorized_download_file(client, oauth_client, unauthorized_us
     assert 'url' not in response.json.keys()
 
 
-def test_unauthorized_indexd_download_file(client, oauth_client, user_client, indexd_client):
+def test_unauthorized_indexd_download_file(
+        client, oauth_client, user_client, indexd_client, kid,
+        rsa_private_key):
     """
     Test ``GET /data/download/1``.
     """
     path = '/data/download/1'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
     headers = {'Authorization': 'Bearer ' + jwt.encode(
-        utils.unauthorized_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        utils.unauthorized_context_claims(
+            user_client.username, user_client.user_id
+        ),
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}
@@ -95,16 +98,18 @@ def test_unauthorized_indexd_download_file(client, oauth_client, user_client, in
     assert 'url' not in response.json.keys()
 
 
-def test_unauthorized_indexd_upload_file(client, oauth_client, encoded_jwt, user_client, indexd_client):
+def test_unauthorized_indexd_upload_file(
+        client, oauth_client, encoded_jwt, user_client, indexd_client, kid,
+        rsa_private_key):
     """
     Test ``GET /data/upload/1``.
     """
     path = '/data/upload/1'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
     headers = {'Authorization': 'Bearer ' + jwt.encode(
-        utils.unauthorized_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        utils.unauthorized_context_claims(
+            user_client.username, user_client.user_id
+        ),
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}
@@ -113,16 +118,16 @@ def test_unauthorized_indexd_upload_file(client, oauth_client, encoded_jwt, user
     assert 'url' not in response.json.keys()
 
 
-def test_unavailable_indexd_upload_file(client, oauth_client, encoded_jwt, user_client, unauthorized_indexd_client):
+def test_unavailable_indexd_upload_file(
+        client, oauth_client, encoded_jwt, user_client,
+        unauthorized_indexd_client, kid, rsa_private_key):
     """
     Test ``GET /data/upload/1``.
     """
     path = '/data/upload/1'
-    kid = test_settings.JWT_KEYPAIR_FILES.keys()[0]
-    private_key = utils.read_file('resources/keys/test_private_key.pem')
     headers = {'Authorization': 'Bearer ' + jwt.encode(
         utils.unauthorized_context_claims(user_client.username, user_client.user_id),
-        key=private_key,
+        key=rsa_private_key,
         headers={'kid': kid},
         algorithm='RS256',
     )}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -59,16 +59,8 @@ SESSION_COOKIE_NAME = 'fence'
 HMAC_ENCRYPTION_KEY = Fernet.generate_key()
 ENABLE_CSRF_PROTECTION = False
 
-JWT_KEYPAIR_FILES = OrderedDict([
-    (
-        'key-test',
-        ('resources/keys/test_public_key.pem', 'resources/keys/test_private_key.pem'),
-    ),
-    (
-        'key-test-2',
-        ('resources/keys/test_public_key_2.pem', 'resources/keys/test_private_key_2.pem'),
-    ),
-])
+#: The test app uses the RSA key fixtures from authutils, so leave this empty.
+JWT_KEYPAIR_FILES = OrderedDict([])
 
 STORAGE_CREDENTIALS = {
     'test-cleversafe': {


### PR DESCRIPTION
For uc-cdis/authutils#4.

Use the authutils text fixtures from uc-cdis/authutils#8 (instead of loading keys from files), so the `tests/resources/keys` files are no longer necessary for testing.

Depends on uc-cdis/authutils#16.