### PR TITLE
PXD-1505 Fix/admin user

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -480,7 +480,7 @@ class UserSyncer(object):
         self._grant_from_storage(to_update, user_project, sess)
         self._update_from_db(sess, to_update, user_project)
 
-        self._validate_and_upadate_user_admin(sess)
+        self._validate_and_update_user_admin(sess)
 
     def _revoke_from_db(self, sess, to_delete):
         """
@@ -509,7 +509,7 @@ class UserSyncer(object):
 
         sess.commit()
 
-    def _validate_and_upadate_user_admin(self, sess):
+    def _validate_and_update_user_admin(self, sess):
         """
         Make sure there is no admin user without project access
 

--- a/tests/dbgap_sync/conftest.py
+++ b/tests/dbgap_sync/conftest.py
@@ -107,7 +107,7 @@ def syncer(db_session, request):
         {'username': 'test_user1@gmail.com', 'is_admin': False,
             'email': 'test_user1@gmail.com'},
         {'username': 'deleted_user@gmail.com',
-            'is_admin': False, 'email': 'deleted_user@gmail.com'},
+            'is_admin': True, 'email': 'deleted_user@gmail.com'},
         {'username': 'TESTUSERD', 'is_admin': True, 'email': 'userD@gmail.com'}
     ]
 

--- a/tests/dbgap_sync/test_user_sync.py
+++ b/tests/dbgap_sync/test_user_sync.py
@@ -51,6 +51,7 @@ def test_sync(syncer, db_session, storage_client):
 
     user = db_session.query(models.User).filter_by(
         username='deleted_user@gmail.com').one()
+    assert not user.is_admin
 
     user_access = db_session.query(
         models.AccessPrivilege).filter_by(user=user).all()


### PR DESCRIPTION


When syncing user permissions from the user.yaml file in fence, if a user's permissions get revoked (user is removed from user.yaml file), the user's access_privileges get removed from the access_privilege table, but their email, user_id and admin status do not get removed from the User table. This allows users to maintain admin access after they have been removed from the user.yaml file.

We wouldn't want to remove the user because that would be an interruptive experience for user who browses public dataset. So let's just clear up the admin access