### PR TITLE
Fix Link External Database

### DIFF
--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -1148,7 +1148,7 @@ def _get_or_create_google_provider(db_session):
 
 
 def link_external_bucket(
-        current_session, name):
+        db, name):
 
     """
     Link with bucket owned by an external party. This will create the bucket
@@ -1163,19 +1163,21 @@ def link_external_bucket(
 
     google_project_id = cirrus_config.GOOGLE_PROJECT_ID
 
-    google_cloud_provider = _get_or_create_google_provider(current_session)
+    db = SQLAlchemyDriver(db)
+    with db.session as current_session:
+        google_cloud_provider = _get_or_create_google_provider(current_session)
 
-    bucket_db_entry = Bucket(
-        name=name,
-        provider_id=google_cloud_provider.id
-    )
-    current_session.add(bucket_db_entry)
-    current_session.commit()
-    privileges = ['read']
+        bucket_db_entry = Bucket(
+            name=name,
+            provider_id=google_cloud_provider.id
+        )
+        current_session.add(bucket_db_entry)
+        current_session.commit()
+        privileges = ['read']
 
-    access_group = _create_google_bucket_access_group(
-        current_session, name, bucket_db_entry.id, google_project_id,
-        privileges)
+        access_group = _create_google_bucket_access_group(
+            current_session, name, bucket_db_entry.id, google_project_id,
+            privileges)
 
     pprint.pprint('bucket access group email: {}'.format(access_group.email))
     return access_group.email

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -664,7 +664,8 @@ def test_link_external_bucket(
         count()
     )
 
-    linked_gbag_email = link_external_bucket(db_session, "test_bucket")
+    from fence.settings import DB
+    linked_gbag_email = link_external_bucket(DB, "test_bucket")
 
     bucket_count_after = (
         db_session.

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -664,8 +664,7 @@ def test_link_external_bucket(
         count()
     )
 
-    from fence.settings import DB
-    linked_gbag_email = link_external_bucket(DB, "test_bucket")
+    linked_gbag_email = link_external_bucket(app.config['DB'], "test_bucket")
 
     bucket_count_after = (
         db_session.


### PR DESCRIPTION
* link_external_bucket now takes DB string as argument
* updated test to use DB string argument