### PR TITLE
fix(log): remove check for capp; became irrelevant upon cdislogging 1.0.0

### DIFF
--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -268,9 +268,8 @@ def generate_signed_refresh_token(
         "azp": client_id or "",
     }
 
-    if flask.current_app:
-        logger.info("issuing JWT refresh token with id [{}] to [{}]".format(jti, sub))
-        logger.debug("issuing JWT refresh token\n" + json.dumps(claims, indent=4))
+    logger.info("issuing JWT refresh token with id [{}] to [{}]".format(jti, sub))
+    logger.debug("issuing JWT refresh token\n" + json.dumps(claims, indent=4))
 
     token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
     token = to_unicode(token, "UTF-8")
@@ -380,9 +379,8 @@ def generate_signed_access_token(
             "linked_google_account"
         ] = linked_google_email
 
-    if flask.current_app:
-        logger.info("issuing JWT access token with id [{}] to [{}]".format(jti, sub))
-        logger.debug("issuing JWT access token\n" + json.dumps(claims, indent=4))
+    logger.info("issuing JWT access token with id [{}] to [{}]".format(jti, sub))
+    logger.debug("issuing JWT access token\n" + json.dumps(claims, indent=4))
 
     token = jwt.encode(claims, private_key, headers=headers, algorithm="RS256")
     token = to_unicode(token, "UTF-8")


### PR DESCRIPTION
A while ago we stopped using the `flask.current_app` logger and started using the updated `cdislogger` logger everywhere. Apparently I [left](https://github.com/uc-cdis/fence/pull/588/files#diff-7b2574a05fa5500b0a4b10b7b7f23fa0) these checks in the code which are now irrelevant. 

