### PR TITLE
Fix/blank record

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -87,7 +87,7 @@ class BlankIndex(object):
                 response from indexd (the contents of the record), containing ``guid``
                 and ``url``
         """
-        index_url = self.indexd.rstrip("/") + "/index/blank"
+        index_url = self.indexd.rstrip("/") + "/index/blank/"
         params = {"uploader": self.uploader, "file_name": self.file_name}
         auth = (config["INDEXD_USERNAME"], config["INDEXD_PASSWORD"])
         indexd_response = requests.post(index_url, json=params, auth=auth)

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -369,7 +369,7 @@ def test_blank_index_upload(app, client, auth_client, encoded_creds_jwt, user_cl
         data = json.dumps({"file_name": "asdf"})
         response = client.post("/data/upload", headers=headers, data=data)
         indexd_url = app.config.get("INDEXD") or app.config.get("BASE_URL") + "/index"
-        endpoint = indexd_url + "/index/blank"
+        endpoint = indexd_url + "/index/blank/"
         auth = ("gdcapi", "")
         mock_requests.post.assert_called_once_with(endpoint, auth=auth, json=mock.ANY)
         # assert_called_once_with cannot handle multiple items in json


### PR DESCRIPTION
`POST /index/blank` gets redirected to `GET /index/blank`. We should use `POST /index/blank/` instead in the `upload` endpoint

### New Features


### Breaking Changes


### Bug Fixes
- use `/index/blank/` instead of `/index/blank`

### Improvements


### Dependency updates


### Deployment changes

