### PR TITLE
PXD-2080 fix(usersync): generate default project name

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -772,15 +772,20 @@ class UserSyncer(object):
                     project = self._get_or_create(sess, Project, **p)
                     self._projects[p["auth_id"]] = project
         for _, projects in user_project.iteritems():
-            for project_name in projects.keys():
-                project = (
-                    sess.query(Project).filter(Project.auth_id == project_name).first()
-                )
+            for auth_id in projects.keys():
+                project = sess.query(Project).filter(Project.auth_id == auth_id).first()
                 if not project:
-                    data = {"name": project_name, "auth_id": project_name}
+                    project_name = auth_id
+                    n = 0
+                    while (
+                        sess.query(Project).filter(Project.name == project_name).first()
+                    ):
+                        n += 1
+                        project_name = auth_id + "_{}".format(n)
+                    data = {"name": project_name, "auth_id": auth_id}
                     project = self._get_or_create(sess, Project, **data)
-                if project_name not in self._projects:
-                    self._projects[project_name] = project
+                if auth_id not in self._projects:
+                    self._projects[auth_id] = project
 
     @classmethod
     def _get_or_create(self, sess, model, **kwargs):


### PR DESCRIPTION
### Bug Fixes
Fence usersync gets confused if all the fields in the Project table don't match an update - SqlAlchemy should consider the project-name a primary key - something like that:
```
sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely) (IntegrityError) duplicate key value violates unique constraint "project_name_key"
```

Just provide more intuitive message so that user can know how to fix it




