### PR TITLE
filter SAWarning about not reflecting partial indices

### DIFF
--- a/fence/models.py
+++ b/fence/models.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.sql import func
+from sqlalchemy import exc as sa_exc
 from sqlalchemy import func
 from sqlalchemy.schema import ForeignKey
 from userdatamodel import Base
@@ -53,6 +54,7 @@ from userdatamodel.models import (
     UserToBucket,
     UserToGroup,
 )
+import warnings
 
 from fence.config import config
 
@@ -813,7 +815,13 @@ def set_foreign_key_constraint_on_delete(
     session,
     metadata,
 ):
-    table = Table(table_name, metadata, autoload=True, autoload_with=driver.engine)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Predicate of partial index \S+ ignored during reflection",
+            category=sa_exc.SAWarning,
+        )
+        table = Table(table_name, metadata, autoload=True, autoload_with=driver.engine)
     foreign_key_name = "{}_{}_fkey".format(table_name.lower(), column_name)
 
     if column_name in table.c:


### PR DESCRIPTION
Upon startup Fence is emitting warnings like this:
```
/usr/local/lib/python2.7/dist-packages/sqlalchemy/dialects/postgresql/base.py:3289: SAWarning: Predicate of partial index unique_group_project_id ignored during reflection
  % idx_name
```
for indices `unique_group_project_id`, `unique_user_group_id`, `unique_user_project_id` (on the `access_privilege` table). 

This is being triggered in the migration code where tables are being loaded in order to inspect their columns:
```table = Table(table_name, metadata, autoload=True, autoload_with=driver.engine)```
and the warning just expresses that SQLAlchemy doesn't know what to do with the predicates (in fact they are just "[where blah is NULL](https://github.com/uc-cdis/userdatamodel/blob/4a63ea3655033631d1623bb9522cd2780bd08e06/userdatamodel/user.py#L262-L276)") and has therefore ignored them. 

Since in this particular code (`set_foreign_key_constraint_on_delete`) we don't care about the partial indices (or their predicates), this is fine, and we can just filter out the warnings. 

(There are a lot of other reflections going on in the migration code, but presumably none of the other functions are used on `access_privileges` or another table with a partial index. So I've taken the approach of minimal filtering and only added the filter on this one function.) 


### Improvements
filter SAWarning about not reflecting partial indices


