### PR TITLE
fix(init): don't try to use boto if it doesn't exist

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -214,7 +214,7 @@ def _check_s3_buckets(app):
                         "bucket regions."
                     )
                     return
-                
+
                 region = app.boto.get_bucket_region(bucket_name, credential)
                 config["S3_BUCKETS"][bucket_name]["region"] = region
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -207,6 +207,14 @@ def _check_s3_buckets(app):
                     config.get("MAX_PRESIGNED_URL_TTL", 3600),
                     app.boto,
                 )
+                if not getattr(app, "boto"):
+                    logger.warning(
+                        "WARNING: boto not setup for app, probably b/c "
+                        "nothing in AWS_CREDENTIALS. Cannot attempt to get bucket "
+                        "bucket regions."
+                    )
+                    return
+                
                 region = app.boto.get_bucket_region(bucket_name, credential)
                 config["S3_BUCKETS"][bucket_name]["region"] = region
 


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
- when AWS_CREDENTIALS cfg is gone, was trying to use boto when it wasn't setup causing an exception

### Improvements


### Dependency updates


### Deployment changes

