### PR TITLE
PXD-859 fix(google-oidc): allow google client with callback without supporting login through google

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -147,7 +147,6 @@ def app_sessions(app):
     configured_google = (
         'OPENID_CONNECT' in app.config
         and 'google' in app.config['OPENID_CONNECT']
-        and 'google' in enabled_idp_ids
     )
     if configured_google:
         app.google_client = GoogleClient(

--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -50,6 +50,13 @@ def make_login_blueprint(app):
         'shibboleth': 'shib',
     }
 
+    # check if google is configured as a client. we will at least need a
+    # a callback if it is
+    google_client_exists = (
+        'OPENID_CONNECT' in app.config
+        and 'google' in app.config['OPENID_CONNECT']
+    )
+
     blueprint = flask.Blueprint('login', __name__)
     blueprint_api = RestfulApi(blueprint)
 
@@ -104,6 +111,10 @@ def make_login_blueprint(app):
         blueprint_api.add_resource(
             GoogleRedirect, '/google', strict_slashes=False
         )
+
+    # we can use Google Client and callback here without the login endpoint
+    # if Google is configured as a client but not in the idps
+    if 'google' in idps or google_client_exists:
         blueprint_api.add_resource(
             GoogleLogin, '/google/login', strict_slashes=False
         )

--- a/tests/credentials/google/test_credentials.py
+++ b/tests/credentials/google/test_credentials.py
@@ -386,6 +386,7 @@ def test_google_bucket_access_existing_proxy_group(
     )
     assert response.status_code == 200
 
+
 def test_google_create_access_token_post(
         app, client, oauth_client, cloud_manager, db_session,
         encoded_creds_jwt):

--- a/tests/link/test_link.py
+++ b/tests/link/test_link.py
@@ -33,6 +33,25 @@ def test_google_link_redirect(client, app, encoded_creds_jwt):
     assert r.location.startswith(app.google_client.get_auth_url())
 
 
+def test_google_link_redirect_no_google_idp(
+        client, app, remove_google_idp, encoded_creds_jwt):
+    """
+    Test that even if Google is not configured as an IDP, when we hit the link
+    endpoint with valid creds, we get a redirect response.
+    This should be redirecting to google's oauth
+    """
+    encoded_credentials_jwt = encoded_creds_jwt['jwt']
+    redirect = 'http://localhost'
+
+    r = client.get(
+        '/link/google',
+        query_string={'redirect': redirect},
+        headers={'Authorization': 'Bearer ' + encoded_credentials_jwt})
+
+    assert r.status_code == 302
+    assert r.location.startswith(app.google_client.get_auth_url())
+
+
 def test_google_link_no_redirect_provided(
         client, app, add_new_g_acnt_mock,
         google_auth_get_user_info_mock):


### PR DESCRIPTION
* Fix configuration to allow not having Google as an IDP for user login but still allow the linking endpoints to work
* Will now set up fence up as a client for Google if information is provided in `OPENID_CONNECT` configuration but will NOT create a login endpoint for Google unless it's in the `ENABLED_IDENTITY_PROVIDERS`

resolve #268 