### PR TITLE
feat(email-flag)

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -407,6 +407,7 @@ WHITE_LISTED_SERVICE_ACCOUNT_EMAILS: []
 # when service accounts or google projects are determined invalid, an email is sent
 # to the project owners. These settings are for that email
 REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION:
+  enable: false
   # this domain MUST exist in GUN_MAIL config
   domain: 'example.com'
   from: 'do-not-reply@example.com'

--- a/fence/local_settings.example.py
+++ b/fence/local_settings.example.py
@@ -186,6 +186,7 @@ GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS = {
 }
 
 REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION = {
+    "enable": False,
     "domain": "smtp domain",
     "subject": "User service account removal notification",
     "from": "do-not-reply@planx-pla.net",

--- a/fence/scripting/google_monitor.py
+++ b/fence/scripting/google_monitor.py
@@ -147,6 +147,7 @@ def validation_check(db):
             )
             email_required = True
 
+        email_required &= config["REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION"]["enable"]
         if email_required:
             logger.debug(
                 "Sending email with service account removal reasons: {} and project "

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -368,6 +368,7 @@ WHITE_LISTED_SERVICE_ACCOUNT_EMAILS:
 # when service accounts or google projects are determined invalid, an email is sent
 # to the project owners. These settings are for that email
 REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION:
+  enable: true
   # this domain MUST exist in GUN_MAIL config
   domain: 'example.com'
   from: 'do-not-reply@example.com'


### PR DESCRIPTION
Add a flag to the `REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION` config to disable it

### Improvements
- the email informing users about a service account removal can be enabled/disabled

### Deployment changes
- the var `REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION.enable` must be added to the fence config
