### PR TITLE
fix(sync): dont overwrite top level fence project to arborist mapping

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -218,7 +218,8 @@ class UserYAML(object):
                     # if no resource or mapping, assume auth_id is resource
                     resource = project["auth_id"]
 
-                project_to_resource[project["auth_id"]] = resource
+                if project["auth_id"] not in project_to_resource:
+                    project_to_resource[project["auth_id"]] = resource
 
                 resource_permissions[resource] = set(project["privilege"])
             user_rbac[username] = resource_permissions


### PR DESCRIPTION

### New Features


### Breaking Changes


### Bug Fixes
- don't overwrite top-level user.yaml mapping for fence project to arborist resource if no resource path field in individual user projects

### Improvements


### Dependency updates


### Deployment changes

