### PR TITLE
fix(config): parse from config file if not passed in

### DIFF
--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -976,6 +976,12 @@ def remove_white_listed_service_account_ids(
     if white_listed_sa_emails is None:
         white_listed_sa_emails = config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS", [])
 
+    logger.debug(
+        "Removing whitelisted SAs {} from the SAs on the project.".format(
+            white_listed_sa_emails
+        )
+    )
+
     monitoring_service_account = get_monitoring_service_account_email(app_creds_file)
 
     if monitoring_service_account in sa_ids:
@@ -1003,7 +1009,10 @@ def is_org_whitelisted(parent_org, white_listed_google_parent_orgs=None):
         "WHITE_LISTED_GOOGLE_PARENT_ORGS", {}
     )
 
-    return parent_org in white_listed_google_parent_orgs
+    # make sure we're comparing same types
+    return str(parent_org) in [
+        str(parent_org) for parent_org in white_listed_google_parent_orgs
+    ]
 
 
 def force_delete_service_account(service_account_email, db=None):

--- a/fence/resources/google/validity.py
+++ b/fence/resources/google/validity.py
@@ -3,6 +3,7 @@ Objects with validity checking for Google service account registration.
 """
 from collections import Mapping
 
+from fence.config import config as fence_config
 from fence.errors import NotFound
 
 from fence.resources.google.utils import (
@@ -304,7 +305,9 @@ class GoogleProjectValidity(ValidityInfo):
         # if there is an org, let's remove whitelisted orgs and then check validity
         # again
         white_listed_google_parent_orgs = (
-            config.get("WHITE_LISTED_GOOGLE_PARENT_ORGS") if config else None
+            config.get("WHITE_LISTED_GOOGLE_PARENT_ORGS")
+            if config
+            else fence_config.get("WHITE_LISTED_GOOGLE_PARENT_ORGS")
         )
 
         if parent_org:
@@ -384,7 +387,9 @@ class GoogleProjectValidity(ValidityInfo):
             )
 
             google_sa_domains = (
-                config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS") if config else None
+                config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS")
+                if config
+                else fence_config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS")
             )
             logger.debug(
                 "Determining if the service account {} is google-managed.".format(
@@ -451,17 +456,17 @@ class GoogleProjectValidity(ValidityInfo):
         )
 
         white_listed_service_accounts = (
-            config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS") if config else []
+            config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS")
+            if config
+            else fence_config.get("WHITE_LISTED_SERVICE_ACCOUNT_EMAILS")
         )
         app_creds_file = (
-            config.get("GOOGLE_APPLICATION_CREDENTIALS") if config else None
+            config.get("GOOGLE_APPLICATION_CREDENTIALS")
+            if config
+            else fence_config.get("GOOGLE_APPLICATION_CREDENTIALS")
         )
 
-        logger.debug(
-            "Removing whitelisted SAs {} from the SAs on the project {}.".format(
-                white_listed_service_accounts, service_accounts
-            )
-        )
+        logger.debug("SAs on the project {}.".format(service_accounts))
 
         remove_white_listed_service_account_ids(
             service_accounts,
@@ -608,7 +613,9 @@ class GoogleProjectValidity(ValidityInfo):
         )
 
         google_sa_domains = (
-            config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS") if config else None
+            config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS")
+            if config
+            else fence_config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS")
         )
 
         logger.debug(
@@ -726,7 +733,9 @@ class GoogleServiceAccountValidity(ValidityInfo):
 
         # check ownership
         google_managed_sa_domains = (
-            config["GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS"] if config else None
+            config["GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS"]
+            if config
+            else fence_config.get("GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS")
         )
 
         logger.debug(


### PR DESCRIPTION
https://github.com/uc-cdis/fence/pull/571 defaulted config to empty list but https://github.com/uc-cdis/fence/blob/9f35d0af0c50d840a93c704c9fc05d34d3535e5c/fence/resources/google/access_utils.py#L976 expects it to be None to default to the configuration file. 

overall confusing logic because previously a config was passed through (this is an ugly solution to the issue where fence-create can't rely on flask app config) but new config doesn't rely on that. Should cleanup code to not do this pass-through logic.

### New Features


### Breaking Changes


### Bug Fixes
- load from config file for google sa validation in every instance of fence-create call
- ensure we're comparings strings to strings for Google parent orgs from config (could be interpretted as ints in the YAML if not correctly quoted)

### Improvements


### Dependency updates


### Deployment changes

