### PR TITLE
PXD-1004 Fix/stale access token

### DIFF
--- a/fence/auth.py
+++ b/fence/auth.py
@@ -109,7 +109,7 @@ def check_scope(scope):
 
 def login_required(scope=None):
     """
-    Create decorator to require a user session in shibboleth.
+    Create decorator to require a user session
     """
 
     def decorator(f):

--- a/fence/resources/user/user_session.py
+++ b/fence/resources/user/user_session.py
@@ -55,8 +55,7 @@ class UserSession(SessionMixin):
             try:
                 jwt_info = validate_jwt(
                     session_token,
-                    public_key=default_public_key(),
-                    aud={'fence'},
+                    aud={'fence'}
                 )
             except JWTError:
                 # if session token is invalid, create a new
@@ -111,7 +110,7 @@ class UserSession(SessionMixin):
         """
         get a value from session json
         """
-        return self.session_token["context"].get(key, *args)
+        return self.session_token['context'].get(key, *args)
 
     def pop(self, key, default):
         return self.session_token['context'].pop(key, default)
@@ -121,7 +120,7 @@ class UserSession(SessionMixin):
         clear current session
         """
         self._encoded_token = None
-        self.session_token = {"context": {}}
+        self.session_token = {'context': {}}
 
     def clear_if_expired(self, app):
         if self._encoded_token:
@@ -142,7 +141,7 @@ class UserSession(SessionMixin):
         return key in self.session_token['context']
 
     def __getitem__(self, key):
-        return self.session_token["context"][key]
+        return self.session_token['context'][key]
 
     def __setitem__(self, key, value):
         # If token doesn't exists, create the first session token when
@@ -150,11 +149,11 @@ class UserSession(SessionMixin):
         if not self._encoded_token:
             self.create_initial_token()
 
-        self.session_token["context"][key] = value
+        self.session_token['context'][key] = value
         self.modified = True
 
     def __delitem__(self, key):
-        del self.session_token["context"][key]
+        del self.session_token['context'][key]
         self.modified = True
 
     def __iter__(self):
@@ -172,15 +171,14 @@ class UserSessionInterface(SessionInterface):
 
     def open_session(self, app, request):
         jwt = request.cookies.get(app.session_cookie_name)
-        flask.g.access_token = (
-            request.cookies.get(app.config['ACCESS_TOKEN_COOKIE_NAME'], None)
-        )
         session = UserSession(jwt)
 
         # NOTE: If we did the expiration check in save_session
         # then an expired token could be used for a single request
         # (on open_session) before it's invalidated for being expired
         session.clear_if_expired(app)
+
+        flask.g.access_token = _get_valid_access_token(app, session, request)
 
         return session
 
@@ -205,6 +203,23 @@ class UserSessionInterface(SessionInterface):
             except Unauthorized:
                 user = None
 
+            # check that the current user is the one from the session,
+            # clear access token if not
+            user_sess_id = _get_user_id_from_session(session)
+            if not user:
+                response.set_cookie(
+                    app.config['ACCESS_TOKEN_COOKIE_NAME'],
+                    expires=0,
+                    httponly=True, domain=domain)
+            elif user.id != user_sess_id:
+                if user.username != user_sess_id:
+                    response.set_cookie(
+                        app.config['ACCESS_TOKEN_COOKIE_NAME'],
+                        expires=0,
+                        httponly=True, domain=domain)
+
+            # if a user is logged in and doesn't have an access token, let's
+            # generate one
             if user and not flask.g.access_token:
                 _create_access_token_cookie(app, session, response, user)
         else:
@@ -226,6 +241,47 @@ class UserSessionInterface(SessionInterface):
                 app.config['ACCESS_TOKEN_COOKIE_NAME'],
                 expires=0,
                 httponly=True, domain=domain)
+
+
+def _get_valid_access_token(app, session, request):
+    """
+    Return a valid access token. If at any point access token is determined
+    invalid, this will return None.
+    """
+    access_token = (
+        request.cookies.get(app.config['ACCESS_TOKEN_COOKIE_NAME'], None)
+    )
+
+    if access_token:
+        try:
+            valid_access_token = validate_jwt(
+                access_token,
+                purpose='access'
+            )
+        except Exception as exc:
+            return None
+
+        # try to get user, execption means they're not logged in
+        try:
+            user = get_current_user(flask_session=session)
+        except Unauthorized:
+            return None
+
+        # check that the current user is the one from the session and access_token
+        user_sess_id = _get_user_id_from_session(session)
+        token_user_id = _get_user_id_from_access_token(valid_access_token)
+
+        if user.id != user_sess_id:
+            if user.username != user_sess_id:
+                return None
+
+        if user.id != token_user_id:
+            if user.username != token_user_id:
+                # only invalid if the token id isn't the user's id OR username
+                # since the username is also unique
+                return None
+
+    return access_token
 
 
 def _clear_session_if_expired(app, session):
@@ -267,3 +323,35 @@ def _create_access_token_cookie(app, session, response, user):
     )
 
     return response
+
+
+def _get_user_id_from_session(session):
+    """
+    Get user's identifier from the session. It could be their id or username
+    since both are unique.
+    """
+    user_sess_id = session.session_token.get('sub')
+    if user_sess_id:
+        try:
+            user_sess_id = int(user_sess_id)
+        except ValueError:
+            # if we can't cast to an int, don't. could be username
+            pass
+
+    return user_sess_id
+
+
+def _get_user_id_from_access_token(access_token):
+    """
+    Get user's identifier from the access token claims. It could be their id or
+    username since both are unique.
+    """
+    token_user_id = access_token.get('sub')
+    if token_user_id:
+        try:
+            token_user_id = int(token_user_id)
+        except ValueError:
+            # if we can't cast to an int, don't. could be username
+            pass
+
+    return token_user_id

--- a/fence/user.py
+++ b/fence/user.py
@@ -6,8 +6,9 @@ from fence.errors import Unauthorized
 from fence.models import User
 
 
-def get_current_user():
-    username = flask.session.get('username')
+def get_current_user(flask_session=None):
+    flask_session = flask_session or flask.session
+    username = flask_session.get('username')
     if flask.current_app.config.get('MOCK_AUTH', False) is True:
         username = 'test'
     if not username:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -512,6 +512,36 @@ def auth_client(app, request):
     request.addfinalizer(reset_authmock)
 
 
+@pytest.fixture(scope='function')
+def test_user_a(db_session):
+    test_user = (
+        db_session
+        .query(models.User)
+        .filter_by(username='test_a')
+        .first()
+    )
+    if not test_user:
+        test_user = models.User(username='test_a', is_admin=False)
+        db_session.add(test_user)
+        db_session.commit()
+    return Dict(username='test_a', user_id=test_user.id)
+
+
+@pytest.fixture(scope='function')
+def test_user_b(db_session):
+    test_user = (
+        db_session
+        .query(models.User)
+        .filter_by(username='test_b')
+        .first()
+    )
+    if not test_user:
+        test_user = models.User(username='test_b', is_admin=False)
+        db_session.add(test_user)
+        db_session.commit()
+    return Dict(username='test_b', user_id=test_user.id)
+
+
 @pytest.fixture(scope='session')
 def db(app, request):
     """

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -1,6 +1,16 @@
 import time
+import flask
 from fence.resources.storage.cdis_jwt import create_session_token
-from fence.settings import SESSION_COOKIE_NAME
+from fence.jwt.token import generate_signed_access_token
+from fence.settings import (
+    SESSION_COOKIE_NAME,
+    ACCESS_TOKEN_COOKIE_NAME,
+    ACCESS_TOKEN_EXPIRES_IN
+)
+from fence.models import User
+
+from fence.jwt.keys import default_public_key
+from fence.jwt.validate import validate_jwt
 
 # Python 2 and 3 compatible
 try:
@@ -53,7 +63,7 @@ def test_valid_session(app):
 
     test_session_jwt = create_session_token(
         app.keypairs[0],
-        app.config.get("SESSION_TIMEOUT"),
+        app.config.get('SESSION_TIMEOUT'),
         context={'username': username},
     )
 
@@ -61,7 +71,7 @@ def test_valid_session(app):
     # the username
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
             assert session["username"] == username
 
@@ -72,7 +82,7 @@ def test_valid_session_modified(app):
 
     test_session_jwt = create_session_token(
         app.keypairs[0],
-        app.config.get("SESSION_TIMEOUT"),
+        app.config.get('SESSION_TIMEOUT'),
         context={'username': username},
     )
 
@@ -80,7 +90,7 @@ def test_valid_session_modified(app):
     # the username
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
 
             assert session["username"] == username
@@ -92,31 +102,31 @@ def test_valid_session_modified(app):
 
 def test_expired_session_lifetime(app):
     # make the start time be max lifetime ago (so it's expired)
-    lifetime = app.config.get("SESSION_LIFETIME")
+    lifetime = app.config.get('SESSION_LIFETIME')
     now = int(time.time())
     one_lifetime_ago = now - lifetime
     username = "Captain Janeway"
 
     test_session_jwt = create_session_token(
         app.keypairs[0],
-        app.config.get("SESSION_TIMEOUT"),
+        app.config.get('SESSION_TIMEOUT'),
         context=dict(session_started=one_lifetime_ago,
                      username=username)
     )
 
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
             # make sure we don't have the username when opening
             # the session, since it has expired
-            assert session.get("username") != username
+            assert session.get('username') != username
 
 
 def test_expired_session_timeout(app):
     # make the start time be one timeout in the past (so the
     # session is expired)
-    max_inactivity = app.config.get("SESSION_TIMEOUT")
+    max_inactivity = app.config.get('SESSION_TIMEOUT')
     now = int(time.time())
     last_active = (now - max_inactivity)
     username = "Captain Janeway"
@@ -134,11 +144,11 @@ def test_expired_session_timeout(app):
 
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
             # make sure we don't have the username when opening
             # the session, since it has expired
-            assert session.get("username") != username
+            assert session.get('username') != username
 
 
 def test_session_cleared(app):
@@ -146,7 +156,7 @@ def test_session_cleared(app):
 
     test_session_jwt = create_session_token(
         app.keypairs[0],
-        app.config.get("SESSION_TIMEOUT"),
+        app.config.get('SESSION_TIMEOUT'),
         context=dict(username=username)
     )
 
@@ -154,11 +164,11 @@ def test_session_cleared(app):
     # the username
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
             session["username"] = username
             session.clear()
-            assert session.get("username") != username
+            assert session.get('username') != username
         client_cookies = [cookie.name for cookie in client.cookie_jar]
         assert SESSION_COOKIE_NAME not in client_cookies
 
@@ -170,10 +180,135 @@ def test_invalid_session_cookie(app):
     # the username
     with app.test_client() as client:
         # manually set cookie for initial session
-        client.set_cookie("localhost", SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         with client.session_transaction() as session:
             # main test is that we haven't raised an exception by this point
 
             # for utmost clarity, make sure that no username
             # exists in the session yet
-            assert not session.get("username")
+            assert not session.get('username')
+
+
+def test_valid_session_valid_access_token(
+        app, db_session, test_user_a, test_user_b, monkeypatch):
+    monkeypatch.setitem(app.config, 'MOCK_AUTH', False)
+    user = db_session.query(User).filter_by(id=test_user_a['user_id']).first()
+    keypair = app.keypairs[0]
+
+    test_session_jwt = create_session_token(
+        keypair,
+        app.config.get('SESSION_TIMEOUT'),
+        context={'username': user.username, 'provider': 'google'})
+
+    test_access_jwt = generate_signed_access_token(
+        kid=keypair.kid,
+        private_key=keypair.private_key,
+        user=user,
+        expires_in=app.config.get('ACCESS_TOKEN_EXPIRES_IN'),
+        scopes=['openid', 'user'],
+        iss=flask.current_app.config.get('BASE_URL'),
+        forced_exp_time=None,
+        client_id=None,
+        linked_google_email=None
+    ).token
+
+    # Test that once the session is started, we have access to
+    # the username
+    with app.test_client() as client:
+        # manually set cookie for initial session
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', ACCESS_TOKEN_COOKIE_NAME, test_access_jwt)
+        with client.session_transaction() as session:
+            assert session["username"] == user.username
+
+        response = client.get('/user')
+        user_id = response.json.get('user_id') or response.json.get('sub')
+        assert response.status_code == 200
+        assert user_id == user.id
+
+
+def test_valid_session_valid_access_token_diff_user(
+        app, test_user_a, test_user_b, db_session, monkeypatch):
+    """
+    Test the case where a valid access token is in a cookie, but it's for a
+    different user than the one logged in. Make sure that a new access token
+    is created for the logged in user and the response doesn't contain info
+    for the non-logged in user.
+    """
+    monkeypatch.setitem(app.config, 'MOCK_AUTH', False)
+    user = db_session.query(User).filter_by(id=test_user_a['user_id']).first()
+    keypair = app.keypairs[0]
+
+    test_session_jwt = create_session_token(
+        keypair,
+        app.config.get('SESSION_TIMEOUT'),
+        context={'username': user.username, 'provider': 'google'})
+
+    # different user's access token
+    other_user = db_session.query(User).filter_by(id=test_user_b['user_id']).first()
+    test_access_jwt = generate_signed_access_token(
+        kid=keypair.kid,
+        private_key=keypair.private_key,
+        user=other_user,
+        expires_in=app.config.get('ACCESS_TOKEN_EXPIRES_IN'),
+        scopes=['openid', 'user'],
+        iss=flask.current_app.config.get('BASE_URL'),
+        forced_exp_time=None,
+        client_id=None,
+        linked_google_email=None
+    ).token
+
+    with app.test_client() as client:
+        # manually set cookie for initial session
+        client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
+        client.set_cookie('localhost', ACCESS_TOKEN_COOKIE_NAME, test_access_jwt)
+        with client.session_transaction() as session:
+            assert session['username'] == user.username
+
+        response = client.get('/user')
+        cookies = _get_cookies_from_response(response)
+
+        # either there's a new access_token in the response headers or the
+        # previously set access token been changed
+        access_token = (
+            cookies.get('access_token', {}).get('access_token')
+            or test_access_jwt
+        )
+
+        valid_access_token = validate_jwt(
+            access_token,
+            aud={'user'},
+            purpose='access',
+            public_key=default_public_key(),
+        )
+        assert response.status_code == 200
+        response_user_id = response.json.get('user_id') or response.json.get('sub')
+        assert response_user_id == test_user_a['user_id']
+
+        user_id = valid_access_token.get('user_id') or valid_access_token.get('sub')
+        assert test_user_a['user_id'] == int(user_id)
+
+
+def _get_cookies_from_response(response):
+    raw_cookies = [
+        header[1]
+        for header in response.headers.iteritems()
+        if header[0] == 'Set-Cookie'
+    ]
+    cookies = {}
+    for cookie in raw_cookies:
+        cookie_items = [item.strip() for item in cookie.split(';')]
+        cookie_name = cookie_items[0].split('=')[0]
+        cookie_info = {
+            item.split('=')[0]: item.split('=')[1]
+            for item in cookie_items
+            if len(item.split('=')) > 1
+        }
+        cookie_more_info = {
+            item: None
+            for item in cookie_items
+            if len(item.split('=')) == 1
+        }
+        cookie_info.update(cookie_more_info)
+        cookies[cookie_name] = cookie_info
+    return cookies

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -218,8 +218,6 @@ def test_valid_session_valid_access_token(
         # manually set cookie for initial session
         client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         client.set_cookie('localhost', ACCESS_TOKEN_COOKIE_NAME, test_access_jwt)
-        with client.session_transaction() as session:
-            assert session["username"] == user.username
 
         response = client.get('/user')
         user_id = response.json.get('user_id') or response.json.get('sub')
@@ -252,18 +250,13 @@ def test_valid_session_valid_access_token_diff_user(
         user=other_user,
         expires_in=app.config.get('ACCESS_TOKEN_EXPIRES_IN'),
         scopes=['openid', 'user'],
-        iss=flask.current_app.config.get('BASE_URL'),
-        forced_exp_time=None,
-        client_id=None,
-        linked_google_email=None
+        iss=flask.current_app.config.get('BASE_URL')
     ).token
 
     with app.test_client() as client:
         # manually set cookie for initial session
         client.set_cookie('localhost', SESSION_COOKIE_NAME, test_session_jwt)
         client.set_cookie('localhost', ACCESS_TOKEN_COOKIE_NAME, test_access_jwt)
-        with client.session_transaction() as session:
-            assert session['username'] == user.username
 
         response = client.get('/user')
         cookies = _get_cookies_from_response(response)
@@ -277,9 +270,7 @@ def test_valid_session_valid_access_token_diff_user(
 
         valid_access_token = validate_jwt(
             access_token,
-            aud={'user'},
-            purpose='access',
-            public_key=default_public_key(),
+            purpose='access'
         )
         assert response.status_code == 200
         response_user_id = response.json.get('user_id') or response.json.get('sub')


### PR DESCRIPTION
Check for valid `access_token` when opening the session. Verify that the user identifier provided in the `access_token` matches the one in the current session. 