### PR TITLE
feat(mock-google): handle MOCK_GOOGLE_AUTH for /link/google endpoints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -913,6 +913,7 @@ def encoded_creds_jwt(
         user_id=user_client["user_id"],
         client_id=oauth_client["client_id"],
         proxy_group_id=google_proxy_group["id"],
+        username=user_client["username"],
     )
 
 


### PR DESCRIPTION
Improve/handle config MOCK_GOOGLE_AUTH in the /link/google endpoints in order to further support integration testing without hitting Google's APIs.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- /link/google now works when MOCK_GOOGLE_AUTH is set

### Dependency updates


### Deployment changes

