### PR TITLE
fix(local-settings): load from /var/www

### DIFF
--- a/bin/fence-create
+++ b/bin/fence-create
@@ -79,12 +79,12 @@ def main():
         DB = os.environ['FENCE_DB']
     else:
         from fence.settings import DB
-    
+
     if os.environ.get('BASE_URL'):
         DB = os.environ['BASE_URL']
     else:
         from fence.settings import BASE_URL
-    
+
     if os.environ.get('ROOT_DIR'):
         ROOT_DIR = os.environ['ROOT_DIR']
     else:
@@ -112,6 +112,7 @@ def main():
         token = create_user_token(DB, BASE_URL, ROOT_DIR, args.__dict__['kid'], args.__dict__['type'], args.__dict__['username'], args.__dict__['scopes'], args.__dict__['exp'])
         if token:
             print(token)
+
 
 if __name__ == '__main__':
     main()

--- a/fence/settings.py
+++ b/fence/settings.py
@@ -7,11 +7,21 @@ logger = get_logger(__name__)
 # default settings if local_settings is not present
 BASE_URL = 'http://localhost/user'
 APP_NAME = 'Gen3 Data Commons'
-# local_settings is not installed under fence module in prod
+
+# ``local_settings"" is not installed under the fence module in produdction.
+# Instead, it should be located at ``/var/www/local_settings.py``. If it is
+# located elsewhere, use that location in ``imp.load_source`` instead of
+# ``/var/www/local_settings.py``, just below.
 try:
+    # Import everything from ``local_settings``, if it exists.
     from local_settings import *
-except:
-    logger.warn("local_settings is not found")
+except ImportError:
+    # If it doesn't, look in ``/var/www``.
+    try:
+        import imp
+        imp.load_source('local_settings', '/var/www/local_settings.py')
+    except IOError:
+        logger.warn("local_settings is not found")
 
 
 # Use this setting when fence will be deployed in such a way that fence will


### PR DESCRIPTION
Resolves #114.

Hard-code attempt to load `/var/www/local_settings.py` if the module was not found in the first attempts. This way the script in the kubernetes pod is always able to locate the settings (since the file is [mounted to that location by the deployment settings](https://github.com/uc-cdis/cloud-automation/blob/268526e20a6e4520c077de2c409154a10d1c7ec6/kube/services/fence/fence-deploy.yaml#L74)).