### PR TITLE
fix(white-list)

### DIFF
--- a/fence/resources/google/validity.py
+++ b/fence/resources/google/validity.py
@@ -451,7 +451,7 @@ class GoogleProjectValidity(ValidityInfo):
         )
 
         white_listed_service_accounts = (
-            config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS") if config else None
+            config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS") if config else []
         )
         app_creds_file = (
             config.get("GOOGLE_APPLICATION_CREDENTIALS") if config else None


### PR DESCRIPTION
Fixes this error:
`[  DEBUG] Removing whitelisted SAs None from the SAs on the project xxx.`
`ERROR in error_handler: Catch exception`
`   File "/fence/fence/resources/google/access_utils.py", line 1001, in remove_white_listed_service_account_ids`
`     for email in white_listed_sa_emails:`
 `TypeError: 'NoneType' object is not iterable`

### Bug Fixes
- if the config var `WHITE_LISTED_SERVICE_ACCOUNT_EMAILS` is not set, default to an empty list
