### PR TITLE
feat(sa-registration): move allowed registration SA types to config, …

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -516,3 +516,13 @@ GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS:
   - 'storage-transfer-service.iam.gserviceaccount.com'
   - 'firebase-sa-management.iam.gserviceaccount.com'
   - 'firebase-rules.iam.gserviceaccount.com'
+
+# The types of service accounts that are allowed to be registered at
+# /google/service_accounts endpoints
+ALLOWED_USER_SERVICE_ACCOUNT_DOMAINS:
+  # compute engine default service account
+  - 'developer.gserviceaccount.com'
+  # app engine default service account
+  - 'appspot.gserviceaccount.com'
+  # user-managed service account
+  - 'iam.gserviceaccount.com'

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -11,10 +11,6 @@ from cirrus.google_cloud.iam import GooglePolicyMember
 from cirrus.google_cloud.errors import GoogleAPIError
 from cirrus.google_cloud.iam import GooglePolicy
 from cirrus import GoogleCloudManager
-from cirrus.google_cloud import (
-    COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
-    USER_MANAGED_SERVICE_ACCOUNT,
-)
 
 import fence
 from cdislogging import get_logger
@@ -39,11 +35,6 @@ from fence.resources.google.utils import (
 from fence.utils import get_valid_expiration_from_request
 
 logger = get_logger(__name__)
-
-ALLOWED_SERVICE_ACCOUNT_TYPES = [
-    COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
-    USER_MANAGED_SERVICE_ACCOUNT,
-]
 
 
 def get_google_project_number(google_project_id, google_cloud_manager):
@@ -173,11 +164,11 @@ def is_valid_service_account_type(account_id, google_cloud_manager):
 
     Returns:
         Bool: True if service acocunt type is allowed as defined
-        in ALLOWED_SERVICE_ACCOUNT_TYPES
+        in ALLOWED_USER_SERVICE_ACCOUNT_DOMAINS
     """
     try:
         sa_type = google_cloud_manager.get_service_account_type(account_id)
-        return sa_type in ALLOWED_SERVICE_ACCOUNT_TYPES
+        return sa_type in config["ALLOWED_USER_SERVICE_ACCOUNT_DOMAINS"]
     except Exception as exc:
         logger.error(
             "validity of Google service account {} (google project: {}) type "

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
+gen3cirrus==0.4.0
 httplib2==0.10.3
 python-jose==2.0.2
 oauthlib==3.0.0
@@ -32,7 +33,6 @@ Werkzeug==0.12.2
 pyyaml==5.1
 userdatamodel==1.2.0
 retry==0.9.2
--e git+https://git@github.com/uc-cdis/cirrus.git@chore/sa-types#egg=cirrus
 -e git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
 -e git+https://github.com/uc-cdis/storage-client.git@0.2.2#egg=storageclient-0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-gen3cirrus==0.3.4
 httplib2==0.10.3
 python-jose==2.0.2
 oauthlib==3.0.0
@@ -33,6 +32,7 @@ Werkzeug==0.12.2
 pyyaml==5.1
 userdatamodel==1.2.0
 retry==0.9.2
+-e git+https://git@github.com/uc-cdis/cirrus.git@chore/sa-types#egg=cirrus
 -e git+https://github.com/uc-cdis/flask-postgres-session.git@68bf5a9723a351729855c429eca8a0f4bbb830c7#egg=flask_postgres_session-0.1.3
 -e git+https://git@github.com/uc-cdis/cdiserrors.git@0.1.0#egg=cdiserrors
 -e git+https://github.com/uc-cdis/storage-client.git@0.2.2#egg=storageclient-0.2.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
         "botocore>=1.7,<1.9.0",
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
-        "cirrus",
         "cryptography>=2.1.2",
         "enum34>=1.1.6",
         "flask-restful>=0.3.6,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "botocore>=1.7,<1.9.0",
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
-        "gen3cirrus>=0.3.4,<1.0.0",
+        "cirrus",
         "cryptography>=2.1.2",
         "enum34>=1.1.6",
         "flask-restful>=0.3.6,<1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Flask-CORS>=3.0.3,<4.0.0",
         "Flask_OAuthlib>=0.9.4,<1.0.0",
         "Flask_SQLAlchemy_Session>=1.1,<2.0",
+        "gen3cirrus>=0.4.0,<1.0",
         "google_api_python_client>=1.6.4,<2.0.0",
         "httplib2>=0.10.3,<1.0.0",
         "python-jose>=2.0.0,<3.0.0",

--- a/tests/google/test_access_utils.py
+++ b/tests/google/test_access_utils.py
@@ -11,13 +11,7 @@ except ImportError:
 from sqlalchemy import or_
 
 from cirrus.errors import CirrusError
-from cirrus.google_cloud import (
-    GoogleCloudManager,
-    COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT,
-    COMPUTE_ENGINE_API_SERVICE_ACCOUNT,
-    GOOGLE_API_SERVICE_ACCOUNT,
-    USER_MANAGED_SERVICE_ACCOUNT,
-)
+from cirrus.google_cloud import GoogleCloudManager
 from cirrus.google_cloud.iam import GooglePolicyMember
 
 import fence
@@ -57,7 +51,7 @@ def test_is_valid_service_account_type_compute_engine_default(cloud_manager):
     """
     (
         cloud_manager.get_service_account_type.return_value
-    ) = COMPUTE_ENGINE_API_SERVICE_ACCOUNT
+    ) = "developer.gserviceaccount.com"
     assert is_valid_service_account_type(1, cloud_manager)
 
 
@@ -66,7 +60,9 @@ def test_not_valid_service_account_type_google_api(cloud_manager):
     Test that GOOGLE_API is not a valid service account type
     for service account registration
     """
-    (cloud_manager.get_service_account_type.return_value) = GOOGLE_API_SERVICE_ACCOUNT
+    (
+        cloud_manager.get_service_account_type.return_value
+    ) = "cloudservices.gserviceaccount.com"
     assert not is_valid_service_account_type(1, cloud_manager)
 
 
@@ -77,7 +73,7 @@ def test_not_valid_service_account_type_compute_engine_api(cloud_manager):
     """
     (
         cloud_manager.get_service_account_type.return_value
-    ) = COMPUTE_ENGINE_DEFAULT_SERVICE_ACCOUNT
+    ) = "compute-system.iam.gserviceaccount.com"
     assert not is_valid_service_account_type(1, cloud_manager)
 
 
@@ -86,7 +82,7 @@ def test_is_valid_service_account_type_user_managed(cloud_manager):
     Test that USER_MANAGED is a valid service account type
     for service account registration
     """
-    (cloud_manager.get_service_account_type.return_value) = USER_MANAGED_SERVICE_ACCOUNT
+    (cloud_manager.get_service_account_type.return_value) = "iam.gserviceaccount.com"
     assert is_valid_service_account_type(1, cloud_manager)
 
 


### PR DESCRIPTION
…add app engine default

relies on https://github.com/uc-cdis/cirrus/pull/68
will update cirrus version when ^ merged

### New Features
- app engine default service account is an allowed type for SA registration for Google data access

### Breaking Changes


### Bug Fixes


### Improvements
- allowed service accounts for registration are now in configuration

### Dependency updates


### Deployment changes

