### PR TITLE
chore(sec): update to only "security" updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,6 +5,9 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"
     default_reviewers:
       - "fantix"
       - "m0nhawk"


### PR DESCRIPTION
<!-- Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review. -->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Make DependaBot only update to "security" updates

### Dependency updates


### Deployment changes

