### PR TITLE
fix(qa): Pin cryptography-2.8 to avoid bug with openssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cached_property==1.5.1
 cdislogging>=1.0.0<2.0.0
 cdiserrors==0.1.2
 cdispyutils==1.0.3
-cryptography==2.8
+cryptography>=2.1.2<=2.8
 datamodelutils==0.4.5
 Flask==1.1.1
 Flask-CORS==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cached_property==1.5.1
 cdislogging>=1.0.0<2.0.0
 cdiserrors==0.1.2
 cdispyutils==1.0.3
-cryptography>=2.1.2<3.0
+cryptography>=2.1.2<=2.8
 datamodelutils==0.4.5
 Flask==1.1.1
 Flask-CORS==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cached_property==1.5.1
 cdislogging>=1.0.0<2.0.0
 cdiserrors==0.1.2
 cdispyutils==1.0.3
-cryptography>=2.1.2<=2.8
+cryptography==2.8
 datamodelutils==0.4.5
 Flask==1.1.1
 Flask-CORS==3.0.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "botocore>=1.7,<1.9.0",
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
-        "cryptography>=2.1.2<=2.8",
+        "cryptography==2.8",
         "flask-restful>=0.3.6,<1.0.0",
         "Flask>=1.1.1,<2.0.0",
         "Flask-CORS>=3.0.3,<4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "botocore>=1.7,<1.9.0",
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
-        "cryptography>=2.1.2<3.0",
+        "cryptography>=2.1.2<=2.8",
         "flask-restful>=0.3.6,<1.0.0",
         "Flask>=1.1.1,<2.0.0",
         "Flask-CORS>=3.0.3,<4.0.0",


### PR DESCRIPTION
Fence :2020.04 images are failing to produce OIDC client credentials. It throws the following error:
```
Error during connection setup: Error relocating /usr/lib/python3.6/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so: SSLv3_client_method: symbol not found (retrying in 3 seconds)
```

### Bug Fixes
Pinning cryptography 2.8 as this bug only seem to manifest itself with 2.9.