### PR TITLE
White list service account ids

### DIFF
--- a/fence/local_settings.example.py
+++ b/fence/local_settings.example.py
@@ -187,3 +187,5 @@ if os.path.exists(fence_creds):
         HTTP_PROXY = data['HTTP_PROXY']
         dbGaP = data["dbGaP"]
         GOOGLE_GROUP_PREFIX = data.get('GOOGLE_GROUP_PREFIX')
+
+WHITE_LISTED_SERVICE_ACCOUNT_EMAILS = []

--- a/fence/local_settings.example.py
+++ b/fence/local_settings.example.py
@@ -139,10 +139,11 @@ S3_BUCKETS = {
 ENABLED_IDENTITY_PROVIDERS = {
     # ID for which of the providers to default to.
     'default': 'google',
-    # Information for identity providers.
+    # Information for identity providers. The name will be what show
+    # up in portal login page
     'providers': {
         'fence': {
-            'name': 'Fence Multi-Tenant OAuth',
+            'name': 'NIH Login',
         },
         'google': {
             'name': 'Google OAuth',

--- a/fence/local_settings.example.py
+++ b/fence/local_settings.example.py
@@ -187,5 +187,5 @@ if os.path.exists(fence_creds):
         HTTP_PROXY = data['HTTP_PROXY']
         dbGaP = data["dbGaP"]
         GOOGLE_GROUP_PREFIX = data.get('GOOGLE_GROUP_PREFIX')
+        WHITE_LISTED_SERVICE_ACCOUNT_EMAILS = data.get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS')
 
-WHITE_LISTED_SERVICE_ACCOUNT_EMAILS = []

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -856,11 +856,10 @@ def remove_white_listed_service_account_ids(service_account_ids):
         service_account_ids.remove(monitoring_service_account)
 
     if 'WHITE_LISTED_SERVICE_ACCOUNT_EMAILS' in flask.current_app.config:
-        whitelist = (flask.current_app.config
-                     .get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS'))
-        for email in whitelist:
-            if email in service_account_ids:
-                service_account_ids.remove(email)
+        for email in (flask.current_app.config
+                      .get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS')):
+                if email in service_account_ids:
+                    service_account_ids.remove(email)
 
     return service_account_ids
 

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -854,6 +854,14 @@ def remove_white_listed_service_account_ids(service_account_ids):
     monitoring_service_account = get_monitoring_service_account_email()
     if monitoring_service_account in service_account_ids:
         service_account_ids.remove(monitoring_service_account)
+
+    if 'WHITE_LISTED_SERVICE_ACCOUNT_EMAILS' in flask.current_app.config:
+        whitelist = (flask.current_app.config
+                     .get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS'))
+        for email in whitelist:
+            if email in service_account_ids:
+                service_account_ids.remove(email)
+
     return service_account_ids
 
 

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -857,7 +857,7 @@ def remove_white_listed_service_account_ids(service_account_ids):
 
     if 'WHITE_LISTED_SERVICE_ACCOUNT_EMAILS' in flask.current_app.config:
         for email in (flask.current_app.config
-                      .get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS')):
+                      .get('WHITE_LISTED_SERVICE_ACCOUNT_EMAILS', [])):
                 if email in service_account_ids:
                     service_account_ids.remove(email)
 

--- a/tests/google/test_access_utils.py
+++ b/tests/google/test_access_utils.py
@@ -36,6 +36,7 @@ from fence.resources.google.access_utils import (
     extend_service_account_access,
     get_current_service_account_project_access,
     patch_user_service_account,
+    remove_white_listed_service_account_ids,
 )
 
 
@@ -833,3 +834,12 @@ def test_update_user_service_account_raise_GoogleAPI_exc4(
     with pytest.raises(Exception):
         assert patch_user_service_account('test', 'test@gmail.com', ['test_auth_1'])
 
+
+def test_whitelisted_service_accounts(app, db_session, client,
+                                      encoded_jwt_service_accounts_access, cloud_manager,
+                                      valid_google_project_patcher, valid_service_account_patcher):
+    service_account_ids = ['test@123', 'test@456', 'test@789']
+    remove_white_listed_service_account_ids(service_account_ids)
+    assert 'test@123' not in service_account_ids
+    assert 'test@456' not in service_account_ids
+    assert 'test@789' in service_account_ids

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -152,3 +152,7 @@ OPENID_CONNECT = {
 GOOGLE_GROUP_PREFIX = 'test'
 
 CIRRUS_CFG = {}
+
+WHITE_LISTED_SERVICE_ACCOUNT_EMAILS = [
+    'test@0', 'test@123', 'test@456',
+]


### PR DESCRIPTION
* remove_white_listed_service_account_ids now removes service account ids listed in settings in addition to monitoring service account

* local_settings.py needs to be updated for this to take effect