### PR TITLE
fix(key-order): order of JWT keypairs

### DIFF
--- a/fence/jwt/keys.py
+++ b/fence/jwt/keys.py
@@ -49,22 +49,23 @@ def load_keypairs(keys_dir):
     # Get the absolute paths for the keypair directories.
     keypair_directories = [os.path.join(keys_dir, d) for d in os.listdir(keys_dir)]
 
-    def key(keypair_dir):
-        """
-        Try to read the directory name as a date. If that doesn't work, take
-        the time that it was last modified.
-
-        This function is used to sort the list of keypair directories by time,
-        converting the keypairs to `datetime` dates for sorting.
-        """
+    def is_datetime(name):
         try:
-            return dateutil.parser.parse(keypair_dir)
+            dateutil.parser.parse(name)
+            return True
         except ValueError:
-            return datetime.datetime.fromtimestamp(int(os.stat(keypair_dir).st_mtime))
+            return False
+
+    directories_timestamped = list(reversed(sorted(
+        d for d in keypair_directories if is_datetime(d)
+    )))
+    directories_other = list(sorted(
+        d for d in keypair_directories if not is_datetime(d)
+    ))
 
     # Sort the keypair directories to load from in the order described in
     # ``key``.
-    keypair_directories = list(sorted(keypair_directories, key=key))
+    keypair_directories = directories_timestamped + directories_other
 
     # Load the keypairs from the directories.
     keypairs = [

--- a/fence/jwt/keys.py
+++ b/fence/jwt/keys.py
@@ -56,12 +56,12 @@ def load_keypairs(keys_dir):
         except ValueError:
             return False
 
-    directories_timestamped = list(reversed(sorted(
-        d for d in keypair_directories if is_datetime(d)
-    )))
-    directories_other = list(sorted(
-        d for d in keypair_directories if not is_datetime(d)
-    ))
+    directories_timestamped = list(
+        reversed(sorted(d for d in keypair_directories if is_datetime(d)))
+    )
+    directories_other = list(
+        sorted(d for d in keypair_directories if not is_datetime(d))
+    )
 
     # Sort the keypair directories to load from in the order described in
     # ``key``.

--- a/fence/rbac/client.py
+++ b/fence/rbac/client.py
@@ -68,6 +68,7 @@ class ArboristClient(object):
         self.logger = logger or get_logger("ArboristClient")
         self._base_url = arborist_base_url.strip("/")
         self._auth_url = self._base_url + "/auth/"
+        self._health_url = self._base_url + "/health"
         self._policy_url = self._base_url + "/policy/"
         self._resource_url = self._base_url + "/resource"
         self._role_url = self._base_url + "/role/"
@@ -80,9 +81,19 @@ class ArboristClient(object):
             bool: whether arborist service is available
         """
         try:
-            response = requests.get(self._base_url + "/health")
-        except requests.RequestException:
+            response = requests.get(self._health_url)
+        except requests.RequestException as e:
+            self.logger.error(
+                "arborist not healthy; got requests exception: {}".format(str(e))
+            )
             return False
+        if response.status_code != 200:
+            self.logger.error(
+                "arborist not healthy; {} returned code {}".format(
+                    self._health_url,
+                    response.status_code,
+                )
+            )
         return response.status_code == 200
 
     @_arborist_retry()

--- a/fence/rbac/client.py
+++ b/fence/rbac/client.py
@@ -90,8 +90,7 @@ class ArboristClient(object):
         if response.status_code != 200:
             self.logger.error(
                 "arborist not healthy; {} returned code {}".format(
-                    self._health_url,
-                    response.status_code,
+                    self._health_url, response.status_code
                 )
             )
         return response.status_code == 200


### PR DESCRIPTION
Fixes bug where the app loads keypair directories in the wrong order.

Now will load directories named with timestamps first, sorting those newest to oldest, and then after that, any other directories, in ascending alphabetical order.