### PR TITLE
fix(upsert): upsert policies

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1074,8 +1074,8 @@ class UserSyncer(object):
         policies = user_yaml.rbac.get("policies", [])
         for policy in policies:
             try:
-                response = self.arborist_client.create_policy(
-                    policy, skip_if_exists=True
+                response = self.arborist_client.update_policy(
+                    policy["id"], policy, create_if_not_exist=True
                 )
                 if response:
                     self._created_policies.add(policy["id"])
@@ -1190,14 +1190,15 @@ class UserSyncer(object):
                         policy_id = _format_policy_id(path, permission)
                         if policy_id not in self._created_policies:
                             try:
-                                self.arborist_client.create_policy(
+                                self.arborist_client.update_policy(
+                                    policy_id,
                                     {
                                         "id": policy_id,
                                         "description": "policy created by fence sync",
                                         "role_ids": [permission],
                                         "resource_paths": [path],
                                     },
-                                    skip_if_exists=True,
+                                    create_if_not_exist=True,
                                 )
                             except ArboristError as e:
                                 self.logger.info(

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-gen3authz==0.2.1
+gen3authz==0.2.2
 gen3config==0.1.7
 gen3cirrus==1.1.1
 gen3users

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -493,8 +493,8 @@ def test_blank_index_upload(app, client, auth_client, encoded_creds_jwt, user_cl
             }
         )
         data_requests.post.return_value.status_code = 200
-        arborist_requests.post.return_value = MockResponse({"auth": True})
-        arborist_requests.post.return_value.status_code = 200
+        arborist_requests.request.return_value = MockResponse({"auth": True})
+        arborist_requests.request.return_value.status_code = 200
         headers = {
             "Authorization": "Bearer " + encoded_creds_jwt.jwt,
             "Content-Type": "application/json",
@@ -755,8 +755,8 @@ def test_blank_index_upload_unauthorized(
     )
     with data_requests_mocker as data_requests, arborist_requests_mocker as arborist_requests:
         # pretend arborist says "no"
-        arborist_requests.post.return_value = MockResponse({"auth": False})
-        arborist_requests.post.return_value.status_code = 200
+        arborist_requests.request.return_value = MockResponse({"auth": False})
+        arborist_requests.request.return_value.status_code = 200
         headers = {
             "Authorization": "Bearer " + encoded_creds_jwt.jwt,
             "Content-Type": "application/json",
@@ -843,8 +843,8 @@ def test_initialize_multipart_upload(
             }
         )
         data_requests.post.return_value.status_code = 200
-        arborist_requests.post.return_value = MockResponse({"auth": True})
-        arborist_requests.post.return_value.status_code = 200
+        arborist_requests.request.return_value = MockResponse({"auth": True})
+        arborist_requests.request.return_value.status_code = 200
         fence.blueprints.data.indexd.BlankIndex.init_multipart_upload.return_value = (
             "test_uploadId"
         )
@@ -898,8 +898,8 @@ def test_multipart_upload_presigned_url(
             }
         )
         data_requests.post.return_value.status_code = 200
-        arborist_requests.post.return_value = MockResponse({"auth": True})
-        arborist_requests.post.return_value.status_code = 200
+        arborist_requests.request.return_value = MockResponse({"auth": True})
+        arborist_requests.request.return_value.status_code = 200
         fence.blueprints.data.indexd.BlankIndex.generate_aws_presigned_url_for_part.return_value = (
             "test_presigned"
         )
@@ -945,8 +945,8 @@ def test_multipart_complete_upload(
             }
         )
         data_requests.post.return_value.status_code = 200
-        arborist_requests.post.return_value = MockResponse({"auth": True})
-        arborist_requests.post.return_value.status_code = 200
+        arborist_requests.request.return_value = MockResponse({"auth": True})
+        arborist_requests.request.return_value.status_code = 200
         fence.blueprints.data.indexd.BlankIndex.generate_aws_presigned_url_for_part.return_value = (
             "test_presigned"
         )


### PR DESCRIPTION
Usersync needs to upsert policies, not create-and-skip-if-exist.
Therefore, in usersync, instead of create_policy, use update_policy with create_if_not_exist set to True
corrects #698 

also bump gen3authz to 0.2.2 and update mocks

### Bug Fixes
in usersync, upsert policies instead of create-and-skip-if-exist. corrects #698 

