### PR TITLE
PXP-4641 Feat/username limit

### DIFF
--- a/fence/models.py
+++ b/fence/models.py
@@ -576,8 +576,6 @@ def migrate(driver):
             % (User.__tablename__, str(User.username.type))
         )
         with driver.session as session:
-            session.execute(to_timestamp)
-        with driver.session as session:
             session.execute(
                 'ALTER TABLE "{}" ALTER COLUMN username TYPE {};'.format(
                     User.__tablename__, str(User.username.type)

--- a/fence/models.py
+++ b/fence/models.py
@@ -567,6 +567,23 @@ def migrate(driver):
                 )
             )
 
+    # username limit migration
+
+    table = Table(User.__tablename__, md, autoload=True, autoload_with=driver.engine)
+    if str(table.c.username.type) != str(User.username.type):
+        print(
+            "Altering table %s column username type to %s"
+            % (User.__tablename__, str(User.username.type))
+        )
+        with driver.session as session:
+            session.execute(to_timestamp)
+        with driver.session as session:
+            session.execute(
+                'ALTER TABLE "{}" ALTER COLUMN username TYPE {};'.format(
+                    User.__tablename__, str(User.username.type)
+                )
+            )
+
     # oidc migration
 
     table = Table(Client.__tablename__, md, autoload=True, autoload_with=driver.engine)

--- a/fence/resources/google/validity.py
+++ b/fence/resources/google/validity.py
@@ -318,7 +318,10 @@ class GoogleProjectValidity(ValidityInfo):
         user_members = None
         service_account_members = []
         try:
-            user_members, service_account_members = get_google_project_valid_users_and_service_accounts(
+            (
+                user_members,
+                service_account_members,
+            ) = get_google_project_valid_users_and_service_accounts(
                 self.google_project_id, self.google_cloud_manager, membership=membership
             )
             self.set("valid_member_types", True)

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -191,7 +191,7 @@ def sync_users(
     """
     sync ACL files from dbGap to auth db and storage backends
     imports from config is done here because dbGap is
-    an optional requirment for fence so it might not be specified
+    an optional requirement for fence so it might not be specified
     in config
     Args:
         projects: path to project_mapping yaml file which contains mapping

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ setuptools==36.6.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
-git+https://github.com/uc-cdis/userdatamodel.git@7c4dc20fd2352dd256bc6db7df665c1bf7fc2c1c
+git+https://github.com/uc-cdis/userdatamodel.git@aad4a5100ebcf905c5fe21b4bc2d1e2a0a0cb62e
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ setuptools>=40.3.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
-git+https://github.com/uc-cdis/userdatamodel.git@aad4a5100ebcf905c5fe21b4bc2d1e2a0a0cb62e
+userdatamodel==2.2.0
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ setuptools==36.6.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
-git+https://github.com/uc-cdis/userdatamodel.git#feat/username-limit#egg=userdatamodel
+git+https://github.com/uc-cdis/userdatamodel.git@7c4dc20fd2352dd256bc6db7df665c1bf7fc2c1c
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ setuptools==36.6.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
-userdatamodel==2.1.1
+git+https://github.com/uc-cdis/userdatamodel.git#feat/username-limit#egg=userdatamodel
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pytest==3.2.3
 python_dateutil==2.6.1
 PyJWT==1.5.3
 requests>=2.18.0<3.0.0
-setuptools==36.6.0
+setuptools>=40.3.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0

--- a/tests/admin/test_admin_users_endpoints.py
+++ b/tests/admin/test_admin_users_endpoints.py
@@ -195,10 +195,13 @@ def test_get_user_long_username(
 ):
     """ GET /users/<username>: [get_user]: happy path """
     r = client.get(
-        "/admin/users/test_amazing_user_with_an_fancy_but_extremely_long_name", headers={"Authorization": "Bearer " + encoded_admin_jwt}
+        "/admin/users/test_amazing_user_with_an_fancy_but_extremely_long_name",
+        headers={"Authorization": "Bearer " + encoded_admin_jwt},
     )
     assert r.status_code == 200
-    assert r.json["username"] == "test_amazing_user_with_an_fancy_but_extremely_long_name"
+    assert (
+        r.json["username"] == "test_amazing_user_with_an_fancy_but_extremely_long_name"
+    )
 
 
 def test_get_user_username_nonexistent(
@@ -223,7 +226,13 @@ def test_get_user_username_noauth(client, db_session):
 
 
 def test_get_user(
-    client, admin_user, encoded_admin_jwt, db_session, test_user_a, test_user_b, test_user_long
+    client,
+    admin_user,
+    encoded_admin_jwt,
+    db_session,
+    test_user_a,
+    test_user_b,
+    test_user_long,
 ):
     """ GET /user: [get_all_users] """
     r = client.get(

--- a/tests/admin/test_admin_users_endpoints.py
+++ b/tests/admin/test_admin_users_endpoints.py
@@ -190,6 +190,17 @@ def test_get_user_username(
     assert r.json["username"] == "test_a"
 
 
+def test_get_user_long_username(
+    client, admin_user, encoded_admin_jwt, db_session, test_user_long
+):
+    """ GET /users/<username>: [get_user]: happy path """
+    r = client.get(
+        "/admin/users/test_amazing_user_with_an_fancy_but_extremely_long_name", headers={"Authorization": "Bearer " + encoded_admin_jwt}
+    )
+    assert r.status_code == 200
+    assert r.json["username"] == "test_amazing_user_with_an_fancy_but_extremely_long_name"
+
+
 def test_get_user_username_nonexistent(
     client, admin_user, encoded_admin_jwt, db_session
 ):
@@ -212,17 +223,18 @@ def test_get_user_username_noauth(client, db_session):
 
 
 def test_get_user(
-    client, admin_user, encoded_admin_jwt, db_session, test_user_a, test_user_b
+    client, admin_user, encoded_admin_jwt, db_session, test_user_a, test_user_b, test_user_long
 ):
     """ GET /user: [get_all_users] """
     r = client.get(
         "/admin/user", headers={"Authorization": "Bearer " + encoded_admin_jwt}
     )
     assert r.status_code == 200
-    assert len(r.json["users"]) == 3
+    assert len(r.json["users"]) == 4
     usernames = [user["name"] for user in r.json["users"]]
     assert "test_a" in usernames
     assert "test_b" in usernames
+    assert "test_amazing_user_with_an_fancy_but_extremely_long_name" in usernames
     assert "admin_user" in usernames
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,12 +301,22 @@ def test_user_b(db_session):
 
 @pytest.fixture(scope="function")
 def test_user_long(db_session):
-    test_user = db_session.query(models.User).filter_by(username="test_amazing_user_with_an_fancy_but_extremely_long_name").first()
+    test_user = (
+        db_session.query(models.User)
+        .filter_by(username="test_amazing_user_with_an_fancy_but_extremely_long_name")
+        .first()
+    )
     if not test_user:
-        test_user = models.User(username="test_amazing_user_with_an_fancy_but_extremely_long_name", is_admin=False)
+        test_user = models.User(
+            username="test_amazing_user_with_an_fancy_but_extremely_long_name",
+            is_admin=False,
+        )
         db_session.add(test_user)
         db_session.commit()
-    return Dict(username="test_amazing_user_with_an_fancy_but_extremely_long_name", user_id=test_user.id)
+    return Dict(
+        username="test_amazing_user_with_an_fancy_but_extremely_long_name",
+        user_id=test_user.id,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,16 @@ def test_user_b(db_session):
     return Dict(username="test_b", user_id=test_user.id)
 
 
+@pytest.fixture(scope="function")
+def test_user_long(db_session):
+    test_user = db_session.query(models.User).filter_by(username="test_amazing_user_with_an_fancy_but_extremely_long_name").first()
+    if not test_user:
+        test_user = models.User(username="test_amazing_user_with_an_fancy_but_extremely_long_name", is_admin=False)
+        db_session.add(test_user)
+        db_session.commit()
+    return Dict(username="test_amazing_user_with_an_fancy_but_extremely_long_name", user_id=test_user.id)
+
+
 @pytest.fixture(scope="session")
 def db(app, request):
     """

--- a/tests/google/test_validity_info.py
+++ b/tests/google/test_validity_info.py
@@ -454,7 +454,7 @@ def test_invalid_service_account_does_not_exist(valid_service_account_patcher):
 
 
 def test_invalid_service_account_does_not_exist_external_access(
-    valid_service_account_patcher
+    valid_service_account_patcher,
 ):
     """
     Test that when a Service Account that does not exist is requested


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4641

Lift up the length limit for username filed, which is causing issues now for users with long email addresses

Works with https://github.com/uc-cdis/userdatamodel/pull/66

### Improvements
- Lift length limit for username filed from 40 to 255 chars

### Dependency updates
- Bumps userdatamodel to 2.2.0
- Bumps setuptools to at least 40.3.0
