### PR TITLE
fix(upload-role): move arborist setup to yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ In the following flow, `Fence (Client Instance)` is an OP relative to `OAuth Cli
 See the [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html) for more details.
 Additionally, see the [OAuth2 specification](https://tools.ietf.org/html/rfc6749).
 
+## Role-Based Access Control
+
+Currently fence works with another Gen3 service named
+[arborist](https://github.com/uc-cdis/arborist) to implement role-based access
+control for commons users. The YAML file of access control information (see
+[#create-user-access-file]()) contains a section `rbac` which are data sent to
+arborist in order to set up the access control model.
+
 ## Accessing Data
 
 Fence has multiple options that provide a mechanism to access data. The access
@@ -184,7 +192,7 @@ File. A `project` is identified by a unique authorization identifier AKA `auth_i
 
 A `project` can be associated with various storage backends that store
 object data for that given `project`. You can assign `read-storage` and `write-storage`
-privilieges to users who should have access to that stored object data. `read` and
+privileges to users who should have access to that stored object data. `read` and
 `write` allow access to the data stored in a graph database.
 
 Depending on the backend, Fence can be configured to provide users access to

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -19,60 +19,6 @@ from fence.rbac import check_arborist_auth
 blueprint = flask.Blueprint("data", __name__)
 
 
-@blueprint.record_once
-def record(setup_state):
-    """
-    FIXME / TODO / NOTE / DISCLAIMER
-
-    This stuff here is a huge hack due to the current limitations of the deployment
-    system with arborist. This blueprint's endpoint `/data/upload`, for uploading new
-    data files, requires an arborist instance to talk to, and that the arborist instance
-    be set up with some certain things (the stuff below). Currently there's not really a
-    better way to make sure that this stuff always exists in arborist. Once there is
-    (say arborist is loading in some YAML on initialization, which would contain the
-    below information), this function should be thrown out.
-    """
-    app = setup_state.app
-    if not hasattr(app, "arborist"):
-        app.logger.warn(
-            "fence app not configured with arborist client; some endpoints will be"
-            " permanently inaccessible on this fence instance"
-        )
-        return
-    app.arborist.delete_policy("data_upload")
-    app.arborist.delete_resource("/data_file")
-    app.arborist.delete_role("file_uploader")
-    role = app.arborist.create_role(
-        {
-            "id": "file_uploader",
-            "description": "can upload data files",
-            "permissions": [
-                {
-                    "id": "file_upload",
-                    "action": {"service": "fence", "method": "file_upload"},
-                }
-            ],
-        }
-    )
-    if not role:
-        raise InternalError("could not set up uploader role in arborist")
-    resource = app.arborist.create_resource(
-        "/", {"name": "data_file", "description": "data files, stored in s3"}
-    )
-    if not resource:
-        raise InternalError("could not set up data file resource in arborist")
-    policy = app.arborist.create_policy(
-        {
-            "id": "data_upload",
-            "description": "upload raw data files to S3",
-            "role_ids": ["file_uploader"],
-            "resource_paths": ["/data_file"],
-        }
-    )
-    if not policy:
-        raise InternalError("could not set up data upload policy in arborist")
-
-
 @blueprint.route("/<path:file_id>", methods=["DELETE"])
 @require_auth_header(aud={"data"})
 @login_required({"data"})

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 httplib2==0.10.3
 python-jose==2.0.2
-oauthlib==2.0.6
+oauthlib==2.1.0
 psycopg2==2.7.3.2
 pysftp==0.2.9
 pytest-flask==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "google_api_python_client>=1.6.4,<2.0.0",
         "httplib2>=0.10.3,<1.0.0",
         "python-jose>=2.0.0,<3.0.0",
-        "oauthlib>=2.0.6,<3.0.0",
+        "oauthlib>=2.1.0,<3.0.0",
         "psycopg2>=2.7.3.2,<3.0.0.0",
         "pysftp>=0.2.9,<1.0.0",
         "pytest-flask>=0.10.0,<1.0.0",

--- a/tests/dbgap_sync/data/yaml/user.yaml
+++ b/tests/dbgap_sync/data/yaml/user.yaml
@@ -2,16 +2,32 @@ cloud_providers: {}
 
 groups: {}
 
-# Define the resource tree which will be uploaded to arborist.
-resources:
-  - name: programs
-    subresources:
-    - name: test
+# Define information used for role-based access control.
+# The information in the `rbac` section is sent to arborist to populate its
+# access control model.
+rbac:
+  policies:
+    - id: 'data_upload'
+      description: 'upload raw data files to S3'
+      role_ids: ['file_uploader']
+      resource_paths: ['/data_file']
+  resources:
+    - name: 'programs'
       subresources:
-      - name: projects
+      - name: 'test'
         subresources:
-        - name: test
-    - name: test_program
+        - name: 'projects'
+          subresources:
+          - name: 'test'
+      - name: 'test_program'
+  roles:
+    - id: 'file_uploader'
+      description: 'can upload data files'
+      permissions:
+        - id: 'file_upload'
+          action:
+            service: 'fence'
+            method: 'file_upload'
 
 # auth_id field in projects exists for pre-arborist backwards-compatibility
 

--- a/ua.yaml
+++ b/ua.yaml
@@ -20,16 +20,42 @@ groups:
             - auth_id: Test_Group
               privilege: ['read', 'read-storage']
 
+resources
+
 users:
     test:
         admin: True
         projects:
           - auth_id: bar
-            path: /programs/test/projects/bar
+            resource: /programs/test/projects/bar
             privilege: ['read', 'update', 'create', 'delete']
           - auth_id: quux
-            path: /programs/test/projects/quux
+            resource: /programs/test/projects/quux
             privilege: ['read', 'update', 'create', 'delete']
-        policies:
-          - data_upload
+        policies: ['data_upload']
 
+rbac:
+    policies:
+        - id: 'data_upload'
+          description: 'upload raw data files to S3'
+          role_ids: ['file_uploader']
+          resource_paths: ['/data_file']
+    resources:
+        - name: 'data_file'
+          description: 'data files, stored in S3'
+        - name: 'programs'
+          subresources:
+              - name: 'test'
+                subresources:
+                    - name: 'projects'
+                      subresources:
+                          - name: 'bar'
+                          - name: quux
+    roles:
+        - id: 'file_uploader'
+          description: 'can upload data files'
+          permissions:
+              - id: 'file_upload'
+                action:
+                    service: 'fence'
+                    method: 'file_upload'

--- a/ua.yaml
+++ b/ua.yaml
@@ -34,6 +34,10 @@ users:
             privilege: ['read', 'update', 'create', 'delete']
         policies: ['data_upload']
 
+# This chunk is currently how fence gets some setup information to arborist, the
+# service which handles RBAC. All the content here (inside each subsection,
+# policies/resources/roles) is exactly how it would be structured in requests
+# to/from the arborist API.
 rbac:
     policies:
         - id: 'data_upload'


### PR DESCRIPTION
### Bug Fixes

The deployment with the previous fence will run into problems if arborist is rolled after fence, because that will discard the role for data upload which fence creates in it. The solution is to use the user.yaml file and have the fence sidecar to arborist handle the upload role setup.

### Deployment changes

Differences in user.yaml required for using with arborist: documentation in progress