### PR TITLE
fix(jwk): use jose library to return JWKs

### DIFF
--- a/fence/jwt/keys.py
+++ b/fence/jwt/keys.py
@@ -15,6 +15,7 @@ import base64
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 import flask
+from jose import jwk
 
 
 class Keypair(object):
@@ -48,16 +49,13 @@ class Keypair(object):
             dict: JWK representation of the public key
         """
         n, e = _rsa_public_numbers(self.public_key)
-        jwk = {
-            'alg': 'RS256',
-            'kty': 'RSA',
+        jwk_dict = jwk.construct(self.public_key, algorithm='RS256').to_dict()
+        jwk_dict.update({
             'use': 'sig',
             'key_ops': 'verify',
             'kid': self.kid,
-            'n': base64.urlsafe_b64encode(str(n)),
-            'e': base64.urlsafe_b64encode(str(e)),
-        }
-        return jwk
+        })
+        return jwk_dict
 
 
 def _rsa_public_numbers(public_key_data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 google_api_python_client==1.6.4
 httplib2==0.10.3
+python-jose==2.0.2
 oauthlib==2.0.6
 psycopg2==2.7.3.2
 pysftp==0.2.9

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Flask_SQLAlchemy_Session>=1.1,<2.0",
         "google_api_python_client>=1.6.4,<2.0.0",
         "httplib2>=0.10.3,<1.0.0",
+        "python-jose>=2.0.0,<3.0.0",
         "oauthlib>=2.0.6,<3.0.0",
         "psycopg2>=2.7.3.2,<3.0.0.0",
         "pysftp>=0.2.9,<1.0.0",

--- a/tests/rfc7517/test_jwks.py
+++ b/tests/rfc7517/test_jwks.py
@@ -1,7 +1,4 @@
-import base64
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+from jose import jwk
 
 
 def test_response_fields(client):
@@ -46,15 +43,6 @@ def test_response_values(app, client):
         assert key['use'] == 'sig'
         assert key['key_ops'] == 'verify'
         assert key['kid'] in app_kids
-        # Attempt to reproduce the public key from the values for the public
-        # modulus and exponent provided in the response, using cryptography
-        # primitives.
-        n = int(base64.b64decode(key['n']))
-        e = int(base64.b64decode(key['e']))
-        numbers = RSAPublicNumbers(e, n)
-        key = numbers.public_key(default_backend())
-        key_pem = key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
-        )
+        # Attempt to reproduce the public key from the JWK response.
+        key_pem = jwk.construct(key).to_pem()
         assert key_pem in app_public_keys


### PR DESCRIPTION
`/.well-known/jwks` endpoint was returning `n` and `e` as base64url-encoded, not base64urlUInt-encoded. This changes `Keypair` to use `python-jose` for creating the required fields in the JWK response, which fixes the problem.