### PR TITLE
feat(encode-url)

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -725,7 +725,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
 
 class GoogleStorageIndexedFileLocation(IndexedFileLocation):
     """
-    And indexed file that lives in a Google Storage bucket.
+    An indexed file that lives in a Google Storage bucket.
     """
 
     def get_signed_url(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ boto3>=1.5<1.6
 cached_property==1.5.1
 cdislogging>=1.0.0<2.0.0
 cdiserrors==0.1.2
-cdispyutils==1.0.1
+cdispyutils==1.0.2
 cryptography>=2.1.2<3.0
 datamodelutils==0.4.5
 Flask==0.12.4
@@ -16,7 +16,7 @@ Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 gen3config==0.1.7
-gen3cirrus==1.1.0
+gen3cirrus==1.1.1
 gen3users
 httplib2==0.10.3
 markdown==3.1.1


### PR DESCRIPTION
PXP-3646: encode spaces in file names in presigned URLs to follow [RFC 1738](https://www.ietf.org/rfc/rfc1738.txt)

https://github.com/uc-cdis/cdis-python-utils/pull/41
https://github.com/uc-cdis/cirrus/pull/74

### Improvements
- Special characters are encoded in presigned urls

### Dependency updates
- Bump cdispyutils to 1.0.2, cirrus to 1.1.1
