### PR TITLE
chore(dep): bump cirrus for error handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ pyyaml
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
 -e git+https://github.com/uc-cdis/authutils.git@3.0.1#egg=authutils-3.0.1
--e git+https://github.com/uc-cdis/cirrus.git@0.2.8#egg=cirrus-0.2.8
+-e git+https://github.com/uc-cdis/cirrus.git@0.2.9#egg=cirrus-0.2.9


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- cirrus -> 0.2.9 for google 403 rate limit error handling

### Deployment changes

