### PR TITLE
chore(error-msg): add hint in usersync error

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1056,7 +1056,7 @@ class UserSyncer(object):
             if not self.arborist_client:
                 raise EnvironmentError(
                     "yaml file contains authz section but sync is not configured with"
-                    " arborist client"
+                    " arborist client--did you run sync with --arborist <arborist client> arg?"
                 )
             self.logger.info("Synchronizing arborist...")
             success = self._update_arborist(sess, user_yaml)


### PR DESCRIPTION
Qingya has pointed out that the sync logs can be confusing because they say they are reading from config (which sync does, for cirrus config) but for usersync you can't specify the arborist client in the config, you need to pass in an `--arborist` arg 


### Improvements
add hint in usersync error about arborist client


