### PR TITLE
fix(delete-google-link): only error out when attempting to remove acc…

### DIFF
--- a/fence/blueprints/link.py
+++ b/fence/blueprints/link.py
@@ -152,23 +152,23 @@ class GoogleLinkRedirect(Resource):
                 .user_google_account_id == g_account.id).first()
         )
 
-        try:
-            with GoogleCloudManager() as g_manager:
-                g_manager.remove_member_from_group(
-                    member_email=g_account.email,
-                    group_id=g_account_access.proxy_group_id
-                )
-        except Exception as exc:
-            error_message = {
-                'error': 'g_acnt_access_error',
-                'error_description': (
-                    'Couldn\'t remove account from user\'s proxy group, '
-                    'Google API failure. Exception: {}'.format(exc)
-                )
-            }
-            return error_message, 400
-
         if g_account_access:
+            try:
+                with GoogleCloudManager() as g_manager:
+                    g_manager.remove_member_from_group(
+                        member_email=g_account.email,
+                        group_id=g_account_access.proxy_group_id
+                    )
+            except Exception as exc:
+                error_message = {
+                    'error': 'g_acnt_access_error',
+                    'error_description': (
+                        'Couldn\'t remove account from user\'s proxy group, '
+                        'Google API failure. Exception: {}'.format(exc)
+                    )
+                }
+                return error_message, 400
+
             current_session.delete(g_account_access)
             current_session.commit()
 


### PR DESCRIPTION
…ess if account HAS access

* Fix bug in DELETE /link/google endpoint where if the account currently does not have access (24 hr expiration has expired) we error out and don't remove the linkage
     * now it only attempts to remove access if it has access