### PR TITLE
chore(dep): bump cirrus 0.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
 -e git+https://github.com/uc-cdis/authutils.git@3.0.1#egg=authutils-3.0.1
--e git+https://github.com/uc-cdis/cirrus.git@0.2.1#egg=cirrus-0.2.1
+-e git+https://github.com/uc-cdis/cirrus.git@0.2.2#egg=cirrus-0.2.2


### PR DESCRIPTION


Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Fix cirrus error raise to be under Exception

### Improvements


### Dependency updates
- cirrus 0.2.1 -> 0.2.2

### Deployment changes

