### PR TITLE
fix(upload): allow upload on existing record

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -335,6 +335,14 @@ class IndexedFile(object):
             except IndexError:
                 raise NotFound("Can't find any file locations.")
 
+        if action == "upload" and not self.index_document.get("urls"):
+            if protocol == "s3":
+                location = S3IndexedFileLocation(self.file_id)
+                return location.get_signed_url(
+                    action, expires_in, public_data=self.public,
+                    force_signed_url=force_signed_url,
+                )
+
         for file_location in self.indexed_file_locations:
             # allow file location to be https, even if they specific http
             if (file_location.protocol == protocol) or (

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -352,8 +352,8 @@ class IndexedFile(object):
                 config, "S3_BUCKETS", InternalError("buckets not configured")
             )
             try:
-                bucket = s3_buckets[0]
-            except IndexError:
+                bucket = next(iter(s3_buckets.keys()))
+            except StopIteration:
                 raise InternalError("buckets not configured")
             file_name = flask.request.args.get("file_name")
             url = "s3://{}/{}/{}".format(bucket, self.file_id, file_name)

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -335,12 +335,23 @@ class IndexedFile(object):
             except IndexError:
                 raise NotFound("Can't find any file locations.")
 
-        if action == "upload" and not self.index_document.get("urls"):
+        # can request to make a new URL using `create`
+        if (
+            action == "upload"
+            and not self.index_document.get("urls")
+            and "create" in flask.request.args
+        ):
             if protocol == "s3":
                 location = S3IndexedFileLocation(self.file_id)
                 return location.get_signed_url(
-                    action, expires_in, public_data=self.public,
+                    action,
+                    expires_in,
+                    public_data=self.public,
                     force_signed_url=force_signed_url,
+                )
+            else:
+                raise NotSupported(
+                    "protocol {} is not supported for these settings".format(protocol)
                 )
 
         for file_location in self.indexed_file_locations:


### PR DESCRIPTION
### Improvements

- Change data API to allow making a new S3 URL for an index record which already exists. (Mostly for internal/testing purposes.)
