### PR TITLE
fix(google-url-signing): fernet lib expects bytes, need explicit cast…

### DIFF
--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -50,7 +50,8 @@ def get_or_create_primary_service_account_key(
         fernet_key = Fernet(
             str(flask.current_app.config['HMAC_ENCRYPTION_KEY'])
         )
-        private_key_bytes = fernet_key.decrypt(user_service_account_key.private_key)
+        private_key_bytes = fernet_key.decrypt(
+            str(user_service_account_key.private_key))
         sa_private_key = json.loads(private_key_bytes.decode('utf-8'))
     else:
         sa_private_key = create_primary_service_account_key(


### PR DESCRIPTION
* quick fix to correct issue during url signing for google
* need to explicitly cast to str() for fernet key 