### PR TITLE
fix(deps): update oauthlib to fix install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 httplib2==0.10.3
 python-jose==2.0.2
-oauthlib==2.0.6
+oauthlib==2.1.0
 psycopg2==2.7.3.2
 pysftp==0.2.9
 pytest-flask==0.10.0


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
- fix installation error because a sub-dependancy changed and required a newer version of oauthlib (which we had pinned to an incompatible version), update our pinned version

### Improvements


### Dependency updates
- oauthlib to 2.1.0

### Deployment changes

