### PR TITLE
fix(cookies): set cookies to expire based on their name *not* value

### DIFF
--- a/fence/utils.py
+++ b/fence/utils.py
@@ -152,7 +152,7 @@ def clear_cookies(response):
     """
     Set all cookies to empty and expired.
     """
-    for cookie_name in flask.request.cookies.values():
+    for cookie_name in flask.request.cookies.keys():
         response.set_cookie(cookie_name, "", expires=0)
 
 


### PR DESCRIPTION
http://flask.pocoo.org/docs/0.12/api/#flask.Request.cookies

cookies
A dict with the contents of all cookies transmitted with the request.

We were getting the *values* and setting new cookies with those as the *name*. Need to set cookies for the *names* stored in the dict's keys.