### PR TITLE
feat(public-files): check authz/acl field, then hit arborist as anon …

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -44,7 +44,6 @@ ACTION_DICT = {
     "gs": {"upload": "PUT", "download": "GET"},
 }
 
-ACTION_TO_ARBORIST_METHOD = {"upload": "write-storage", "download": "read-storage"}
 
 SUPPORTED_PROTOCOLS = ["s3", "http", "ftp", "https", "gs"]
 SUPPORTED_ACTIONS = ["upload", "download"]
@@ -388,7 +387,8 @@ class IndexedFile(object):
             return self.index_document.get("uploader") == username
 
         try:
-            method = ACTION_TO_ARBORIST_METHOD[action]
+            action_to_method = {"upload": "write-storage", "download": "read-storage"}
+            method = action_to_method[action]
             # action should be upload or download
             # return bool for authorization
             return self.check_authz(method)
@@ -796,14 +796,6 @@ class GoogleStorageIndexedFileLocation(IndexedFileLocation):
         )
         return final_url
 
-    def check_public(self, authz):
-        if "*" in authz or "/open" in authz:
-            return True
-        else:
-            # check if an anonymous user can access the file, if so, it's public
-            method = ACTION_TO_ARBORIST_METHOD["download"]
-            return self.check_authz(method, token="")
-
 
 def _get_user_info():
     """
@@ -841,3 +833,8 @@ def filter_auth_ids(action, list_auth_ids):
         if checked_permission in values:
             authorized_dbgaps.append(key)
     return authorized_dbgaps
+
+
+def check_public(self, authz):
+    if "*" in authz or "/open" in authz:
+        return True

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -367,7 +367,7 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        return check_public(self.authz)
+        return "*" in self.authz or "/open" in self.authz
 
     @login_required({"data"})
     def check_authorization(self, action):
@@ -829,8 +829,3 @@ def filter_auth_ids(action, list_auth_ids):
         if checked_permission in values:
             authorized_dbgaps.append(key)
     return authorized_dbgaps
-
-
-def check_public(authz):
-    if "*" in authz or "/open" in authz:
-        return True

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -365,7 +365,7 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        authz_resources = self.index_document.get("authz", []).extend(self.set_acls)
+        authz_resources = self.set_acls.extend(self.index_document.get("authz", []))
         return "*" in authz_resources or "/open" in authz_resources
 
     @login_required({"data"})

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -372,7 +372,7 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        return check_public(self.authz)
+        return self.check_public(self.authz)
 
     @login_required({"data"})
     def check_authorization(self, action):
@@ -796,6 +796,14 @@ class GoogleStorageIndexedFileLocation(IndexedFileLocation):
         )
         return final_url
 
+    def check_public(self, authz):
+        if "*" in authz or "/open" in authz:
+            return True
+        else:
+            # check if an anonymous user can access the file, if so, it's public
+            method = ACTION_TO_ARBORIST_METHOD["download"]
+            return self.check_authz(method, token="")
+
 
 def _get_user_info():
     """
@@ -833,12 +841,3 @@ def filter_auth_ids(action, list_auth_ids):
         if checked_permission in values:
             authorized_dbgaps.append(key)
     return authorized_dbgaps
-
-
-def check_public(authz):
-    if "*" in authz or "/open" in authz:
-        return True
-    else:
-        # check if an anonymous user can access the file, if so, it's public
-        method = ACTION_TO_ARBORIST_METHOD["download"]
-        return check_authz(method, token="")

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -365,7 +365,8 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        authz_resources = self.set_acls.extend(self.index_document.get("authz", []))
+        authz_resources = list(self.set_acls)
+        authz_resources.extend(self.index_document.get("authz", []))
         return "*" in authz_resources or "/open" in authz_resources
 
     @login_required({"data"})

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -44,7 +44,6 @@ ACTION_DICT = {
     "gs": {"upload": "PUT", "download": "GET"},
 }
 
-
 SUPPORTED_PROTOCOLS = ["s3", "http", "ftp", "https", "gs"]
 SUPPORTED_ACTIONS = ["upload", "download"]
 ANONYMOUS_USER_ID = "anonymous"
@@ -350,14 +349,11 @@ class IndexedFile(object):
         else:
             raise Unauthorized("This file is not accessible")
 
-    def check_authz(self, action, token=None):
-        if token is None:
-            token = get_jwt()
-
+    def check_authz(self, action):
         if not self.index_document.get("authz"):
             raise ValueError("index record missing `authz`")
 
-        request = {"user": {"token": token}, "requests": []}
+        request = {"user": {"token": get_jwt()}, "requests": []}
         for resource in self.index_document["authz"]:
             request["requests"].append(
                 {"resource": resource, "action": {"service": "fence", "method": action}}
@@ -371,7 +367,7 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        return self.check_public(self.authz)
+        return check_public(self.authz)
 
     @login_required({"data"})
     def check_authorization(self, action):
@@ -835,6 +831,6 @@ def filter_auth_ids(action, list_auth_ids):
     return authorized_dbgaps
 
 
-def check_public(self, authz):
+def check_public(authz):
     if "*" in authz or "/open" in authz:
         return True


### PR DESCRIPTION

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- fence will now consider authz field on indexd record to determine if a file is public or not (for different signed url behavior). previously only checked acl field

### Dependency updates


### Deployment changes

