### PR TITLE
[PXP-3384] fix(patch-sa): add all granting_project_ids

### DIFF
--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -492,7 +492,13 @@ def patch_user_service_account(
         session, project_access
     )
 
-    to_add = set.difference(granting_project_ids, accessed_project_ids)
+    # The cronjob doesn't clean out the entries in ServiceAccountAccessPrivilege,
+    # so the Google SA will get removed from the GBAG but this set diff will end up
+    # being empty. And so patching will not re-add the SA to the GBAG.
+    # This is a quick fix for PATCH, but I'm guessing we use set diff bc Google calls are slow.
+    # So probably we want the cronjob to correctly delete the relevant db entries.
+    #to_add = set.difference(granting_project_ids, accessed_project_ids)
+    to_add = granting_project_ids
     to_delete = set.difference(accessed_project_ids, granting_project_ids)
 
     _revoke_user_service_account_from_google(

--- a/tests/google/test_access_utils.py
+++ b/tests/google/test_access_utils.py
@@ -298,7 +298,7 @@ def test_update_user_service_account_success(cloud_manager, db_session, setup_da
     """
     (
         cloud_manager.return_value.__enter__.return_value.add_member_to_group.return_value
-    ) = {}
+    ) = {"email": "test@gmail.com"}
     (
         cloud_manager.return_value.__enter__.return_value.remove_member_from_group.return_value
     ) = {}
@@ -413,9 +413,10 @@ def test_update_user_service_account_success3(cloud_manager, db_session, setup_d
     )
     patch_user_service_account("test", "test@gmail.com", ["test_auth_1", "test_auth_2"])
 
-    assert not (
-        cloud_manager.return_value.__enter__.return_value.add_member_to_group.called
-    )
+    # No longer true as we are now adding to every project/GBAG every time
+    # assert not (
+    #    cloud_manager.return_value.__enter__.return_value.add_member_to_group.called
+    # )
 
     assert not (
         cloud_manager.return_value.__enter__.return_value.remove_member_from_group.called

--- a/tests/google/test_access_utils.py
+++ b/tests/google/test_access_utils.py
@@ -405,18 +405,16 @@ def test_update_user_service_account_success2(cloud_manager, db_session, setup_d
 def test_update_user_service_account_success3(cloud_manager, db_session, setup_data):
     """
     test@gmail.com has access to test_auth_1 and test_auth_2 already
-    Test that there is no add and delete operations when client try to update
+    Test that there are no delete operations when client try to update
     with projects already granted access
+    (This test used to also check that no Google-side add operations occurred
+    given the same situation, but this is no longer expected as we are now
+    adding SA to every project/GBAG every time--see #670)
     """
     service_account = (
         db_session.query(UserServiceAccount).filter_by(email="test@gmail.com").first()
     )
     patch_user_service_account("test", "test@gmail.com", ["test_auth_1", "test_auth_2"])
-
-    # No longer true as we are now adding to every project/GBAG every time
-    # assert not (
-    #    cloud_manager.return_value.__enter__.return_value.add_member_to_group.called
-    # )
 
     assert not (
         cloud_manager.return_value.__enter__.return_value.remove_member_from_group.called


### PR DESCRIPTION
The `google-delete-expired-service-account` job does not appear to clean out the entries in fence db's `service_account_access_privilege`, so the Google SA will get removed from the GBAG when the link expires, but in `patch_user_service_account()`, the set difference will be empty. Therefore the PATCH call will not re-add the SA to the GBAG. 

So use `granting_project_ids` instead of `to_add` when re-adding SAs to GBAGs. (But continue to use `to_add` in the fence db.) Update tests accordingly. 

### Bug Fixes
Re-add SAs to all GBAGs in PATCH endpoint
