### PR TITLE
fix(httplib2): httplib2>=0.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gen3authz==0.4.0
 gen3config==0.1.7
 gen3cirrus==1.1.2
 gen3users
-httplib2==0.10.3
+httplib2==0.17.0
 markdown==3.1.1
 python-jose==2.0.2
 oauthlib==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "gen3cirrus>=1.1.0,<2.0",
         "gen3config>=0.1.6,<1.0.0",
         "google_api_python_client>=1.6.4,<2.0.0",
-        "httplib2>=0.10.3,<1.0.0",
+        "httplib2>=0.17.0,<1.0.0",
         "markdown>=3.1.1,<4.0.0",
         "python-jose>=2.0.0,<3.0.0",
         "oauthlib>=3.0.0,<4.0.0",


### PR DESCRIPTION
Fix build error: httplib2 0.10.3 is installed but httplib2<1dev,>=0.17.0 is required by {'google-api-python-client'}

### Dependency updates
- httplib2 to 0.17.0
