### PR TITLE
fix(authlib): interface changed, .session is no longer available

### DIFF
--- a/fence/blueprints/login/fence_login.py
+++ b/fence/blueprints/login/fence_login.py
@@ -56,7 +56,7 @@ class FenceLogin(Resource):
                 " login page for the original application to continue."
             )
         # Get the token response and log in the user.
-        redirect_uri = flask.current_app.fence_client.session.redirect_uri
+        redirect_uri = flask.current_app.fence_client._get_session().redirect_uri
         tokens = flask.current_app.fence_client.fetch_access_token(
             redirect_uri, **flask.request.args.to_dict()
         )


### PR DESCRIPTION
authutils has new authlib for this fence_client. the interface changed, can no longer directly access `.session`, there's now a function to return the session.

Fence 500's on master for multi-tenant flow without this fix.

Seems like `authlib` decided to make retrieving the `session` an internal function, which seems strange. Perhaps there's a better way to do the access token fetching with the correct redirect. But for now, this is the quick fix