### PR TITLE
fix(token-create): bugfix for token-create

### DIFF
--- a/bin/fence-create
+++ b/bin/fence-create
@@ -240,29 +240,29 @@ def main():
             project_auth_id=args.project_auth_id
         )
     elif args.action == 'token-create':
-        keys_path = args.pop('keys-dir', os.path.join(ROOT_DIR, 'keys'))
+        keys_path = getattr(args, 'keys-dir', os.path.join(ROOT_DIR, 'keys'))
         keypairs = keys.load_keypairs(keys_path)
         # Default to the most recent one, but try to find the keypair with
         # matching ``kid`` to the argument provided.
         keypair = keypairs[-1]
-        kid = args.get('kid')
+        kid = getattr(args, 'kid')
         if kid:
             for try_keypair in keypairs:
                 if try_keypair.kid == kid:
                     keypair = try_keypair
                     break
         jwt_creator = JWTCreator(
-            DB, BASE_URL, kid=keypair.kid, private_key= keypair.private_key,
-            username=args['username'], scopes=args['scopes'],
+            DB, BASE_URL, kid=keypair.kid, private_key=keypair.private_key,
+            username=args.username, scopes=args.scopes, expires_in=args.exp,
         )
-        if args['type'] == 'access':
-            print(jwt_creator.create_access_token())
-        elif args['type'] == 'refresh':
-            print(jwt_creator.create_refresh_token())
+        if args.type == 'access_token':
+            print(jwt_creator.create_access_token().token)
+        elif args.type == 'refresh_token':
+            print(jwt_creator.create_refresh_token().token)
         else:
             print(
                 'invalid token type "{}"; expected "access" or "refresh"'
-                .format(args['type'])
+                .format(args.type)
             )
             sys.exit(1)
 

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -258,7 +258,7 @@ def generate_signed_id_token(
 
 
 def generate_signed_refresh_token(
-        kid, private_key, user, expires_in, scopes, client_id=None):
+        kid, private_key, user, expires_in, scopes, iss=None, client_id=None):
     """
     Generate a JWT refresh token and output a UTF-8
     string of the encoded JWT signed with the private key.
@@ -277,11 +277,19 @@ def generate_signed_refresh_token(
     iat, exp = issued_and_expiration_times(expires_in)
     jti = str(uuid.uuid4())
     sub = str(user.id)
+    if not iss:
+        try:
+            iss = flask.current_app.config.get('BASE_URL')
+        except RuntimeError:
+            raise ValueError(
+                'must provide value for `iss` (issuer) field if'
+                ' running outside of flask application'
+            )
     claims = {
         'pur': 'refresh',
         'aud': scopes,
         'sub': sub,
-        'iss': flask.current_app.config.get('BASE_URL'),
+        'iss': iss,
         'iat': iat,
         'exp': exp,
         'jti': jti,
@@ -345,8 +353,8 @@ def generate_api_key(
 
 
 def generate_signed_access_token(
-        kid, private_key, user, expires_in, scopes, forced_exp_time=None,
-        client_id=None, linked_google_email=None):
+        kid, private_key, user, expires_in, scopes, iss=None,
+        forced_exp_time=None, client_id=None, linked_google_email=None):
     """
     Generate a JWT access token and output a UTF-8
     string of the encoded JWT signed with the private key.
@@ -369,11 +377,19 @@ def generate_signed_access_token(
     exp = forced_exp_time or exp
     sub = str(user.id)
     jti = str(uuid.uuid4())
+    if not iss:
+        try:
+            iss = flask.current_app.config.get('BASE_URL')
+        except RuntimeError:
+            raise ValueError(
+                'must provide value for `iss` (issuer) field if'
+                ' running outside of flask application'
+            )
     claims = {
         'pur': 'access',
         'aud': scopes,
         'sub': sub,
-        'iss': flask.current_app.config.get('BASE_URL'),
+        'iss': iss,
         'iat': iat,
         'exp': exp,
         'jti': jti,

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -502,7 +502,7 @@ class JWTCreator(object):
 
     default_expiration = 3600
 
-    def __init__(self, db, base_url=None, **kwargs):
+    def __init__(self, db, base_url, **kwargs):
         self.db = db
         self.base_url = base_url
 
@@ -521,7 +521,7 @@ class JWTCreator(object):
 
         # Set attributes on this object from the kwargs.
         for kwarg_name in self.all_kwargs:
-            setattr(self, kwarg_name, kwargs[kwarg_name])
+            setattr(self, kwarg_name, kwargs.get(kwarg_name))
 
         # If the scopes look like this:
         #
@@ -554,7 +554,8 @@ class JWTCreator(object):
                     'no user found with given username: ' + self.username
                 )
             return generate_signed_access_token(
-                self.kid, self.private_key, user, self.expires_in, self.scopes
+                self.kid, self.private_key, user, self.expires_in, self.scopes,
+                iss=self.base_url,
             )
 
     def create_refresh_token(self):
@@ -576,7 +577,8 @@ class JWTCreator(object):
                     'no user found with given username: ' + self.username
                 )
             jwt_result = generate_signed_refresh_token(
-                self.kid, self.private_key, user, self.expires_in, self.scopes
+                self.kid, self.private_key, user, self.expires_in, self.scopes,
+                iss=self.base_url,
             )
 
             current_session.add(UserRefreshToken(


### PR DESCRIPTION
- fix bug because `args` is not dictionary-like
- fix using base URL because flask app not available
- fix argument to be the same as before: for example `access_token`, not `access`