### PR TITLE
fix(sa-prefix)

### DIFF
--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -355,11 +355,6 @@ def _update_service_account_db_entry(
             .filter(GoogleServiceAccount.email == old_sa_email)
             .first()
         )
-        old_service_account_keys_db_entries = (
-            current_session.query(GoogleServiceAccountKey)
-            .filter(GoogleServiceAccountKey.email == old_sa_email)
-            .all()
-        )
         if old_service_account_db_entry:
             logger.info(
                 "Found Google Service Account using old naming convention without a prefix: "
@@ -367,6 +362,12 @@ def _update_service_account_db_entry(
                 "cronjob removes them (e.g. fence-create google-manage-keys). NOTE: "
                 "the SA will still exist in Google but fence will use new SA {} for "
                 "new keys.".format(old_sa_email, new_service_account["email"])
+            )
+
+            old_service_account_keys_db_entries = (
+                current_session.query(GoogleServiceAccountKey)
+                .filter(GoogleServiceAccountKey.service_account_id == old_service_account_db_entry.id)
+                .all()
             )
 
             # remove the keys then the sa itself from db

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -366,7 +366,10 @@ def _update_service_account_db_entry(
 
             old_service_account_keys_db_entries = (
                 current_session.query(GoogleServiceAccountKey)
-                .filter(GoogleServiceAccountKey.service_account_id == old_service_account_db_entry.id)
+                .filter(
+                    GoogleServiceAccountKey.service_account_id
+                    == old_service_account_db_entry.id
+                )
                 .all()
             )
 

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -346,7 +346,7 @@ def _update_service_account_db_entry(
             client_id, user_id
         )
         old_sa_email = "@".join(
-            (old_service_account_id, new_service_account["email"].split("@")[0])
+            (old_service_account_id, new_service_account["email"].split("@")[-1])
         )
 
         # clear out old SA and keys if there is one

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -346,7 +346,7 @@ def _update_service_account_db_entry(
             client_id, user_id
         )
         old_sa_email = "@".join(
-            (old_service_account_id, new_service_account["email"].split("@")[:-1])
+            (old_service_account_id, new_service_account["email"].split("@")[0])
         )
 
         # clear out old SA and keys if there is one


### PR DESCRIPTION
```
(old_service_account_id, new_service_account["email"].split("@")[:-1])
TypeError: sequence item 1: expected string, list found
```

```
.filter(GoogleServiceAccountKey.email == old_sa_email)
AttributeError: type object 'GoogleServiceAccountKey' has no attribute 'email'
```

### Bug Fixes
- fix 500 errors when creating a service account with prefix

### Improvements


### Dependency updates


### Deployment changes

