### PR TITLE
feat(userinfo): add google primary service account email to userinfo …

### DIFF
--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -91,7 +91,7 @@ def get_user_info(current_session, username):
         "message": "",
     }
 
-    # Note that client_id is None, which is how we store the user's SA
+    # User SAs are stored in db with client_id = None
     primary_service_account = get_service_account(client_id=None, user_id=user.id) or {}
     primary_service_account_email = getattr(primary_service_account, "email", None)
     info["primary_google_service_account"] = primary_service_account_email

--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -90,6 +90,11 @@ def get_user_info(current_session, username):
         "message": "",
     }
 
+    # Note that client_id is None, which is how we store the user's SA
+    primary_service_account = get_service_account(client_id=None, user_id=user.id) or {}
+    primary_service_account_email = getattr(primary_service_account, "email", None)
+    info["primary_google_service_account"] = primary_service_account_email
+
     if hasattr(flask.current_app, "arborist"):
         try:
             resources = flask.current_app.arborist.list_resources_for_user(

--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -10,6 +10,7 @@ from fence.resources import userdatamodel as udm
 from fence.resources.google.utils import (
     get_linked_google_account_email,
     get_linked_google_account_exp,
+    get_service_account,
 )
 from fence.resources.userdatamodel import get_user_groups
 import smtplib

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -46,11 +46,11 @@ paths:
         - oauth2
       summary: Perform OAuth2 authorization
       description: |
-        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard 
+        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
         simply because of its length and complexity.
-        
+
         Please [refer to the standard](https://openid.net/specs/openid-connect-core-1_0.html) for complete details.
-        
+
         Obtain an authorization grant through the OAuth2 protocol. To handle
         this request, render a page for the user to confirm the OAuth2 grant
         (through e.g. Google). Redirect user to `redirect_uri` with an added
@@ -114,11 +114,11 @@ paths:
         - oauth2
       summary: Perform OAuth2 authorization
       description: |
-        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard 
+        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
         simply because of its length and complexity.
-        
+
         Please [refer to the standard](https://openid.net/specs/openid-connect-core-1_0.html) for complete details.
-        
+
         Obtain an authorization grant through the OAuth2 protocol. To handle
         this request, render a page for the user to confirm the OAuth2 grant
         (through e.g. Google). Redirect user to `redirect_uri` with an added
@@ -166,11 +166,11 @@ paths:
         - oauth2
       summary: Exchange code for or refresh the access token.
       description: |
-        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard 
+        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
         simply because of its length and complexity.
-        
+
         Please [refer to the standard](https://openid.net/specs/openid-connect-core-1_0.html) for complete details.
-        
+
         Exchange the `code` obtained from OAuth2 for an access token, or refresh
         the access token using a refresh token.
       operationId: token
@@ -841,7 +841,7 @@ paths:
       summary: Receive API key
       description: >-
         Get a new API key for the current user. API keys can be used to retrieve
-        access tokens which will allow for authed communication to our API. Can 
+        access tokens which will allow for authed communication to our API. Can
         pass a list of requested OIDC scopes in the body. Automatically gives "openid" scope.
         Any additional scopes (like "user" for seeing user information or "data" for hitting
         signed url endpoint) must be explicitly requested and user must already have access.
@@ -1980,6 +1980,7 @@ components:
         - certificates_uploaded
         - email
         - message
+        - primary_google_service_account
       properties:
         pdc_id:
           type: string
@@ -2003,6 +2004,9 @@ components:
           description: ''
         message:
           type: string
+        primary_google_service_account:
+          type: string
+          description: 'email address of the users primary service account used for signing URLs'
     SignedURL:
       type: object
       properties:


### PR DESCRIPTION
…for requester pays support

### New Features
- added `google_primary_service_account` email to userinfo endpoint (to support Google requester pays buckets, need to know email of service account that signed the url)

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

