### PR TITLE
chore(job): PXD-2307 add google user sa job

### DIFF
--- a/bin/google-user-sa-validation.sh
+++ b/bin/google-user-sa-validation.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+update-ca-certificates
+mkdir /google_job
+touch /google_job/status.json
+echo '<virtualhost *:80>
+    documentroot /google_job/
+
+    aliasmatch ^/(.*)$ /google_job/status.json
+
+    <directory "/google_job/status.json">
+      require all granted
+    </directory>
+</virtualhost>' >/etc/apache2/sites-available/fence.conf
+rm -rf /var/run/apache2/apache2.pid
+/usr/sbin/apache2ctl start
+while [ $? -eq 0 ]; do
+    fence-create google-manage-user-registrations
+    echo "{'last_run': '$(date)'}" >/google_job/status.json
+done
+


### PR DESCRIPTION
Add a script to keep running google user sa validation job. The script will exit when any run fail.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Add a script to keep running google user sa validation job

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

