### PR TITLE
fix(cfg): default for storage creds should be dictionary not list

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -374,8 +374,8 @@ dbGaP:
 #               access for users.
 # //////////////////////////////////////////////////////////////////////////////////////
 # Configuration for various storage systems for the backend
-# NOTE: Remove the [] and supply backends if needed. Example in comments below
-STORAGE_CREDENTIALS: []
+# NOTE: Remove the {} and supply backends if needed. Example in comments below
+STORAGE_CREDENTIALS: {}
 # Google Cloud Storage backend
 #
 #  'google':


### PR DESCRIPTION

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

