### PR TITLE
fix(travis): remove added boto cfg that travis incorrectly tries to load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install -e git+https://git@github.com/uc-cdis/wool.git#egg=wool; fi
 
 before_script:
+  - sudo rm -f /etc/boto.cfg
   - mkdir -p tests/resources/keys; cd tests/resources/keys; openssl genrsa -out test_private_key.pem 2048; openssl rsa -in test_private_key.pem -pubout -out test_public_key.pem
   - openssl genrsa -out test_private_key_2.pem 2048; openssl rsa -in test_private_key_2.pem -pubout -out test_public_key_2.pem
   - cd -


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/7940

Google's library is adding a boto.cfg that travis tries to load and bad things happen (issues with finding google modules, imports fail). We don't need this boto configuration in our CI. Added workaround per the issue above