### PR TITLE
(PXP-4777) Feat/synapse userid

### DIFF
--- a/fence/blueprints/login/synapse.py
+++ b/fence/blueprints/login/synapse.py
@@ -26,7 +26,7 @@ class SynapseCallback(DefaultOAuth2Callback):
 
     def post_login(self, user, token_result):
         user.id_from_idp = token_result["sub"]
-        user.email = token_result["email_verified"]
+        user.email = token_result["email"]
         user.display_name = "{given_name} {family_name}".format(**token_result)
         info = {}
         if user.additional_info is not None:

--- a/fence/resources/openid/synapse_oauth2.py
+++ b/fence/resources/openid/synapse_oauth2.py
@@ -15,10 +15,9 @@ class SynapseOauth2Client(Oauth2ClientBase):
 
     """
 
-    REQUIRED_CLAIMS = {"given_name", "family_name", "email", "email_verified"}
+    REQUIRED_CLAIMS = {"given_name", "family_name", "email", "email_verified", "userid"}
     OPTIONAL_CLAIMS = {
         # "company",
-        # "userid",
         # "orcid",
         # "is_certified",
         # "is_validated",
@@ -125,7 +124,7 @@ class SynapseOauth2Client(Oauth2ClientBase):
                         return dict(error="Required claim {} not found".format(claim))
                 else:
                     rv[claim] = value
-            rv["fence_username"] = rv["email"] + " (via Synapse)"
+            rv["fence_username"] = rv["userid"] + " (via Synapse)"
             return rv
         except Exception as e:
             self.logger.exception("Can't get user info")

--- a/fence/resources/openid/synapse_oauth2.py
+++ b/fence/resources/openid/synapse_oauth2.py
@@ -124,7 +124,7 @@ class SynapseOauth2Client(Oauth2ClientBase):
                         return dict(error="Required claim {} not found".format(claim))
                 else:
                     rv[claim] = value
-            rv["fence_username"] = rv["userid"] + " (via Synapse)"
+            rv["fence_username"] = rv["userid"] + " (Synapse ID)"
             return rv
         except Exception as e:
             self.logger.exception("Can't get user info")


### PR DESCRIPTION
Minor changes for Synapse login (BRAIN Dream challenge)

### Bug Fixes
- Fixed an error causing Synapse users' email being incorrectly populated

### Improvements
- Request numerical `userid` from Synapse
-  Use `userid` from Synapse as part of username


