### PR TITLE
fix(sa-registration): bugs with not getting users correctly and not g…

### DIFF
--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -682,14 +682,14 @@ def _get_google_access_groups(session, project_id):
     Returns:
         List(GoogleBucketAccessGroup)
     """
-    access_groups = []
+    access_groups = set()
     project = session.query(Project).filter_by(id=project_id).first()
 
     for bucket in project.buckets:
         groups = bucket.google_bucket_access_groups
-        access_groups.extend(groups)
+        access_groups.update(groups)
 
-    return set(access_groups)
+    return access_groups
 
 
 def extend_service_account_access(service_account_email, db=None):

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -689,7 +689,7 @@ def _get_google_access_groups(session, project_id):
         groups = bucket.google_bucket_access_groups
         access_groups.extend(groups)
 
-    return access_groups
+    return set(access_groups)
 
 
 def extend_service_account_access(service_account_email, db=None):

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -680,7 +680,7 @@ def _get_google_access_groups(session, project_id):
         project_id (int): project id in db
 
     Returns:
-        List(GoogleBucketAccessGroup)
+        set(GoogleBucketAccessGroup)
     """
     access_groups = set()
     project = session.query(Project).filter_by(id=project_id).first()

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -619,11 +619,19 @@ def get_user_from_google_member(member):
     Return:
         fence.models.User: User from our db for member on Google project
     """
-    return (
+    linked_google_account = (
         current_session.query(UserGoogleAccount)
         .filter(UserGoogleAccount.email == member.email_id.lower())
         .first()
     )
+    if linked_google_account:
+        return (
+            current_session.query(User)
+            .filter(User.id == linked_google_account.user_id)
+            .first()
+        )
+
+    return None
 
 
 def get_monitoring_service_account_email():


### PR DESCRIPTION
…etting access groups correctly

* use sets for google bucket access groups because a group can provide access to multiple buckets and we don't want to count it twice (causes errors/issues later on)
* fix function that was incorrectly returning UserGoogleAccount objects instead of generic fence User objects

Note: UserGoogleAccount objects are a User's linked Google account (after they go through oauth)
