### PR TITLE
fix(data): support public bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-pip \
     python-setuptools \
     vim \
-    && pip install --upgrade pip \
+    && pip install pip==9.0.3 \
     && pip install --upgrade setuptools \
     && mkdir /var/www/fence \
     && mkdir -p /var/www/.cache/Python-Eggs/ \

--- a/fence/blueprints/data.py
+++ b/fence/blueprints/data.py
@@ -96,13 +96,12 @@ def resolve_url(url, location, expires, action, user_id, username):
         if len(aws_creds) > 0:
             if location.netloc not in s3_buckets.keys():
                 raise Unauthorized('permission denied for bucket')
-            if location.netloc in s3_buckets.keys():
-                credential_key = s3_buckets[location.netloc]
-                if credential_key not in aws_creds:
-                    raise Unauthorized('permission denied for bucket')
-                # public bucket
-                if credential_key == '*':
-                    return dict(url=http_url)
+            credential_key = s3_buckets[location.netloc]
+            # public bucket
+            if credential_key == '*':
+                return dict(url=http_url)
+            if credential_key not in aws_creds:
+                raise Unauthorized('permission denied for bucket')
         config = get_value(aws_creds, credential_key,
                            InternalError('aws credential of that bucket is not found'))
         region = flask.current_app.boto.get_bucket_region(location.netloc, config)

--- a/fence/blueprints/data.py
+++ b/fence/blueprints/data.py
@@ -10,14 +10,10 @@ ACTION_DICT = {
     "s3": {
         "upload": "PUT",
         "download": "GET"
-    },
-    "http": {
-        "upload": "put_object",
-        "download": "get_object"
     }
 }
 
-SUPPORTED_PROTOCOLS = ['s3', 'http', 'ftp']
+SUPPORTED_PROTOCOLS = ['s3', 'http', 'ftp', 'https']
 
 
 def get_index_document(file_id):
@@ -74,6 +70,8 @@ def upload_file(file_id):
 
 
 def check_protocol(protocol, scheme):
+    if scheme not in SUPPORTED_PROTOCOLS:
+        return False
     if protocol is None:
         return True
     if protocol == scheme:
@@ -90,17 +88,24 @@ def resolve_url(url, location, expires, action, user_id, username):
                               InternalError('credentials not configured'))
         s3_buckets = get_value(flask.current_app.config, 'S3_BUCKETS',
                                InternalError('buckets not configured'))
+
+        http_url = (
+            'https://{}.s3.amazonaws.com/{}'
+            .format(location.netloc, location.path.strip('/'))
+        )
         if len(aws_creds) > 0:
             if location.netloc not in s3_buckets.keys():
                 raise Unauthorized('permission denied for bucket')
-            if location.netloc in s3_buckets.keys() and \
-                    s3_buckets[location.netloc] not in aws_creds:
-                raise Unauthorized('permission denied for bucket')
-        credential_key = s3_buckets[location.netloc]
+            if location.netloc in s3_buckets.keys():
+                credential_key = s3_buckets[location.netloc]
+                if credential_key not in aws_creds:
+                    raise Unauthorized('permission denied for bucket')
+                # public bucket
+                if credential_key == '*':
+                    return dict(url=http_url)
         config = get_value(aws_creds, credential_key,
                            InternalError('aws credential of that bucket is not found'))
         region = flask.current_app.boto.get_bucket_region(location.netloc, config)
-        http_url = 'https://{}.s3.amazonaws.com/{}'.format(location.netloc, location.path.strip('/'))
         if 'aws_access_key_id' not in config:
             raise Unauthorized('credential is not configured correctly')
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def indexd_get_unavailable_bucket(file_id):
     }
 
 
-def indexd_get_public_bucket(file_id):
+def indexd_get_public_object(file_id):
     return {
         'did': '',
         'baseid': '',
@@ -94,6 +94,21 @@ def indexd_get_public_bucket(file_id):
         "updated_date": ''
     }
 
+
+def indexd_get_public_bucket(file_id):
+    return {
+        'did': '',
+        'baseid': '',
+        'rev': '',
+        'size': 10,
+        'file_name': 'file1',
+        'urls': ['s3://bucket4/key'],
+        'hashes': {},
+        'metadata': {'acls': '*'},
+        'form': '',
+        'created_date': '',
+        "updated_date": ''
+    }
 
 def mock_get_bucket_location(self, bucket, config):
     return 'us-east-1'
@@ -357,9 +372,18 @@ def public_indexd_client(app, request):
     mocker.mock_functions()
     indexd_patcher = patch(
         'fence.blueprints.data.get_index_document',
-        indexd_get_public_bucket)
+        indexd_get_public_object)
     mocker.add_mock(indexd_patcher)
 
+
+@pytest.fixture(scope='function')
+def public_bucket_indexd_client(app, request):
+    mocker = Mocker()
+    mocker.mock_functions()
+    indexd_patcher = patch(
+        'fence.blueprints.data.get_index_document',
+        indexd_get_public_bucket)
+    mocker.add_mock(indexd_patcher)
 
 @pytest.fixture(scope='function')
 def patch_app_db_session(app, monkeypatch):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 from . import utils
 import jwt
+import urlparse
 
 
 def test_indexd_download_file(
@@ -136,7 +137,7 @@ def test_unavailable_indexd_upload_file(
     assert 'url' not in response.json.keys()
 
 
-def test_public_bucket_download_file(client, auth_client, public_indexd_client):
+def test_public_object_download_file(client, auth_client, public_indexd_client):
     """
     Test ``GET /data/upload/1``.
     """
@@ -145,3 +146,17 @@ def test_public_bucket_download_file(client, auth_client, public_indexd_client):
     print response.json
     assert response.status_code == 200
     assert 'url' in response.json.keys()
+
+
+def test_public_bucket_download_file(
+        client, auth_client, public_bucket_indexd_client):
+    """
+    Test ``GET /data/upload/1`` with public bucket
+    """
+    path = '/data/download/1'
+    response = client.get(path)
+    print response.json
+    assert response.status_code == 200
+    url = response.json['url']
+    # public url without signature
+    assert urlparse.urlparse(url).query == ''

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -83,6 +83,7 @@ S3_BUCKETS = {
     "bucket1": "CRED1",
     "bucket2": "CRED2",
     "bucket3": "CRED1",
+    "bucket4": "*",
 }
 
 ENABLED_IDENTITY_PROVIDERS = {


### PR DESCRIPTION
- don't try to resolve scheme that's not supported yet (eg: gs)
- if the bucket is configured to be '*' (without creds) in settings, return the http url 
- latest pip is broken in docker build, pin to 9
- remove deadcode (http conf)