### PR TITLE
fix(sa-prefix): default to *not* changing the current SA naming conve…

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -362,6 +362,14 @@ CIRRUS_CFG:
 #       length restrictions on group names.
 GOOGLE_GROUP_PREFIX: ''
 
+# Prefix to namespace Google Service Accounts in a single Google Cloud Platform Project.
+# This is primarily to support multiple instances of fence references the same Google
+# project. If that is not something you need to support, then you can leave this blank.
+#
+# NOTE: Make this short! Less than 8 characters if possible. Google has
+#       length restrictions on service account names.
+GOOGLE_SERVICE_ACCOUNT_PREFIX: ''
+
 # //////////////////////////////////////////////////////////////////////////////////////
 # EMAIL
 #   - Support for sending emails from fence. Used for user certificates

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -30,6 +30,10 @@ from fence.models import (
 from fence.resources.google import STORAGE_ACCESS_PROVIDER_NAME
 from fence.errors import NotSupported, NotFound
 
+from cdislogging import get_logger
+
+logger = get_logger(__name__)
+
 
 def get_or_create_primary_service_account_key(
     user_id, username, proxy_group_id, expires=None
@@ -303,11 +307,11 @@ def get_or_create_service_account(client_id, user_id, username, proxy_group_id):
     if proxy_group_id:
         if client_id:
             service_account_id = get_valid_service_account_id_for_client(
-                client_id, user_id, prefix=config["GOOGLE_GROUP_PREFIX"]
+                client_id, user_id, prefix=config["GOOGLE_SERVICE_ACCOUNT_PREFIX"]
             )
         else:
             service_account_id = get_valid_service_account_id_for_user(
-                user_id, username, prefix=config["GOOGLE_GROUP_PREFIX"]
+                user_id, username, prefix=config["GOOGLE_SERVICE_ACCOUNT_PREFIX"]
             )
 
         with GoogleCloudManager() as g_cloud:
@@ -331,6 +335,47 @@ def _update_service_account_db_entry(
     """
     Now that SA exists in Google so lets check our db and update/add as necessary
     """
+
+    # if we're now using a prefix for SAs, cleanup the db
+    if config["GOOGLE_SERVICE_ACCOUNT_PREFIX"]:
+        # - if using the old naming convention without a prefix,
+        # remove that SA from the db b/c we'll be using the new one from now on
+        # - construct old email using account id provided and
+        # domain from new email to find the db entry
+        old_service_account_id = get_valid_service_account_id_for_client(
+            client_id, user_id
+        )
+        old_sa_email = "@".join(
+            (old_service_account_id, new_service_account["email"].split("@")[:-1])
+        )
+
+        # clear out old SA and keys if there is one
+        old_service_account_db_entry = (
+            current_session.query(GoogleServiceAccount)
+            .filter(GoogleServiceAccount.email == old_sa_email)
+            .first()
+        )
+        old_service_account_keys_db_entries = (
+            current_session.query(GoogleServiceAccountKey)
+            .filter(GoogleServiceAccountKey.email == old_sa_email)
+            .all()
+        )
+        if old_service_account_db_entry:
+            logger.info(
+                "Found Google Service Account using old naming convention without a prefix: "
+                "{}. Removing from db. Keys should still have access in Google until "
+                "cronjob removes them (e.g. fence-create google-manage-keys). NOTE: "
+                "the SA will still exist in Google but fence will use new SA {} for "
+                "new keys.".format(old_sa_email, new_service_account["email"])
+            )
+
+            # remove the keys then the sa itself from db
+            for old_key in old_service_account_keys_db_entries:
+                current_session.delete(old_key)
+
+            current_session.commit()
+            current_session.delete(old_service_account_db_entry)
+
     service_account_db_entry = (
         current_session.query(GoogleServiceAccount)
         .filter(GoogleServiceAccount.email == new_service_account["email"])


### PR DESCRIPTION

### New Features

### Breaking Changes


### Bug Fixes


### Improvements
- default to *not* changing the current Google SA naming convention in an env
- handle conversion to new Google SA naming convention gracefully if changed
- new GOOGLE_SERVICE_ACCOUNT_PREFIX for Google SA names

### Dependency updates


### Deployment changes

