### PR TITLE
PXP-4872 Fix usersync access revoke

### DIFF
--- a/docs/usersync.md
+++ b/docs/usersync.md
@@ -1,12 +1,12 @@
 # Usersync
 
-Usersync is a script that parses user access information from multiple sources (user.yaml files, dbGaP user authorization telemetry files AKA whitelists) and keeps users' access to Gen3 resources up to date by updating the Fence and Arborist databases.
+Usersync is a script that parses user access information from multiple sources (user.yaml files, dbGaP user authorization "telemetry" files AKA whitelists) and keeps users' access to Gen3 resources up to date by updating the Fence and Arborist databases.
 
 ## Usersync flow
 
 ![Usersync Flow](images/usersync.png)
 
-> Note that at the time of writing, the user.yaml file overrides the access obtained from the telemetry files. In the future, usersync will combine the access instead.
+> Note that at the time of writing, the user.yaml file overrides the access obtained from the dbGaP authorization files. In the future, usersync will combine the access instead.
 
 ## Usersync result example
 
@@ -125,7 +125,7 @@ users:
 ```
 </details>
 
-### Example of telemetry file (CSV format):
+### Example of dbGaP authorization file (CSV format):
 
 ```
 user name, login, authority, role, email, phone, status, phsid, permission set, created
@@ -135,7 +135,7 @@ Mrs. GHI,GHI,eRA,PI,ghi@com,"123-456-789",active,phs3.v2.p3.c4,"General Research
 
 Usersync gives users "read" and "read-storage" permissions to the dbGaP studies.
 
-> Note: The dbGaP telemetry files contain consent codes that can be parsed by usersync: [more details here](dbgap_info.md). This simplified example does not include consent code parsing.
+> Note: The dbGaP authorization files contain consent codes that can be parsed by usersync: [more details here](dbgap_info.md). This simplified example does not include consent code parsing.
 
 ### Resulting access:
 
@@ -148,9 +148,9 @@ Usersync gives users "read" and "read-storage" permissions to the dbGaP studies.
   - /open: read + read-storage
   - /programs/phs1: read
   - /programs/phs2: read
-  - /programs/phs3: read + read-storage _(from the telemetry file)_
+  - /programs/phs3: read + read-storage _(from the dbGaP authorization file)_
 - user GHI:
-  - /programs/phs3: create _(user.yaml access overrides telemetry file access)_
+  - /programs/phs3: read + read-storage + create _(user.yaml access combined with dbGaP authorization file access)_
 
 ## Validation
 

--- a/docs/usersync.md
+++ b/docs/usersync.md
@@ -6,7 +6,7 @@ Usersync is a script that parses user access information from multiple sources (
 
 ![Usersync Flow](images/usersync.png)
 
-> Note that at the time of writing, the user.yaml file overrides the access obtained from the dbGaP authorization files. In the future, usersync will combine the access instead.
+> The access from the user.yaml file and the dbGaP authorization files is combined (see example below), but the user.yaml file overrides the user information (such as email) obtained from the dbGaP authorization files.
 
 ## Usersync result example
 

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1226,7 +1226,8 @@ class UserSyncer(object):
             try:
                 response = self.arborist_client.put_group(
                     group["name"],
-                    description=group.get("description", ""),
+                    # Arborist doesn't handle group descriptions yet
+                    # description=group.get("description", ""),
                     users=group["users"],
                     policies=group["policies"],
                 )

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1210,8 +1210,11 @@ class UserSyncer(object):
 
         # delete from arborist the groups that have been deleted
         # from the user.yaml
-        current_groups = set(self.arborist_client.list_groups())
-        for deleted_group in current_groups.difference(set(g["name"] for g in groups)):
+        current_group_names = set(
+            g["name"] for g in self.arborist_client.list_groups().get("groups", [])
+        )
+        useryaml_group_names = set(g["name"] for g in groups)
+        for deleted_group in current_group_names.difference(useryaml_group_names):
             self.arborist_client.delete_group(deleted_group)
 
         # create/update the groups defined in the user.yaml

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1210,12 +1210,14 @@ class UserSyncer(object):
 
         # delete from arborist the groups that have been deleted
         # from the user.yaml
-        current_group_names = set(
+        arborist_groups = set(
             g["name"] for g in self.arborist_client.list_groups().get("groups", [])
         )
-        useryaml_group_names = set(g["name"] for g in groups)
-        for deleted_group in current_group_names.difference(useryaml_group_names):
-            self.arborist_client.delete_group(deleted_group)
+        useryaml_groups = set(g["name"] for g in groups)
+        for deleted_group in arborist_groups.difference(useryaml_groups):
+            # do not try to delete built in groups
+            if deleted_group not in ["anonymous", "logged-in"]:
+                self.arborist_client.delete_group(deleted_group)
 
         # create/update the groups defined in the user.yaml
         for group in groups:

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -571,13 +571,15 @@ class UserSyncer(object):
     @staticmethod
     def sync_two_user_info_dict(user_info1, user_info2):
         """
-        Merge user_info1 into user_info2, which are both nested dicts like:
-
-            {username: {'email': 'abc@email.com'}}
+        Merge user_info1 into user_info2. Values in user_info2 are overriden
+        by values in user_info1. user_info2 ends up containing the merged dict.
 
         Args:
-            user_info1 (dict)
-            user_info2 (dict)
+            user_info1 (dict): nested dict
+            user_info2 (dict): nested dict
+
+            Example:
+            {username: {'email': 'abc@email.com'}}
 
         Returns:
             None
@@ -587,11 +589,13 @@ class UserSyncer(object):
     @staticmethod
     def sync_two_phsids_dict(phsids1, phsids2):
         """
-        Merge pshid1 into phsids2
+        Merge pshid1 into phsids2. phsids2 ends up containing the merged dict
+        (see explanation below).
 
         Args:
             phsids1, phsids2: nested dicts mapping phsids to sets of permissions
 
+            Example:
             {
                 username: {
                     phsid1: {'read-storage','write-storage'},
@@ -1033,18 +1037,25 @@ class UserSyncer(object):
             key.lower(): value for key, value in user_yaml.projects.items()
         }
 
-        self.sync_two_phsids_dict(user_projects_csv, user_projects)
+        # merge all user info dicts into "user_info".
+        # the user info (such as email) in the user.yaml files
+        # overrides the user info from the CSV files.
         self.sync_two_user_info_dict(user_info_csv, user_info)
-
-        # privileges in yaml files overide ones in csv files
-        self.sync_two_phsids_dict(user_yaml.projects, user_projects)
         self.sync_two_user_info_dict(user_yaml.user_info, user_info)
+
+        # merge all access info dicts into "user_projects".
+        # the access info is combined - if the user.yaml access is
+        # ["read"] and the CSV file access is ["read-storage"], the
+        # resulting access is ["read", "read-storage"].
+        self.sync_two_phsids_dict(user_projects_csv, user_projects)
+        self.sync_two_phsids_dict(user_yaml.projects, user_projects)
 
         if self.parse_consent_code:
             self._grant_all_consents_to_c999_users(
                 user_projects, user_yaml.project_to_resource
             )
 
+        # update the Fence DB
         if user_projects:
             self.logger.info("Sync to db and storage backend")
             self.sync_to_db_and_storage_backend(user_projects, user_info, sess)
@@ -1052,6 +1063,7 @@ class UserSyncer(object):
         else:
             self.logger.info("No users for syncing")
 
+        # update the Arborist DB (resources, roles, policies, groups)
         if user_yaml.authz:
             if not self.arborist_client:
                 raise EnvironmentError(
@@ -1066,8 +1078,9 @@ class UserSyncer(object):
                 self.logger.error("Could not synchronize successfully")
                 exit(1)
         else:
-            self.logger.info("No resources specified; skipping arborist sync")
+            self.logger.info("No `authz` section; skipping arborist sync")
 
+        # update the Arborist DB (user access)
         if self.arborist_client:
             self.logger.info("Synchronizing arborist with authorization info...")
             success = self._update_authz_in_arborist(sess, user_projects, user_yaml)
@@ -1178,6 +1191,7 @@ class UserSyncer(object):
                 self.logger.error(e)
                 # keep going; maybe just some conflicts from things existing already
 
+        # update roles
         roles = user_yaml.authz.get("roles", [])
         for role in roles:
             try:
@@ -1188,6 +1202,7 @@ class UserSyncer(object):
                 self.logger.error(e)
                 # keep going; maybe just some conflicts from things existing already
 
+        # update policies
         policies = user_yaml.authz.get("policies", [])
         for policy in policies:
             policy_id = policy.pop("id")
@@ -1206,6 +1221,7 @@ class UserSyncer(object):
                     self.logger.debug("Upserted policy with id {}".format(policy_id))
                     self._created_policies.add(policy_id)
 
+        # update groups
         groups = user_yaml.authz.get("groups", [])
 
         # delete from arborist the groups that have been deleted

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1207,6 +1207,14 @@ class UserSyncer(object):
                     self._created_policies.add(policy_id)
 
         groups = user_yaml.authz.get("groups", [])
+
+        # delete from arborist the groups that have been deleted
+        # from the user.yaml
+        current_groups = set(self.arborist_client.list_groups())
+        for deleted_group in current_groups.difference(set(g["name"] for g in groups)):
+            self.arborist_client.delete_group(deleted_group)
+
+        # create/update the groups defined in the user.yaml
         for group in groups:
             missing = {"name", "users", "policies"}.difference(set(group.keys()))
             if missing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,7 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-# gen3authz==0.3.0
-git+https://github.com/uc-cdis/gen3authz.git@feat/delete-group#egg=gen3authz&subdirectory=python
+gen3authz==0.3.0
 gen3config==0.1.7
 gen3cirrus==1.1.2
 gen3users

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-# gen3authz==0.2.3
-git+https://github.com/uc-cdis/gen3authz.git@feat/delete-group#egg=gen3authz
+# gen3authz==0.3.0
+git+https://github.com/uc-cdis/gen3authz.git@feat/delete-group#egg=gen3authz&subdirectory=python
 gen3config==0.1.7
 gen3cirrus==1.1.2
 gen3users

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4
 flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
-gen3authz==0.2.3
+# gen3authz==0.2.3
+git+https://github.com/uc-cdis/gen3authz.git@feat/delete-group#egg=gen3authz
 gen3config==0.1.7
 gen3cirrus==1.1.2
 gen3users

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "Flask-CORS>=3.0.3,<4.0.0",
         "Flask_OAuthlib>=0.9.4,<1.0.0",
         "Flask_SQLAlchemy_Session>=1.1,<2.0",
-        "gen3authz>=0.2.0,<0.3.0",
+        "gen3authz>=0.3.0,<0.4.0",
         "gen3cirrus>=1.1.0,<2.0",
         "gen3config>=0.1.6,<1.0.0",
         "google_api_python_client>=1.6.4,<2.0.0",

--- a/tests/dbgap_sync/test_user_sync.py
+++ b/tests/dbgap_sync/test_user_sync.py
@@ -383,7 +383,7 @@ def test_sync_two_phsids_dict(syncer, db_session, storage_client):
 
 
 @pytest.mark.parametrize("syncer", ["google", "cleversafe"], indirect=True)
-def test_sync_two_phsids_dict_override(syncer, db_session, storage_client):
+def test_sync_two_phsids_dict_combine(syncer, db_session, storage_client):
     phsids1 = {
         "userA": {
             "phs000178": {"read", "read-storage"},


### PR DESCRIPTION
addresses the following:
- make sure access is revoked when a group is deleted from the user.yaml -> delete all groups that are in the arborist DB but not in the user.yaml
- when a resource is renamed in the user.yaml, the old resource doesn't get deleted and users could still have access to it (e.g. user has access to `/A` and we renamed `/A/B` to `/A/C`) -> can only be reproduced by renaming **top-level** resources, because the "PUT resource" does its job of overriding all the subresources. So users could not still have access to it (the validation check makes sure the resource paths users have access to exist). We can still delete all obsolete resources in the future to clean up the DB but i didn't do it here
- project access in the user.yaml overrides project access in the dbGaP files, but it should combine access instead -> comments that say "override" in the fence code created confusion, but in reality the access is already combined (there is a unit test that checks that). I updated/added comments
- disable the option of adding a description to a group because Arborist doesn't allow that

relates to https://github.com/uc-cdis/gen3authz/pull/26

### Bug Fixes
- Do not allow specifying descriptions for groups

### Improvements
- Properly revoke access given to users in a group when the group is deleted

### Dependency updates
- gen3authz to 0.3.0

