### PR TITLE
fix(bytestring): init Popen with text mode

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -110,6 +110,7 @@ def _read_file(filepath, encrypted=True, key=None, logger=None):
             stdin=open(filepath, "r"),
             stdout=sp.PIPE,
             stderr=open(os.devnull, "w"),
+            universal_newlines=True,
         )
         yield StringIO(p.communicate()[0])
     else:


### PR DESCRIPTION
`_read_file` in sync_users.py was crashing because [`subprocess.Popen`](https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen) was being initialized not in text mode, causing [`Popen.communicate`](https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen.communicate) to return a bytestring while StringIO() expects a string. So dbgap sync broke. 

### Bug Fixes
in usersync _read_file, init Popen with text mode so that output stream is string not bytestring

