### PR TITLE
Update authlib from v0.9 to v0.11

### DIFF
--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -17,11 +17,7 @@ stateless.
 import flask
 
 from authlib.common.urls import add_params_to_uri
-from authlib.oauth2.rfc6749 import (
-    AccessDeniedError,
-    InvalidRequestError,
-    OAuth2Error,
-)
+from authlib.oauth2.rfc6749 import AccessDeniedError, InvalidRequestError, OAuth2Error
 
 from fence.errors import Unauthorized
 from fence.jwt.token import SCOPE_DESCRIPTION

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -114,10 +114,10 @@ def _handle_consent_confirmation(user, is_confirmed):
     """
     if is_confirmed == "yes":
         # user has already given consent, continue flow
-        response = server.create_authorization_response(user)
+        response = server.create_authorization_response(grant_user=user)
     else:
         # user did not give consent
-        response = server.create_authorization_response(None)
+        response = server.create_authorization_response(grant_user=None)
     return response
 
 

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -78,7 +78,6 @@ def authorize(*args, **kwargs):
 
     try:
         grant = server.validate_consent_request(end_user=user)
-        grant.validate_prompt(user)
     except OAuth2Error as e:
         raise Unauthorized("{} failed to authorize".format(str(e)))
 

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -17,7 +17,7 @@ stateless.
 import flask
 
 from authlib.common.urls import add_params_to_uri
-from authlib.specs.rfc6749.errors import (
+from authlib.oauth2.rfc6749 import (
     AccessDeniedError,
     InvalidRequestError,
     OAuth2Error,
@@ -254,7 +254,7 @@ def _get_authorize_error_response(error, redirect_uri):
     Get error response as defined by OIDC spec.
 
     Args:
-        error (authlib.specs.rfc6749.error.OAuth2Error): Specific Oauth2 error
+        error (authlib.oauth2.rfc6749.error.OAuth2Error): Specific Oauth2 error
         redirect_uri (str): Redirection url
     """
     params = error.get_body()

--- a/fence/error_handler.py
+++ b/fence/error_handler.py
@@ -4,7 +4,7 @@ import flask
 from flask import render_template
 from werkzeug.exceptions import HTTPException
 
-from authlib.specs.rfc6749.errors import OAuth2Error
+from authlib.oauth2.rfc6749.errors import OAuth2Error
 from cdislogging import get_logger
 
 from fence.errors import APIError

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -3,7 +3,7 @@ import time
 import uuid
 
 from authlib.common.encoding import to_unicode
-from authlib.specs.oidc import CodeIDToken as AuthlibCodeIDToken
+from authlib.oidc.core import CodeIDToken as AuthlibCodeIDToken
 from cdislogging import get_logger
 import flask
 import jwt

--- a/fence/oidc/endpoints.py
+++ b/fence/oidc/endpoints.py
@@ -1,5 +1,5 @@
-from authlib.specs.rfc6749.errors import InvalidClientError, OAuth2Error
-import authlib.specs.rfc7009
+from authlib.oauth2.rfc6749.errors import InvalidClientError, OAuth2Error
+import authlib.oauth2.rfc7009
 import bcrypt
 import flask
 
@@ -12,9 +12,9 @@ import fence.jwt.blacklist
 logger = get_logger(__name__)
 
 
-class RevocationEndpoint(authlib.specs.rfc7009.RevocationEndpoint):
+class RevocationEndpoint(authlib.oauth2.rfc7009.RevocationEndpoint):
     """
-    Inherit from ``authlib.specs.rfc7009.RevocationEndpoint`` to define how the
+    Inherit from ``authlib.oauth2.rfc7009.RevocationEndpoint`` to define how the
     server should handle requests for token revocation.
     """
 

--- a/fence/oidc/grants/authorization_code_grant.py
+++ b/fence/oidc/grants/authorization_code_grant.py
@@ -3,7 +3,7 @@ import bcrypt
 from authlib.common.security import generate_token
 from authlib.oauth2.rfc6749.errors import InvalidClientError, UnauthorizedClientError
 from authlib.oauth2.rfc6749.grants import (
-    AuthorizationCodeGrant as AuthlibAuthorizationCodeGrant
+    AuthorizationCodeGrant as AuthlibAuthorizationCodeGrant,
 )
 from authlib.oauth2.rfc6749.util import get_obj_value
 import flask

--- a/fence/oidc/grants/authorization_code_grant.py
+++ b/fence/oidc/grants/authorization_code_grant.py
@@ -1,11 +1,11 @@
 import bcrypt
 
 from authlib.common.security import generate_token
-from authlib.specs.rfc6749.errors import InvalidClientError, UnauthorizedClientError
-from authlib.specs.rfc6749.grants import (
+from authlib.oauth2.rfc6749.errors import InvalidClientError, UnauthorizedClientError
+from authlib.oauth2.rfc6749.grants import (
     AuthorizationCodeGrant as AuthlibAuthorizationCodeGrant
 )
-from authlib.specs.rfc6749.util import get_obj_value
+from authlib.oauth2.rfc6749.util import get_obj_value
 import flask
 
 from fence.models import AuthorizationCode

--- a/fence/oidc/grants/implicit_grant.py
+++ b/fence/oidc/grants/implicit_grant.py
@@ -1,6 +1,6 @@
-from authlib.specs.oidc.grants import OpenIDImplicitGrant
-from authlib.specs.oidc.grants.base import create_response_mode_response
-from authlib.specs.rfc6749 import AccessDeniedError, InvalidRequestError
+from authlib.oidc.core.grants import OpenIDImplicitGrant
+from authlib.oidc.core.grants.util import create_response_mode_response
+from authlib.oauth2.rfc6749 import AccessDeniedError, InvalidRequestError
 import flask
 
 from fence.models import AuthorizationCode

--- a/fence/oidc/grants/implicit_grant.py
+++ b/fence/oidc/grants/implicit_grant.py
@@ -50,7 +50,7 @@ class ImplicitGrant(OpenIDImplicitGrant):
         return create_response_mode_response(
             redirect_uri=self.redirect_uri,
             params=params,
-            response_mode=self.request.response_mode,
+            response_mode=self.request.data.get('response_mode', self.DEFAULT_RESPONSE_MODE)
         )
 
     def generate_token(self, *args, **kwargs):

--- a/fence/oidc/grants/implicit_grant.py
+++ b/fence/oidc/grants/implicit_grant.py
@@ -7,13 +7,16 @@ from fence.models import AuthorizationCode
 
 
 class ImplicitGrant(OpenIDImplicitGrant):
-    def validate_nonce(self, required=False):
-        """
-        Override method in authlib to skip adding ``exists_nonce`` hook on server. I
-        don't think this needs to exist according to OIDC spec but this stays consistent
-        with authlib so here we are
-        """
-        return True
+    def exists_nonce(self, nonce, request):
+        with flask.current_app.db.session as session:
+            code = (
+                session.query(AuthorizationCode)
+                .filter_by(nonce=nonce)
+                .first()
+            )
+            if code:
+                return True
+            return False
 
     def create_authorization_response(self, grant_user):
         """

--- a/fence/oidc/grants/implicit_grant.py
+++ b/fence/oidc/grants/implicit_grant.py
@@ -1,6 +1,6 @@
 from authlib.oidc.core.grants import OpenIDImplicitGrant
 from authlib.oidc.core.grants.util import create_response_mode_response
-from authlib.oauth2.rfc6749 import AccessDeniedError, InvalidRequestError
+from authlib.oauth2.rfc6749 import AccessDeniedError
 import flask
 
 from fence.models import AuthorizationCode
@@ -9,11 +9,7 @@ from fence.models import AuthorizationCode
 class ImplicitGrant(OpenIDImplicitGrant):
     def exists_nonce(self, nonce, request):
         with flask.current_app.db.session as session:
-            code = (
-                session.query(AuthorizationCode)
-                .filter_by(nonce=nonce)
-                .first()
-            )
+            code = session.query(AuthorizationCode).filter_by(nonce=nonce).first()
             if code:
                 return True
             return False
@@ -50,7 +46,9 @@ class ImplicitGrant(OpenIDImplicitGrant):
         return create_response_mode_response(
             redirect_uri=self.redirect_uri,
             params=params,
-            response_mode=self.request.data.get('response_mode', self.DEFAULT_RESPONSE_MODE)
+            response_mode=self.request.data.get(
+                "response_mode", self.DEFAULT_RESPONSE_MODE
+            ),
         )
 
     def generate_token(self, *args, **kwargs):

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -67,7 +67,7 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
         self.request.user = user
         self.server.save_token(token, self.request)
-        token = self.process_token(token, self.request)
+        self.execute_hook('process_token', token=token)
         self.delete_authorization_code(authorization_code)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -18,8 +18,12 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
     def __init__(self, *args, **kwargs):
         super(OpenIDCodeGrant, self).__init__(*args, **kwargs)
         # Override authlib validate_request_prompt with our own, to fix login prompt behavior
-        self._hooks['after_validate_consent_request'].discard(grants.util.validate_request_prompt)
-        self.register_hook('after_validate_consent_request', self.validate_request_prompt)
+        self._hooks["after_validate_consent_request"].discard(
+            grants.util.validate_request_prompt
+        )
+        self.register_hook(
+            "after_validate_consent_request", self.validate_request_prompt
+        )
 
     @staticmethod
     def create_authorization_code(client, grant_user, request):
@@ -73,7 +77,7 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
         self.request.user = user
         self.server.save_token(token, self.request)
-        self.execute_hook('process_token', token=token)
+        self.execute_hook("process_token", token=token)
         self.delete_authorization_code(authorization_code)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
@@ -123,11 +127,7 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
     def exists_nonce(self, nonce, request):
         with flask.current_app.db.session as session:
-            code = (
-                session.query(AuthorizationCode)
-                .filter_by(nonce=nonce)
-                .first()
-            )
+            code = session.query(AuthorizationCode).filter_by(nonce=nonce).first()
             if code:
                 return True
             return False

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -1,11 +1,11 @@
 from authlib.common.security import generate_token
-from authlib.specs.oidc import grants
-from authlib.specs.oidc.errors import (
+from authlib.oidc.core import grants
+from authlib.oidc.core.errors import (
     AccountSelectionRequiredError,
     ConsentRequiredError,
     LoginRequiredError,
 )
-from authlib.specs.rfc6749 import InvalidRequestError
+from authlib.oauth2.rfc6749 import InvalidRequestError
 import flask
 
 from fence.models import AuthorizationCode, ClientAuthType, User

--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -1,14 +1,14 @@
 import bcrypt
 import flask
 
-from authlib.specs.rfc6749.errors import (
+from authlib.oauth2.rfc6749.errors import (
     InvalidClientError,
     InvalidRequestError,
     InvalidScopeError,
     UnauthorizedClientError,
 )
-from authlib.specs.rfc6749.grants import RefreshTokenGrant as AuthlibRefreshTokenGrant
-from authlib.specs.rfc6749.util import scope_to_list
+from authlib.oauth2.rfc6749.grants import RefreshTokenGrant as AuthlibRefreshTokenGrant
+from authlib.oauth2.rfc6749.util import scope_to_list
 from cdislogging import get_logger
 
 from fence.jwt.validate import validate_jwt

--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -2,7 +2,6 @@ import bcrypt
 import flask
 
 from authlib.oauth2.rfc6749.errors import (
-    InvalidClientError,
     InvalidRequestError,
     InvalidScopeError,
     UnauthorizedClientError,
@@ -151,7 +150,7 @@ class RefreshTokenGrant(AuthlibRefreshTokenGrant):
 
         self.request.user = user
         self.server.save_token(token, self.request)
-        self.execute_hook('process_token', token=token)
+        self.execute_hook("process_token", token=token)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def _validate_token_scope(self, token):

--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -151,7 +151,7 @@ class RefreshTokenGrant(AuthlibRefreshTokenGrant):
 
         self.request.user = user
         self.server.save_token(token, self.request)
-        token = self.process_token(token, self.request)
+        self.execute_hook('process_token', token=token)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def _validate_token_scope(self, token):

--- a/fence/oidc/oidc_server.py
+++ b/fence/oidc/oidc_server.py
@@ -1,7 +1,7 @@
 from authlib.common.urls import urlparse, url_decode
 from authlib.flask.oauth2 import AuthorizationServer
 from authlib.oauth2.rfc6749.authenticate_client import (
-    ClientAuthentication as AuthlibClientAuthentication
+    ClientAuthentication as AuthlibClientAuthentication,
 )
 
 from authlib.oauth2.rfc6749.errors import InvalidClientError as AuthlibClientError

--- a/fence/oidc/oidc_server.py
+++ b/fence/oidc/oidc_server.py
@@ -1,10 +1,10 @@
 from authlib.common.urls import urlparse, url_decode
 from authlib.flask.oauth2 import AuthorizationServer
-from authlib.specs.rfc6749.authenticate_client import (
+from authlib.oauth2.rfc6749.authenticate_client import (
     ClientAuthentication as AuthlibClientAuthentication
 )
 
-from authlib.specs.rfc6749.errors import InvalidClientError as AuthlibClientError
+from authlib.oauth2.rfc6749.errors import InvalidClientError as AuthlibClientError
 import flask
 
 from fence.oidc.errors import InvalidClientError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Authlib==0.9
+Authlib==0.11
 addict==2.1.1
 authutils>=3.0.5<4.0.0
 boto>=2.36.0<3.0.0

--- a/tests/oidc/core/token/test_id_token.py
+++ b/tests/oidc/core/token/test_id_token.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-from authlib.specs.rfc7519 import InvalidClaimError
+from authlib.jose.errors import InvalidClaimError
 
 from fence.jwt.token import generate_signed_id_token, UnsignedIDToken
 from fence.jwt.validate import validate_jwt


### PR DESCRIPTION
[v0.10](https://github.com/lepture/authlib/releases/tag/v0.10), [v0.11](https://github.com/lepture/authlib/releases/tag/v0.11)

### Change import statements 

The `authlib.specs` module was [refactored](https://gist.github.com/lepture/7e38d505c1e22e6e913d8625e5c52cca#file-sp-md) in authlib [0.11](https://github.com/lepture/authlib/releases/tag/v0.11), so this PR changes the import statements.

### Pass user as kwarg in `fence.blueprints.oauth2`

Fence's `OIDCServer` inherits from `AuthorizationServer` from `authlib.flask.oauth2`. In Authlib 0.9 the `AuthorizationServer`'s `create_authorization_response` method involved [this hack](https://github.com/lepture/authlib/blob/abf4555fa6b0d8cf64c31b2c4c90fb5d875c2de8/authlib/flask/oauth2/authorization_server.py#L231-L233), so in `fence.blueprints.oauth2` we were able to do `response = server.create_authorization_response(user)` (i.e. pass `user` as, in fact, the `request` arg). In Authlib 0.11, the [Flask `AuthorizationServer`](https://github.com/lepture/authlib/blob/v0.11/authlib/flask/oauth2/authorization_server.py) just inherits its `create_authorization_response` method [from the `authlib.oauth2` `AuthorizationServer`](https://github.com/lepture/authlib/blob/5403f90a0a910b1519622a2b97e03f0b9cce36e4/authlib/oauth2/rfc6749/authorization_server.py#L148), which doesn't have that hack, so now we will do `server.create_authorization_response(grant_user=user)`, like upright citizens.

### Call `process_token` differently

Currently Fence's `OpenIDCodeGrant` and `RefreshTokenGrant` each implement their own `create_token_response` methods that override those in the corresponding Authlib classes. These custom `create_token_response` methods used to call `self.process_token`, implemented by Authlib. In 0.10 Authlib refactored their Grant classes so that now `BaseGrant` has a dictionary [`self._hooks`](https://github.com/lepture/authlib/blob/5403f90a0a910b1519622a2b97e03f0b9cce36e4/authlib/oauth2/rfc6749/grants/base.py#L36-L41), which has an item `process_token`, a set of functions. So `process_token` is no longer a method on the Grant class(es). In Authlib therefore, `process_token` is now called in `create_token_response` [like this](https://github.com/lepture/authlib/blob/aa28a07bf12d6151418a87808d76da8e165c6ae4/authlib/oauth2/rfc6749/grants/refresh_token.py#L139). So in the custom `create_token_response` methods in `OpenIDCodeGrant` and `RefreshTokenGrant` we are following suit. 

NOTE: It may also be worth noting that [the new `process_token`](https://github.com/lepture/authlib/blob/5403f90a0a910b1519622a2b97e03f0b9cce36e4/authlib/oidc/core/grants/code.py#L33) on `OpenIDCodeGrant` [comes from](https://github.com/lepture/authlib/blob/5403f90a0a910b1519622a2b97e03f0b9cce36e4/authlib/oidc/core/grants/code.py#L72-L79) the class `OpenIDCode`. Grant extensions are [new in 0.10](https://github.com/lepture/authlib/releases/tag/v0.10). As is evident in the linked code, `OpenIDCode` is registered automatically by Authlib as a grant extension on `OpenIDCodeGrant`, so that's how the `process_token` hook gets registered without Fence doing `server.register_grant(OpenIDCodeGrant, [OpenIDCode])` in `fence/oidc/server.py`. 

*_Thanks for the correction lepture!!_*

### Define `exists_nonce` methods on OIDC grant classes

We don't have HybridGrant, so this applies to Implicit and Code grants. 

Previously Fence's Implicit and Code grants had custom `validate_nonce` methods overriding the Authlib ones, in order to skip adding `exists_nonce` hooks on the Auth server. Now Authlib has one `validate_nonce` method in [utils](https://github.com/lepture/authlib/blob/17e930874db4482dd9da5019cfb8e6adb6c0f9bd/authlib/oidc/core/grants/util.py#L45) (not one for every grant class), which gets registered to one of the grant hooks and which calls the grant's `exists_nonce` method. Per [the Authlib 0.10 release notes](https://gist.github.com/lepture/b333e6a128fe473a721d97159f5724be#openid-connect-exists_nonce), we should therefore be defining an `exists_nonce` method on each grant. So we are turning the custom `validate_nonce`s into `exists_nonce`s. Since Authlib's `validate_nonce` deals with checking `required` and checking that the nonce is present, those checks are removed in our code, and `exists_nonce` just checks the database for the nonce. 

### Override `validate_prompt` differently

In OIDC code grant we used to override authlib `validate_prompt` with our own `validate_prompt` to fix the login prompt behavior. Now authlib's oidc code grant (similarly to above situation) just has a `validate_request_prompt` in [utils](https://github.com/lepture/authlib/blob/17e930874db4482dd9da5019cfb8e6adb6c0f9bd/authlib/oidc/core/grants/util.py#L22) which gets [registered](https://github.com/lepture/authlib/blob/17e930874db4482dd9da5019cfb8e6adb6c0f9bd/authlib/oidc/core/grants/code.py#L60-L63) to the `after_validate_consent_request` hook... in the `OpenIDCode` grant extension. So the override broke, and the prompt would end up being None. So now we override the new `validate_request_prompt` by overriding (augmenting?) `__init__` in `OpenIDCodeGrant` so that it pops the util fn from `_hooks` and sticks our own method in there instead. 

### Dependency updates
bump authlib from 0.9 to 0.11
