### PR TITLE
[PXP-2318] chore(app-debug): Set log level based on config['DEBUG']

### DIFF
--- a/dockerrun.bash
+++ b/dockerrun.bash
@@ -6,12 +6,6 @@
 #
 update-ca-certificates
 #
-# Enable debug flag based on GEN3_DEBUG environment
-#
-if [[ -f ./wsgi.py && "$GEN3_DEBUG" == "True" ]]; then
-  echo -e "\napplication.debug=True\n" >> ./wsgi.py
-fi
-#
 # Kubernetes may mount jwt-keys as a tar ball
 #
 if [ -f /fence/jwt-keys.tar ]; then

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -37,6 +37,8 @@ import fence.blueprints.google
 
 from cdislogging import get_logger
 
+# import pdb
+# pdb.set_trace()
 logger = get_logger(__name__)
 
 app = flask.Flask(__name__)
@@ -153,6 +155,9 @@ def app_config(
     logger.error("This is an ERROR")
     logger.info("Done logging info, warn, debug, error before loading config")
     print("Before loading config....... app.debug is... " + str(app.debug))
+    print("Before loading config....... logger.level is..." + str(logger.level))
+    print("Effective level: " + str(logger.getEffectiveLevel()))
+    print("Manager disable level: " + str(logger.manager.disable))
 
     logger.info("Loading settings...")
     # not using app.config.from_object because we don't want all the extra flask cfg
@@ -162,6 +167,9 @@ def app_config(
 
     # dump the settings into the config singleton before loading a configuration file
     config.update(dict(settings_cfg))
+
+    # import pdb
+    # pdb.set_trace()
 
     # load the configuration file, this overwrites anything from settings/local_settings
     config.load(config_path, file_name)
@@ -182,9 +190,12 @@ def app_config(
     print("After loading config")
     print("****************APP.DEBUG IS......... " + str(app.debug))
     print("****************AND CONFIG DEBUG IS...." + str(config["DEBUG"]))
-    #app.debug = config["DEBUG"] #Actually, I think config.load handles this
-    #print("****************AND NOW APP.DEBUG IS............ " + str(app.debug))
+    # app.debug = config["DEBUG"] #Actually, I think config.load handles this
+    # print("****************AND NOW APP.DEBUG IS............ " + str(app.debug))
     print("The set is now done")
+    print("After loading config....... logger.level is..." + str(logger.level))
+    print("Effective level: " + str(logger.getEffectiveLevel()))
+    print("Manager disable level: " + str(logger.manager.disable))
 
     print("About to try to print a debug, info, and warn via logger after the set")
     logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -37,8 +37,6 @@ import fence.blueprints.google
 
 from cdislogging import get_logger
 
-# import pdb
-# pdb.set_trace()
 logger = get_logger(__name__)
 
 app = flask.Flask(__name__)
@@ -173,31 +171,13 @@ def app_config(
         config["STORAGE_CREDENTIALS"], logger=app.logger
     )
 
-    # app.debug = config["DEBUG"] #Actually, I think config.load handles this
-
-    print("Test logging...")
-    print("Confirm that app.config['LOGGER_HANDLER_POLICY']=='always': " + str(app.config['LOGGER_HANDLER_POLICY']=='always'))
-    print("Setting app.debug to TRUE")
+    # app.debug should always be True bc we want at least INFO lvl logging in dev+prod
+    # and flask 0.12 will set lvl to ERROR if app.debug is False
     app.debug = True
+    logger.level = 10 if config["DEBUG"] == True else 20
 
-    print("Setting logger.level to DEBUG...")
-    logger.level = 10
-    print("Expect to be printed below: DEBUG, INFO, WARN, ERROR.")
-    logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")
-    logger.info("THIS IS AN INFO PRINT AFTER THE SET")
-    logger.warn("THIS IS A WARN PRINT AFTER THE SET")
-    logger.error("THIS IS AN ERROR PRINT AFTER THE SET")
-    print("Expect to be printed above: DEBUG, INFO, WARN, ERROR.")
-
-    print("Setting logger.level to INFO...")
-    logger.level = 20
-    print("Expect to be printed below: INFO, WARN, ERROR.")
-    logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")
-    logger.info("THIS IS AN INFO PRINT AFTER THE SET")
-    logger.warn("THIS IS A WARN PRINT AFTER THE SET")
-    logger.error("THIS IS AN ERROR PRINT AFTER THE SET")
-    print("Expect to be printed above: INFO, WARN, ERROR.")
-
+    if not app.config["LOGGER_HANDLER_POLICY"]=="always" and not app.config["LOGGER_HANDLER_POLICY"]=="debug":
+        logger.warn("LOGGER_HANDLER_POLICY neither 'always' nor 'debug'; logs will not print'")
 
     _setup_oidc_clients(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -180,7 +180,7 @@ def app_config(
         not app.config["LOGGER_HANDLER_POLICY"] == "always"
         and not app.config["LOGGER_HANDLER_POLICY"] == "debug"
     ):
-        logger.warn(
+        print(
             "LOGGER_HANDLER_POLICY neither 'always' nor 'debug'; logs will not print'"
         )
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -148,17 +148,6 @@ def app_config(
     if root_dir is None:
         root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-    print("Before loading config....... logging info, warn, debug, error")
-    logger.info("This is an INFO")
-    logger.warn("This is a WARN")
-    logger.debug("This is a DEBUG")
-    logger.error("This is an ERROR")
-    logger.info("Done logging info, warn, debug, error before loading config")
-    print("Before loading config....... app.debug is... " + str(app.debug))
-    print("Before loading config....... logger.level is..." + str(logger.level))
-    print("Effective level: " + str(logger.getEffectiveLevel()))
-    print("Manager disable level: " + str(logger.manager.disable))
-
     logger.info("Loading settings...")
     # not using app.config.from_object because we don't want all the extra flask cfg
     # vars inside our singleton when we pass these through in the next step
@@ -167,9 +156,6 @@ def app_config(
 
     # dump the settings into the config singleton before loading a configuration file
     config.update(dict(settings_cfg))
-
-    # import pdb
-    # pdb.set_trace()
 
     # load the configuration file, this overwrites anything from settings/local_settings
     config.load(config_path, file_name)
@@ -187,22 +173,31 @@ def app_config(
         config["STORAGE_CREDENTIALS"], logger=app.logger
     )
 
-    print("After loading config")
-    print("****************APP.DEBUG IS......... " + str(app.debug))
-    print("****************AND CONFIG DEBUG IS...." + str(config["DEBUG"]))
     # app.debug = config["DEBUG"] #Actually, I think config.load handles this
-    # print("****************AND NOW APP.DEBUG IS............ " + str(app.debug))
-    print("The set is now done")
-    print("After loading config....... logger.level is..." + str(logger.level))
-    print("Effective level: " + str(logger.getEffectiveLevel()))
-    print("Manager disable level: " + str(logger.manager.disable))
 
-    print("About to try to print a debug, info, and warn via logger after the set")
+    print("Test logging...")
+    print("Confirm that app.config['LOGGER_HANDLER_POLICY']=='always': " + str(app.config['LOGGER_HANDLER_POLICY']=='always'))
+    print("Setting app.debug to TRUE")
+    app.debug = True
+
+    print("Setting logger.level to DEBUG...")
+    logger.level = 10
+    print("Expect to be printed below: DEBUG, INFO, WARN, ERROR.")
     logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")
     logger.info("THIS IS AN INFO PRINT AFTER THE SET")
     logger.warn("THIS IS A WARN PRINT AFTER THE SET")
     logger.error("THIS IS AN ERROR PRINT AFTER THE SET")
-    print("Just tried to print a debug, info,  warn, and error via logger after the set")
+    print("Expect to be printed above: DEBUG, INFO, WARN, ERROR.")
+
+    print("Setting logger.level to INFO...")
+    logger.level = 20
+    print("Expect to be printed below: INFO, WARN, ERROR.")
+    logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")
+    logger.info("THIS IS AN INFO PRINT AFTER THE SET")
+    logger.warn("THIS IS A WARN PRINT AFTER THE SET")
+    logger.error("THIS IS AN ERROR PRINT AFTER THE SET")
+    print("Expect to be printed above: INFO, WARN, ERROR.")
+
 
     _setup_oidc_clients(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -36,7 +36,7 @@ import fence.blueprints.well_known
 import fence.blueprints.link
 import fence.blueprints.google
 
-from cdislogging import get_logger, get_stream_handler
+from cdislogging import get_logger
 
 logger = get_logger(__name__)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -176,8 +176,13 @@ def app_config(
     app.debug = True
     logger.level = 10 if config["DEBUG"] == True else 20
 
-    if not app.config["LOGGER_HANDLER_POLICY"]=="always" and not app.config["LOGGER_HANDLER_POLICY"]=="debug":
-        logger.warn("LOGGER_HANDLER_POLICY neither 'always' nor 'debug'; logs will not print'")
+    if (
+        not app.config["LOGGER_HANDLER_POLICY"] == "always"
+        and not app.config["LOGGER_HANDLER_POLICY"] == "debug"
+    ):
+        logger.warn(
+            "LOGGER_HANDLER_POLICY neither 'always' nor 'debug'; logs will not print'"
+        )
 
     _setup_oidc_clients(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -182,7 +182,7 @@ def app_config(
 
     app.debug = config["DEBUG"]
     # Following will update logger level, propagate, and handlers
-    get_logger(__name__, log_level='debug' if config["DEBUG"] == True else 'info')
+    get_logger(__name__, log_level="debug" if config["DEBUG"] == True else "info")
 
     _setup_oidc_clients(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -174,7 +174,7 @@ def app_config(
 
     # app.debug should always be True bc we want at least INFO lvl logging in dev+prod
     # and flask 0.12 will set lvl to ERROR if app.debug is False
-    app.debug = True
+    app.debug = config["DEBUG"]
     logger.level = DEBUG if config["DEBUG"] == True else INFO
 
     _setup_oidc_clients(app)

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -177,14 +177,6 @@ def app_config(
     app.debug = True
     logger.level = DEBUG if config["DEBUG"] == True else INFO
 
-    if (
-        not app.config["LOGGER_HANDLER_POLICY"] == "always"
-        and not app.config["LOGGER_HANDLER_POLICY"] == "debug"
-    ):
-        print(
-            "LOGGER_HANDLER_POLICY neither 'always' nor 'debug'; logs will not print'"
-        )
-
     _setup_oidc_clients(app)
 
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from logging import INFO, DEBUG
 import os
 
 from authutils.oauth2.client import OAuthClient
@@ -35,7 +36,7 @@ import fence.blueprints.well_known
 import fence.blueprints.link
 import fence.blueprints.google
 
-from cdislogging import get_logger
+from cdislogging import get_logger, get_stream_handler
 
 logger = get_logger(__name__)
 
@@ -174,7 +175,7 @@ def app_config(
     # app.debug should always be True bc we want at least INFO lvl logging in dev+prod
     # and flask 0.12 will set lvl to ERROR if app.debug is False
     app.debug = True
-    logger.level = 10 if config["DEBUG"] == True else 20
+    logger.level = DEBUG if config["DEBUG"] == True else INFO
 
     if (
         not app.config["LOGGER_HANDLER_POLICY"] == "always"

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -146,6 +146,14 @@ def app_config(
     if root_dir is None:
         root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
+    print("Before loading config....... logging info, warn, debug, error")
+    logger.info("This is an INFO")
+    logger.warn("This is a WARN")
+    logger.debug("This is a DEBUG")
+    logger.error("This is an ERROR")
+    logger.info("Done logging info, warn, debug, error before loading config")
+    print("Before loading config....... app.debug is... " + str(app.debug))
+
     logger.info("Loading settings...")
     # not using app.config.from_object because we don't want all the extra flask cfg
     # vars inside our singleton when we pass these through in the next step
@@ -171,7 +179,19 @@ def app_config(
         config["STORAGE_CREDENTIALS"], logger=app.logger
     )
 
-    app.debug = config["DEBUG"]
+    print("After loading config")
+    print("****************APP.DEBUG IS......... " + str(app.debug))
+    print("****************AND CONFIG DEBUG IS...." + str(config["DEBUG"]))
+    #app.debug = config["DEBUG"] #Actually, I think config.load handles this
+    #print("****************AND NOW APP.DEBUG IS............ " + str(app.debug))
+    print("The set is now done")
+
+    print("About to try to print a debug, info, and warn via logger after the set")
+    logger.debug("THIS IS A DEBUG PRINT AFTER THE SET")
+    logger.info("THIS IS AN INFO PRINT AFTER THE SET")
+    logger.warn("THIS IS A WARN PRINT AFTER THE SET")
+    logger.error("THIS IS AN ERROR PRINT AFTER THE SET")
+    print("Just tried to print a debug, info,  warn, and error via logger after the set")
 
     _setup_oidc_clients(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -171,6 +171,8 @@ def app_config(
         config["STORAGE_CREDENTIALS"], logger=app.logger
     )
 
+    app.debug = config["DEBUG"]
+
     _setup_oidc_clients(app)
 
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from logging import INFO, DEBUG
 import os
 
 from authutils.oauth2.client import OAuthClient
@@ -38,7 +37,9 @@ import fence.blueprints.google
 
 from cdislogging import get_logger
 
-logger = get_logger(__name__)
+# Can't read config yet. Just set to debug for now, else no handlers.
+# Later, in app_config(), will actually set level based on config
+logger = get_logger(__name__, log_level='debug')
 
 app = flask.Flask(__name__)
 CORS(app=app, headers=["content-type", "accept"], expose_headers="*")
@@ -180,7 +181,8 @@ def app_config(
     app.storage_manager = StorageManager(config["STORAGE_CREDENTIALS"], logger=logger)
 
     app.debug = config["DEBUG"]
-    logger.level = DEBUG if config["DEBUG"] == True else INFO
+    # Following will update logger level, propagate, and handlers
+    get_logger(__name__, log_level='debug' if config["DEBUG"] == True else 'info')
 
     _setup_oidc_clients(app)
 

--- a/fence/auth.py
+++ b/fence/auth.py
@@ -1,3 +1,5 @@
+import flask
+from flask_sqlalchemy_session import current_session
 from functools import wraps
 import urllib
 
@@ -8,8 +10,7 @@ from authutils.token.validate import (
     set_current_token,
     validate_request,
 )
-import flask
-from flask_sqlalchemy_session import current_session
+from cdislogging import get_logger
 
 from fence.errors import Unauthorized, InternalError
 from fence.jwt.validate import validate_jwt
@@ -17,6 +18,8 @@ from fence.models import User, IdentityProvider, query_for_user
 from fence.user import get_current_user
 from fence.utils import clear_cookies
 from fence.config import config
+
+logger = get_logger(__name__)
 
 
 def build_redirect_url(hostname, path):
@@ -71,7 +74,7 @@ def logout(next_url):
     Args:
         next_url (str): Final redirect desired after logout
     """
-    flask.current_app.logger.debug("IN AUTH LOGOUT, next_url = {0}".format(next_url))
+    logger.debug("IN AUTH LOGOUT, next_url = {0}".format(next_url))
 
     # propogate logout to IDP
     provider_logout = None

--- a/fence/blueprints/admin.py
+++ b/fence/blueprints/admin.py
@@ -10,8 +10,13 @@ import flask
 from flask import request, jsonify, Blueprint, current_app
 from flask_sqlalchemy_session import current_session
 
+from cdislogging import get_logger
+
 from fence.auth import admin_login_required
 from fence.resources import admin
+
+
+logger = get_logger(__name__)
 
 
 blueprint = Blueprint("admin", __name__)
@@ -28,7 +33,7 @@ def debug_log(function):
             for arg, value in zip(argument_names, args) + kwargs.items()
         )
         msg = function.func_name + "\n\t" + "\n\t".join(argument_values)
-        flask.current_app.logger.debug(msg)
+        logger.debug(msg)
         return function(*args, **kwargs)
 
     return write_log

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -1,5 +1,7 @@
 import flask
 
+from cdislogging import get_logger
+
 from fence.auth import login_required, require_auth_header, current_token
 from fence.blueprints.data.indexd import (
     BlankIndex,
@@ -15,6 +17,9 @@ from fence.errors import (
 )
 from fence.utils import is_valid_expiration
 from fence.rbac import check_arborist_auth
+
+
+logger = get_logger(__name__)
 
 
 blueprint = flask.Blueprint("data", __name__)
@@ -44,7 +49,7 @@ def delete_data_file(file_id):
         raise Forbidden("deleting submitted records is not supported")
     if current_token["context"]["user"]["name"] != uploader:
         raise Forbidden("user is not uploader for file {}".format(file_id))
-    flask.current_app.logger.info("deleting record and files for {}".format(file_id))
+    logger.info("deleting record and files for {}".format(file_id))
     record.delete_files(delete_all=True)
     return record.delete()
 

--- a/fence/blueprints/google.py
+++ b/fence/blueprints/google.py
@@ -37,9 +37,6 @@ from fence.resources.google.utils import (
 from fence.models import UserServiceAccount
 from fence.utils import get_valid_expiration_from_request
 from flask_sqlalchemy_session import current_session
-from cdislogging import get_logger
-
-logger = get_logger(__name__)
 
 
 class ValidationErrors(str, Enum):

--- a/fence/blueprints/link.py
+++ b/fence/blueprints/link.py
@@ -451,7 +451,7 @@ def _force_update_user_google_account(
                 user_google_account = add_new_user_google_account(
                     user_id, google_email, current_session
                 )
-                flask.current_app.logger.info(
+                logger.info(
                     "Linking Google account {} to user with id {}.".format(
                         google_email, user_id
                     )
@@ -477,7 +477,7 @@ def _force_update_user_google_account(
         user_google_account, proxy_group_id, google_email, expiration, current_session
     )
 
-    flask.current_app.logger.info(
+    logger.info(
         "Adding user's (id: {}) Google account to their proxy group (id: {})."
         " Expiration: {}".format(
             user_google_account.user_id, proxy_group_id, expiration

--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -8,6 +8,8 @@ the endpoints for each provider.
 
 import flask
 
+from cdislogging import get_logger
+
 from fence.blueprints.login.fence_login import FenceRedirect, FenceLogin
 from fence.blueprints.login.google import GoogleRedirect, GoogleLogin
 from fence.blueprints.login.shib import ShibbolethLoginStart, ShibbolethLoginFinish
@@ -16,6 +18,9 @@ from fence.blueprints.login.orcid import ORCIDRedirect, ORCIDLogin
 from fence.errors import InternalError
 from fence.restful import RestfulApi
 from fence.config import config
+
+
+logger = get_logger(__name__)
 
 
 def make_login_blueprint(app):
@@ -34,7 +39,7 @@ def make_login_blueprint(app):
         default_idp = config["ENABLED_IDENTITY_PROVIDERS"]["default"]
         idps = config["ENABLED_IDENTITY_PROVIDERS"]["providers"]
     except KeyError as e:
-        app.logger.warn(
+        logger.warn(
             "app not configured correctly with ENABLED_IDENTITY_PROVIDERS:"
             " missing {}".format(str(e))
         )

--- a/fence/error_handler.py
+++ b/fence/error_handler.py
@@ -1,13 +1,17 @@
 import uuid
 from httplib import responses as http_responses
-
 import flask
 from flask import render_template
-from authlib.specs.rfc6749.errors import OAuth2Error
 from werkzeug.exceptions import HTTPException
+
+from authlib.specs.rfc6749.errors import OAuth2Error
+from cdislogging import get_logger
 
 from fence.errors import APIError
 from fence.config import config
+
+
+logger = get_logger(__name__)
 
 
 def get_error_response(error):
@@ -18,7 +22,7 @@ def get_error_response(error):
     message = details.get("message")
 
     error_id = _get_error_identifier()
-    flask.current_app.logger.error(
+    logger.error(
         "{} HTTP error occured. ID: {}\nDetails: {}".format(
             status_code, error_id, str(details)
         )
@@ -59,7 +63,7 @@ def get_error_details_and_status(error):
             error.get_response().status_code,
         )
     else:
-        flask.current_app.logger.exception("Catch exception")
+        logger.exception("Catch exception")
         error_code = 500
         if hasattr(error, "code"):
             error_code = error.code

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -4,12 +4,16 @@ import uuid
 
 from authlib.common.encoding import to_unicode
 from authlib.specs.oidc import CodeIDToken as AuthlibCodeIDToken
+from cdislogging import get_logger
 import flask
 import jwt
 
 from fence.jwt import keys
 from fence.jwt.errors import JWTSizeError
 from fence.config import config
+
+logger = get_logger(__name__)
+
 
 SCOPE_DESCRIPTION = {
     "openid": "default scope",
@@ -198,7 +202,7 @@ def generate_signed_session_token(kid, private_key, expires_in, context=None):
         "jti": str(uuid.uuid4()),
         "context": context,
     }
-    flask.current_app.logger.debug(
+    logger.debug(
         "issuing JWT session token\n" + json.dumps(claims, indent=4)
     )
     token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
@@ -300,10 +304,10 @@ def generate_signed_refresh_token(
     }
 
     if flask.current_app:
-        flask.current_app.logger.info(
+        logger.info(
             "issuing JWT refresh token with id [{}] to [{}]".format(jti, sub)
         )
-        flask.current_app.logger.debug(
+        logger.debug(
             "issuing JWT refresh token\n" + json.dumps(claims, indent=4)
         )
 
@@ -342,14 +346,14 @@ def generate_api_key(kid, private_key, user_id, expires_in, scopes, client_id):
         "jti": jti,
         "azp": client_id or "",
     }
-    flask.current_app.logger.info(
+    logger.info(
         "issuing JWT API key with id [{}] to [{}]".format(jti, sub)
     )
-    flask.current_app.logger.debug(
+    logger.debug(
         "issuing JWT API key\n" + json.dumps(claims, indent=4)
     )
     token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
-    flask.current_app.logger.debug(str(token))
+    logger.debug(str(token))
     token = to_unicode(token, "UTF-8")
     return JWTResult(token=token, kid=kid, claims=claims)
 
@@ -422,10 +426,10 @@ def generate_signed_access_token(
         ] = linked_google_email
 
     if flask.current_app:
-        flask.current_app.logger.info(
+        logger.info(
             "issuing JWT access token with id [{}] to [{}]".format(jti, sub)
         )
-        flask.current_app.logger.debug(
+        logger.debug(
             "issuing JWT access token\n" + json.dumps(claims, indent=4)
         )
 
@@ -527,7 +531,7 @@ def generate_id_token(
     if nonce:
         claims["nonce"] = nonce
 
-    flask.current_app.logger.info(
+    logger.info(
         "issuing JWT ID token\n" + json.dumps(claims, indent=4)
     )
 

--- a/fence/oidc/endpoints.py
+++ b/fence/oidc/endpoints.py
@@ -3,8 +3,13 @@ import authlib.specs.rfc7009
 import bcrypt
 import flask
 
+from cdislogging import get_logger
+
 from fence.errors import BlacklistingError
 import fence.jwt.blacklist
+
+
+logger = get_logger(__name__)
 
 
 class RevocationEndpoint(authlib.specs.rfc7009.RevocationEndpoint):
@@ -33,7 +38,7 @@ class RevocationEndpoint(authlib.specs.rfc7009.RevocationEndpoint):
         """
         client_params = self.parse_basic_auth_header()
         if not client_params:
-            flask.current_app.logger.debug(
+            logger.debug(
                 "validating client in revoke request:" " missing client auth header"
             )
             raise InvalidClientError(uri=self.uri)
@@ -41,7 +46,7 @@ class RevocationEndpoint(authlib.specs.rfc7009.RevocationEndpoint):
         client_id, client_secret = client_params
         client = self.client_model.get_by_client_id(client_id)
         if not client:
-            flask.current_app.logger.debug(
+            logger.debug(
                 "validating client in revoke request:"
                 " no client with matching client id:" + " " + client_id
             )
@@ -54,7 +59,7 @@ class RevocationEndpoint(authlib.specs.rfc7009.RevocationEndpoint):
             bcrypt.hashpw(client_secret.encode("utf-8"), hashed.encode("utf-8"))
             != hashed
         ):
-            flask.current_app.logger.debug(
+            logger.debug(
                 "client secret hash does not match stored secret hash"
             )
             raise InvalidClientError(uri=self.uri)

--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -1,4 +1,5 @@
 import bcrypt
+import flask
 
 from authlib.specs.rfc6749.errors import (
     InvalidClientError,
@@ -8,10 +9,12 @@ from authlib.specs.rfc6749.errors import (
 )
 from authlib.specs.rfc6749.grants import RefreshTokenGrant as AuthlibRefreshTokenGrant
 from authlib.specs.rfc6749.util import scope_to_list
-import flask
+from cdislogging import get_logger
 
 from fence.jwt.validate import validate_jwt
 from fence.models import ClientAuthType, User
+
+logger = get_logger(__name__)
 
 
 class RefreshTokenGrant(AuthlibRefreshTokenGrant):
@@ -144,7 +147,7 @@ class RefreshTokenGrant(AuthlibRefreshTokenGrant):
             token["refresh_token"] = self.request.data.get("refresh_token", "")
 
         # TODO
-        flask.current_app.logger.info("")
+        logger.info("")
 
         self.request.user = user
         self.server.save_token(token, self.request)

--- a/fence/rbac/client.py
+++ b/fence/rbac/client.py
@@ -10,6 +10,7 @@ import backoff
 from cdislogging import get_logger
 import requests
 
+from fence.config import config
 from fence.errors import Forbidden
 from fence.rbac.errors import ArboristError, ArboristUnhealthyError
 
@@ -65,7 +66,9 @@ class ArboristClient(object):
     """
 
     def __init__(self, logger=None, arborist_base_url="http://arborist-service/"):
-        self.logger = logger or get_logger("ArboristClient")
+        self.logger = logger or get_logger(
+            "ArboristClient", log_level="debug" if config["DEBUG"] == True else "info"
+        )
         self._base_url = arborist_base_url.strip("/")
         self._auth_url = self._base_url + "/auth/"
         self._health_url = self._base_url + "/health"

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -36,9 +36,6 @@ from cdislogging import get_logger
 logger = get_logger(__name__)
 
 
-logger = get_logger(__name__)
-
-
 def get_or_create_primary_service_account_key(
     user_id, username, proxy_group_id, expires=None
 ):

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -6,6 +6,7 @@ import flask
 from flask_sqlalchemy_session import current_session
 from sqlalchemy import desc, func
 
+from cdislogging import get_logger
 from cirrus import GoogleCloudManager
 from cirrus.google_cloud.iam import GooglePolicyMember
 from cirrus.google_cloud.utils import (
@@ -31,6 +32,9 @@ from fence.resources.google import STORAGE_ACCESS_PROVIDER_NAME
 from fence.errors import NotSupported, NotFound
 
 from cdislogging import get_logger
+
+logger = get_logger(__name__)
+
 
 logger = get_logger(__name__)
 
@@ -191,7 +195,7 @@ def create_google_access_key(client_id, user_id, username, proxy_group_id):
     with GoogleCloudManager() as g_cloud:
         key = g_cloud.get_access_key(service_account.email)
 
-    flask.current_app.logger.info(
+    logger.info(
         "Created key with id {} for service account {} in user {}'s "
         "proxy group {} (user's id: {}).".format(
             key.get("private_key_id"),
@@ -402,7 +406,7 @@ def _update_service_account_db_entry(
 
     current_session.commit()
 
-    flask.current_app.logger.info(
+    logger.info(
         "Created service account {} for proxy group {}.".format(
             new_service_account["email"], proxy_group_id
         )
@@ -500,7 +504,7 @@ def _create_proxy_group(user_id, username):
     current_session.add(proxy_group)
     current_session.commit()
 
-    flask.current_app.logger.info(
+    logger.info(
         "Created proxy group {} for user {} with id {}.".format(
             new_proxy_group["email"], username, user_id
         )

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -8,7 +8,7 @@ import pprint
 from cirrus import GoogleCloudManager
 from cirrus.google_cloud.errors import GoogleAuthError
 from cirrus.config import config as cirrus_config
-from cdispyutils.log import get_logger
+from cdislogging import get_logger
 from sqlalchemy import func
 from userdatamodel.driver import SQLAlchemyDriver
 from userdatamodel.models import (

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -11,13 +11,14 @@ import shutil
 from stat import S_ISDIR
 import yaml
 
-from cdispyutils.log import get_logger
+from cdislogging import get_logger
 import paramiko
 from paramiko.proxy import ProxyCommand
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func
 from userdatamodel.driver import SQLAlchemyDriver
 
+from fence.config import config
 from fence.models import (
     AccessPrivilege,
     AuthorizationProvider,
@@ -249,7 +250,9 @@ class UserSyncer(object):
         self.driver = SQLAlchemyDriver(DB)
         self.project_mapping = project_mapping or {}
         self._projects = dict()
-        self.logger = get_logger("user_syncer")
+        self.logger = get_logger(
+            "user_syncer", log_level="debug" if config["DEBUG"] == True else "info"
+        )
 
         self.arborist_client = None
         if arborist:

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pyyaml==5.1
 userdatamodel==1.2.0
 -e git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
--e git+https://git@github.com/uc-cdis/cdislogging.git@master#egg=cdislogging
+-e git+https://git@github.com/uc-cdis/cdislogging.git@dbb03568d8ccb5c9895c3a9a50d134a279ca7fc1#egg=cdislogging
 -e git+https://github.com/uc-cdis/storage-client.git@0.2.2#egg=storageclient-0.2.2
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 Authlib==0.9
 addict==2.1.1
+authutils>=3.0.5<4.0.0
 boto>=2.36.0<3.0.0
 botocore>=1.7<1.10.39
 boto3>=1.5<1.6
 cached_property==1.5.1
+cdislogging>=1.0.0<2.0.0
 cryptography>=2.1.2
 enum34>=1.1.6
 Flask==0.12.4
@@ -32,8 +34,6 @@ pyyaml==5.1
 userdatamodel==1.2.0
 -e git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
--e git+https://git@github.com/uc-cdis/cdislogging.git@dbb03568d8ccb5c9895c3a9a50d134a279ca7fc1#egg=cdislogging
 -e git+https://github.com/uc-cdis/storage-client.git@0.2.2#egg=storageclient-0.2.2
 -e git+https://github.com/uc-cdis/datamodelutils.git@0.4.0#egg=datamodelutils
 -e git+https://github.com/uc-cdis/cdis-python-utils.git@0.2.10#egg=cdispyutils
--e git+https://github.com/uc-cdis/authutils.git@3.0.1#egg=authutils-3.0.1

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,5 +2,4 @@ from fence import app_init
 from fence import app
 
 app_init(app)
-app.debug = False
 application = app


### PR DESCRIPTION
todo: update cdislogging tag and authutils tag

tldr: Updated cdislogging. In Fence, **stop using app.logger; only use `get_logger()` from cdislogging**, both to instantiate and to update logger objects. Supply the optional `log_level` argument to `get_logger()` to set logging levels, bearing in mind the tree structure of the loggers. You probably just want to set log level once in `app_config()`, and in all other modules, simply inherit the level and handlers from this parent logger by calling `get_logger()` with no `log_level` arg (which will set level to default NOTSET).

- [PXP-2318] is to set `app.debug` in `app_config()` based on `config["DEBUG"]`.
- However, toggling `app.debug` turns out to toggle not just DEBUG level logging but also INFO and WARNING levels.
- This is because flask 0.12 does this: https://github.com/pallets/flask/blob/1c2a2cd0014693f1e1f894e498c2dc50dbb44f66/flask/logging.py#L65-L89

- In both dev and prod, we would like to log at either DEBUG or INFO level depending on `config["DEBUG"]`.
- ~So if we want this behavior we need to always have `app.debug==True` and always have `app.config['LOGGER_HANDLER_POLICY']=='always'`, and then in `app_config()`, set the `logger.level`--not `app.debug`--based on `config["DEBUG"]`. So probably the story needs to be modified.~

- So, we are not going to use the app logger at all, and instead use only cdislogging `get_logger()`. 
- `get_logger()` should be used both to instantiate and to update logger objects. Supply `log_level` argument to `get_logger()` to set logging levels, bearing in mind the tree structure of the loggers.

- `app.debug` will still indeed be set based on `config["DEBUG"]`. Not a problem if we avoid using the flask app logger.


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Set log level based on config['DEBUG']

### Dependency updates


### Deployment changes

