### PR TITLE
Get gen3cirrus from PyPI, bump storage-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-gen3cirrus==0.3.0
+gen3cirrus==0.3.1
 httplib2==0.10.3
 python-jose==2.0.2
 oauthlib==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
+gen3cirrus==0.3.0
 httplib2==0.10.3
 python-jose==2.0.2
 oauthlib==3.0.0
@@ -32,9 +33,8 @@ pyyaml
 -e git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
 -e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
--e git+https://github.com/uc-cdis/storage-client.git@0.2.1#egg=storageclient-0.2.1
+-e git+https://github.com/uc-cdis/storage-client.git@0.2.2#egg=storageclient-0.2.2
 -e git+https://github.com/uc-cdis/userdatamodel.git@1.1.7#egg=userdatamodel
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
 -e git+https://github.com/uc-cdis/authutils.git@3.0.1#egg=authutils-3.0.1
--e git+https://github.com/uc-cdis/cirrus.git@0.2.10#egg=cirrus-0.2.10

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "botocore>=1.7,<1.9.0",
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
-        "cirrus",
+        "gen3cirrus>=0.3.0,<1.0.0",
         "cryptography>=2.1.2",
         "enum34>=1.1.6",
         "flask-restful>=0.3.6,<1.0.0",


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- Get gen3cirrus from PyPI, bump to 0.3.1
- Bump storage-client to 0.2.2

### Deployment changes

