### PR TITLE
PXP-3717 Fix/token

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -312,6 +312,11 @@ MAX_API_KEY_TTL: 2592000
 # The number of seconds after an access token is issued until it expires.
 MAX_ACCESS_TOKEN_TTL: 3600
 
+# TEMPORARY: The maximum number of projects allowed in token claims.
+# This config var should be removed after sheepdog and peregrine support
+# auth checks against Arborist, and no longer check the token.
+TOKEN_PROJECTS_CUTOFF: 15
+
 
 ########################################################################################
 #                               OPTIONAL CONFIGURATIONS                                #

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -373,6 +373,21 @@ def generate_signed_access_token(
         "azp": client_id or "",
     }
 
+    # NOTE: "THIS IS A TERRIBLE STOP-GAP SOLUTION SO THAT USERS WITH
+    #       MINIMAL ACCESS CAN STILL USE LATEST VERSION OF FENCE
+    #       WITH VERSIONS OF PEREGRINE/SHEEPDOG THAT DO NOT CURENTLY
+    #       SUPPORT AUTHORIZATION CHECKS AGAINST ARBORIST (AND INSTEAD
+    #       RELY ON THE PROJECTS IN THE TOKEN). If the token is too large
+    #       everything breaks. I'm sorry" --See PXP-3717
+    if len(dict(user.project_access)) < config["TOKEN_PROJECTS_CUTOFF"]:
+        claims["context"]["user"]["projects"] = dict(user.project_access)
+    else:
+        logger.warn(
+            "NOT including project_access = {} in claims for user {} because there are too many projects for the token\n".format(
+                user.project_access, user.username
+            )
+        )
+
     # only add google linkage information if provided
     if linked_google_email:
         claims["context"]["user"]["google"][

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -382,7 +382,7 @@ def generate_signed_access_token(
     if len(dict(user.project_access)) < config["TOKEN_PROJECTS_CUTOFF"]:
         claims["context"]["user"]["projects"] = dict(user.project_access)
     else:
-        logger.warn(
+        logger.warning(
             "NOT including project_access = {} in claims for user {} because there are too many projects for the token\n".format(
                 user.project_access, user.username
             )


### PR DESCRIPTION
PXP-3717
take this hack for STAGE https://github.com/uc-cdis/fence/compare/fix/3.2.1.x#diff-7b2574a05fa5500b0a4b10b7b7f23fa0
but make number of projects configurable with default 15 and add log

### Bug Fixes
limit projects in token to avoid token being too large
