### PR TITLE
chore(setting): fix fence login name

### DIFF
--- a/fence/local_settings.example.py
+++ b/fence/local_settings.example.py
@@ -139,10 +139,11 @@ S3_BUCKETS = {
 ENABLED_IDENTITY_PROVIDERS = {
     # ID for which of the providers to default to.
     'default': 'google',
-    # Information for identity providers.
+    # Information for identity providers. The name will be what show
+    # up in portal login page
     'providers': {
         'fence': {
-            'name': 'Fence Multi-Tenant OAuth',
+            'name': 'NIH Login',
         },
         'google': {
             'name': 'Google OAuth',


### PR DESCRIPTION
"Fence Multi-Tenant OAuth" is not something end user can understand
The name should be the final idp's name, and our major/only use case for multi tenant fence is NIH Login. So the default name in the template should be that