### PR TITLE
fix(google-sa): use email internally as it is globally unique in goog…

### DIFF
--- a/fence/blueprints/storage_creds/google.py
+++ b/fence/blueprints/storage_creds/google.py
@@ -75,9 +75,7 @@ class GoogleCredentialsList(Resource):
                 proxy_group_id=proxy_group_id,
             )
 
-            keys = g_cloud_manager.get_service_account_keys_info(
-                service_account.google_unique_id
-            )
+            keys = g_cloud_manager.get_service_account_keys_info(service_account.email)
 
             # replace Google's expiration date by the one in our DB
             reg = re.compile(".+\/keys\/(.+)")  # get key_id from xx/keys/key_id
@@ -108,7 +106,7 @@ class GoogleCredentialsList(Resource):
                     )
                     with GoogleCloudManager() as g_cloud:
                         g_cloud.delete_service_account_key(
-                            service_account.google_unique_id, key_id
+                            service_account.email, key_id
                         )
 
             result = {"access_keys": keys}
@@ -191,7 +189,7 @@ class GoogleCredentialsList(Resource):
 
             if service_account:
                 keys_for_account = g_cloud.get_service_account_keys_info(
-                    service_account.google_unique_id
+                    service_account.email
                 )
 
                 # Only delete the key if is owned by current client's SA
@@ -200,9 +198,7 @@ class GoogleCredentialsList(Resource):
                 ]
 
                 for key in all_client_keys:
-                    _delete_service_account_key(
-                        g_cloud, service_account.google_unique_id, key
-                    )
+                    _delete_service_account_key(g_cloud, service_account.email, key)
             else:
                 flask.abort(404, "Could not find service account for current user.")
 
@@ -260,7 +256,7 @@ class GoogleCredentials(Resource):
 
             if service_account:
                 keys_for_account = g_cloud.get_service_account_keys_info(
-                    service_account.google_unique_id
+                    service_account.email
                 )
 
                 # Only delete the key if is owned by current client's SA
@@ -270,7 +266,7 @@ class GoogleCredentials(Resource):
 
                 if access_key in all_client_keys:
                     _delete_service_account_key(
-                        g_cloud, service_account.google_unique_id, access_key
+                        g_cloud, service_account.email, access_key
                     )
                 else:
                     flask.abort(

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -265,15 +265,6 @@ def add_custom_service_account_key_expiration(
     current_session.commit()
 
 
-def get_or_create_service_account(client_id, user_id, username, proxy_group_id):
-    # underlying cloud api library effectively handles conflicts now without error
-    service_account = create_service_account(
-        client_id, user_id, username, proxy_group_id
-    )
-
-    return service_account
-
-
 def get_service_account(client_id, user_id):
     """
     Return the service account (from Fence db) for given client.
@@ -296,7 +287,7 @@ def get_service_account(client_id, user_id):
     return service_account
 
 
-def create_service_account(client_id, user_id, username, proxy_group_id):
+def get_or_create_service_account(client_id, user_id, username, proxy_group_id):
     """
     Create a Google Service account for the current client and user.
     This effectively handles conflicts in Google and will update our db

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -186,13 +186,13 @@ def create_google_access_key(client_id, user_id, username, proxy_group_id):
     )
 
     with GoogleCloudManager() as g_cloud:
-        key = g_cloud.get_access_key(service_account.google_unique_id)
+        key = g_cloud.get_access_key(service_account.email)
 
     flask.current_app.logger.info(
         "Created key with id {} for service account {} in user {}'s "
         "proxy group {} (user's id: {}).".format(
             key.get("private_key_id"),
-            service_account.google_unique_id,
+            service_account.email,
             username,
             proxy_group_id,
             user_id,

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -457,9 +457,7 @@ def remove_expired_google_service_account_keys(db):
         with GoogleCloudManager() as g_mgr:
             # handle service accounts with default max expiration
             for service_account, client in client_service_accounts:
-                g_mgr.handle_expired_service_account_keys(
-                    service_account.google_unique_id
-                )
+                g_mgr.handle_expired_service_account_keys(service_account.email)
 
             # handle service accounts with custom expiration
             for expired_user_key in expired_sa_keys_for_users:
@@ -472,7 +470,7 @@ def remove_expired_google_service_account_keys(db):
                 )
 
                 response = g_mgr.delete_service_account_key(
-                    account=sa.google_unique_id, key_name=expired_user_key.key_id
+                    account=sa.email, key_name=expired_user_key.key_id
                 )
                 response_error_code = response.get("error", {}).get("code")
 

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -909,13 +909,19 @@ def link_bucket_to_project(db, bucket_id, bucket_provider, project_auth_id):
             current_session.add(storage_access)
             current_session.commit()
 
-        project_linkage = ProjectToBucket(
-            project_id=project_db_entry.id,
-            bucket_id=bucket_db_entry.id,
-            privilege=["owner"],  # TODO What should this be???
+        project_linkage = (
+            current_session.query(ProjectToBucket)
+            .filter_by(project_id=project_db_entry.id, bucket_id=bucket_db_entry.id)
+            .first()
         )
-        current_session.add(project_linkage)
-        current_session.commit()
+        if not project_linkage:
+            project_linkage = ProjectToBucket(
+                project_id=project_db_entry.id,
+                bucket_id=bucket_db_entry.id,
+                privilege=["owner"],  # TODO What should this be???
+            )
+            current_session.add(project_linkage)
+            current_session.commit()
 
 
 def create_or_update_google_bucket(
@@ -1087,13 +1093,21 @@ def _create_or_update_google_bucket_and_db(
                 db_session.query(Project).filter_by(auth_id=project_auth_id).first()
             )
             if project_db_entry:
-                project_linkage = ProjectToBucket(
-                    project_id=project_db_entry.id,
-                    bucket_id=bucket_db_entry.id,
-                    privilege=["owner"],  # TODO What should this be???
+                project_linkage = (
+                    db_session.query(ProjectToBucket)
+                    .filter_by(
+                        project_id=project_db_entry.id, bucket_id=bucket_db_entry.id
+                    )
+                    .first()
                 )
-                db_session.add(project_linkage)
-                db_session.commit()
+                if not project_linkage:
+                    project_linkage = ProjectToBucket(
+                        project_id=project_db_entry.id,
+                        bucket_id=bucket_db_entry.id,
+                        privilege=["owner"],  # TODO What should this be???
+                    )
+                    db_session.add(project_linkage)
+                    db_session.commit()
                 print(
                     "Successfully linked project with auth_id {} "
                     "to the bucket.".format(project_auth_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
 -e git+https://github.com/uc-cdis/authutils.git@3.0.1#egg=authutils-3.0.1
--e git+https://github.com/uc-cdis/cirrus.git@0.2.9#egg=cirrus-0.2.9
+-e git+https://github.com/uc-cdis/cirrus.git@0.2.10#egg=cirrus-0.2.10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -841,7 +841,9 @@ def primary_google_service_account(app, db_session, user_client, google_proxy_gr
 
     mock = MagicMock()
     mock.return_value = service_account
-    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patcher = patch("fence.resources.google.utils.get_or_create_service_account", mock)
+    patcher.start()
+    request.addfinalizer(patcher.stop)
 
     return Dict(
         id=service_account_id, email=email, get_or_create_service_account_mock=mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -843,11 +843,12 @@ def primary_google_service_account(app, db_session, user_client, google_proxy_gr
     mock.return_value = service_account
     patcher = patch("fence.resources.google.utils.get_or_create_service_account", mock)
     patcher.start()
-    request.addfinalizer(patcher.stop)
 
-    return Dict(
+    yield Dict(
         id=service_account_id, email=email, get_or_create_service_account_mock=mock
     )
+
+    patcher.stop()
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -837,7 +837,14 @@ def primary_google_service_account(app, db_session, user_client, google_proxy_gr
     )
     db_session.add(service_account)
     db_session.commit()
-    return Dict(id=service_account_id, email=email)
+
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+
+    return Dict(
+        id=service_account_id, email=email, get_or_create_service_account_mock=mock
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/credentials/google/test_credentials.py
+++ b/tests/credentials/google/test_credentials.py
@@ -306,6 +306,13 @@ def test_google_bucket_access_existing_proxy_group(
     db_session.add(service_account)
     db_session.commit()
 
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
+
     encoded_credentials_jwt = encoded_creds_jwt["jwt"]
 
     path = "/credentials/google/"
@@ -344,6 +351,13 @@ def test_google_create_access_token_post(
     )
     db_session.add(service_account)
     db_session.commit()
+
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
 
     response = client.post(
         path, data=data, headers={"Authorization": "Bearer " + encoded_credentials_jwt}
@@ -401,6 +415,13 @@ def test_google_delete_owned_access_token(
     )
     db_session.add(service_account)
     db_session.commit()
+
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
 
     response = client.delete(
         path, data={}, headers={"Authorization": "Bearer " + encoded_credentials_jwt}
@@ -490,6 +511,13 @@ def test_google_delete_all_owned_access_tokens(
     db_session.add(service_account)
     db_session.commit()
 
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
+
     response = client.delete(
         path, data={}, headers={"Authorization": "Bearer " + encoded_credentials_jwt}
     )
@@ -567,6 +595,13 @@ def test_google_attempt_delete_unowned_access_token(
     db_session.add(service_account)
     db_session.commit()
 
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
+
     response = client.delete(
         path, data={}, headers={"Authorization": "Bearer " + encoded_credentials_jwt}
     )
@@ -623,6 +658,13 @@ def test_google_delete_invalid_access_token(
     )
     db_session.add(service_account)
     db_session.commit()
+
+    # make function return the service account we created and don't try to update db
+    # since we already did it in the test
+    mock = MagicMock()
+    mock.return_value = service_account
+    patch("fence.resources.google.utils.get_or_create_service_account", mock).start()
+    patch("fence.resources.google.utils._update_service_account_db_entry", mock).start()
 
     response = client.delete(
         path, data={}, headers={"Authorization": "Bearer " + encoded_credentials_jwt}

--- a/tests/credentials/google/test_credentials.py
+++ b/tests/credentials/google/test_credentials.py
@@ -330,6 +330,7 @@ def test_google_create_access_token_post(
     client_id = encoded_creds_jwt["client_id"]
 
     service_account_id = "123456789"
+    service_account_email = client_id + "-" + str(user_id) + "@test.com"
     path = "/credentials/google/"
     data = {}
 
@@ -338,7 +339,7 @@ def test_google_create_access_token_post(
         google_unique_id=service_account_id,
         client_id=client_id,
         user_id=user_id,
-        email=(client_id + "-" + str(user_id) + "@test.com"),
+        email=service_account_email,
         google_project_id="projectId-0",
     )
     db_session.add(service_account)
@@ -348,11 +349,13 @@ def test_google_create_access_token_post(
         path, data=data, headers={"Authorization": "Bearer " + encoded_credentials_jwt}
     )
 
-    # check that the service account id was included in a
+    # check that the service account id or email was included in a
     # call to cloud_manager
-    (
+    args, kwargs = (
         cloud_manager.return_value.__enter__.return_value.get_access_key
-    ).assert_called_with(service_account_id)
+    ).call_args
+    combined = [arg for arg in args] + [value for key, value in kwargs.iteritems()]
+    assert service_account_id in combined or service_account_email in combined
 
     assert response.status_code == 200
 
@@ -369,11 +372,12 @@ def test_google_delete_owned_access_token(
 
     service_account_key = "some_key_321"
     service_account_id = "123456789"
+    service_account_email = client_id + "-" + str(user_id) + "@test.com"
     path = "/credentials/google/" + service_account_key
 
     def get_account_keys(*args, **kwargs):
         # Return the keys only if the correct account is given
-        if args[0] == service_account_id:
+        if args[0] == service_account_id or args[0] == service_account_email:
             # Return two keys, first one is NOT the one we're
             # requesting to delete
             return [
@@ -392,7 +396,7 @@ def test_google_delete_owned_access_token(
         google_unique_id=service_account_id,
         client_id=client_id,
         user_id=user_id,
-        email=(client_id + "-" + str(user_id) + "@test.com"),
+        email=service_account_email,
         google_project_id="projectId-0",
     )
     db_session.add(service_account)
@@ -409,14 +413,18 @@ def test_google_delete_owned_access_token(
             str(mock_call)
             for mock_call in cloud_manager.mock_calls
             if service_account_id in str(mock_call)
+            or service_account_email in str(mock_call)
         ]
     )
     assert response.status_code == 204
 
     # check that we actually requested to delete the correct service key
-    (
+    args, kwargs = (
         cloud_manager.return_value.__enter__.return_value.delete_service_account_key
-    ).assert_called_with(service_account_id, service_account_key)
+    ).call_args
+    all_args = [arg for arg in args] + [value for key, value in kwargs.iteritems()]
+    assert service_account_id in all_args or service_account_email in all_args
+    assert service_account_key in all_args
 
 
 @pytest.mark.parametrize(
@@ -452,11 +460,12 @@ def test_google_delete_all_owned_access_tokens(
     service_account_key1 = "42"
     service_account_key2 = "one_MILLION_dollars"
     service_account_id = "123456789"
+    service_account_email = client_id + "-" + str(user_id) + "@test.com"
     path = "/credentials/google/" + query_arg
 
     def get_account_keys(*args, **kwargs):
         # Return the keys only if the correct account is given
-        if args[0] == service_account_id:
+        if args[0] == service_account_id or args[0] == service_account_email:
             # Return multiple keys
             return [
                 {"name": "project/service_accounts/keys/" + service_account_key0},
@@ -475,7 +484,7 @@ def test_google_delete_all_owned_access_tokens(
         google_unique_id=service_account_id,
         client_id=client_id,
         user_id=user_id,
-        email=(client_id + "-" + str(user_id) + "@test.com"),
+        email=service_account_email,
         google_project_id="projectId-0",
     )
     db_session.add(service_account)
@@ -493,14 +502,18 @@ def test_google_delete_all_owned_access_tokens(
                 str(mock_call)
                 for mock_call in cloud_manager.mock_calls
                 if service_account_id in str(mock_call)
+                or service_account_email in str(mock_call)
             ]
         )
         assert response.status_code == 204
 
-        expected_calls = [
+        valid_calls = [
             (service_account_id, service_account_key0),
             (service_account_id, service_account_key1),
             (service_account_id, service_account_key2),
+            (service_account_email, service_account_key0),
+            (service_account_email, service_account_key1),
+            (service_account_email, service_account_key2),
         ]
         actual_calls = []
         # check that we actually requested to delete the correct service key
@@ -512,7 +525,7 @@ def test_google_delete_all_owned_access_tokens(
             args, kwargs = call
             actual_calls.append(args)
 
-        assert sorted(expected_calls) == sorted(actual_calls)
+        assert set(actual_calls).issubset(valid_calls)
     else:
         # check that the service account id was NOT included in a call to
         # cloud_manager
@@ -521,6 +534,7 @@ def test_google_delete_all_owned_access_tokens(
                 str(mock_call)
                 for mock_call in cloud_manager.mock_calls
                 if service_account_id in str(mock_call)
+                or service_account_email in str(mock_call)
             ]
         )
         assert response.status_code != 204


### PR DESCRIPTION
…le and "google_unique_id" is only unique within a Google Project

Issues arise when using a service accounts "uniqueID" because it is ONLY unique within a single Google project. Also, if you recreate the same service account (e.g. same email address) you'll end up with a different uniqueID.

Modify code to use "email" internally to avoid issues, since the email *is* globally unique. Also use "email" in calls to Google API so that if it gets deleted from Google and recreated, the api calls will still work (previously was using uniqueID, which will have changed with a delete/recreate).

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Better handling of service accounts by using their globally unique email internally
- Don't create duplicate entries in edge table ProjectToBucket

### Dependency updates


### Deployment changes

