### PR TITLE
fix(token): actually rm projects from claims before check

### DIFF
--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -366,7 +366,6 @@ def generate_signed_access_token(
             "user": {
                 "name": user.username,
                 "is_admin": user.is_admin,
-                "projects": dict(user.project_access),
                 "google": {"proxy_group": user.google_proxy_group_id},
             }
         },


### PR DESCRIPTION
I messed up. Need to do this or else the whole `if len(dict(user.project_access)) < config["TOKEN_PROJECTS_CUTOFF"]` thing is pointless. Facepalm

Logically part of this PR  https://github.com/uc-cdis/fence/pull/677 