### PR TITLE
PXP-5867 Update OIDC endpoints in swagger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@chore/skip_tests_for_swagger_doc_updates') _
+@Library('cdis-jenkins-lib@master') _
 
 testPipeline {
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('cdis-jenkins-lib@master') _
+@Library('cdis-jenkins-lib@chore/skip_tests_for_swagger_doc_updates') _
 
-testPipeline { 
+testPipeline {
 }

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -6,7 +6,7 @@ info:
   title: Fence OpenAPI Specification
   version: 0.1.0
   description: >-
-    Access management for CDIS data commons. Code is available on
+    Access management for Gen3 data commons. Code is available on
     [GitHub](https://github.com/uc-cdis/fence).
   termsOfService: 'http://cdis.uchicago.edu/terms/'
   contact:
@@ -305,6 +305,11 @@ paths:
       tags:
         - user
       summary: Return info about the current user
+      description: |
+      **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
+        simply because of its length and complexity.
+
+        Please [refer to the standard](https://openid.net/specs/openid-connect-core-1_0.html) for complete details.
       security:
         - OAuth2:
             - user
@@ -1975,40 +1980,69 @@ components:
     UserInfo:
       type: object
       required:
-        - pdc_id
+        - user_id
+        - sub
         - username
-        - resources_granted
+        - name
+        - display_name
+        - preferred_username
+        - phone_number
+        - email
+        - is_admin
+        - role
         - project_access
         - certificates_uploaded
-        - email
+        - resources_granted
+        - groups
         - message
-        - primary_google_service_account
       properties:
-        pdc_id:
+        user_id:
+          type: string
+          description: 'This value is deprecated in favor of sub.'
+        sub:
           type: string
         username:
           type: string
+          description: 'This value is deprecated in favor of name.'
+        name:
+          type: string
+          description: 'The full name of the end-user.'
+        display_name:
+          type: string
+          description: 'The display name of the end-user.'
+        preferred_username:
+          type: string
+          description: 'The preferred username of the end-user.'
+        phone_number:
+          type: string
+          description: 'The phone number of the end-user.'
+        email:
+          type: string
+          description: 'The email of the end-user'
+        is_admin:
+          type: boolean
+          description: 'Boolean value stating if end-user is an admin or not'
+        role:
+          type: string
           description: ''
-        resources_granted:
-          type: array
-          items:
-            type: string
         project_access:
           type: object
-          additionalProperties:
-            type: string
+          description: ''
         certificates_uploaded:
           type: array
           items:
             type: string
-        email:
-          type: string
-          description: ''
+        resources_granted:
+          type: array
+          items:
+            type: string
+        groups:
+          type: object
         message:
           type: string
-        primary_google_service_account:
+        azp:
           type: string
-          description: 'email address of the users primary service account used for signing URLs'
+          description: 'authorized party - the party to which the ID token was issued.'
     SignedURL:
       type: object
       properties:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -2044,7 +2044,7 @@ components:
           description: ''
         project_access:
           type: object
-          description: ''
+          description: 'dictionary mapping of project name to list of permissions'
         certificates_uploaded:
           type: array
           items:
@@ -2064,7 +2064,7 @@ components:
           description: 'email address of the users primary service account used for signing URLs'
         authz:
           type: object
-          description: 'end user authorization information'
+          description: 'end user authorization information, mapping of resource name to list of permission, service roles'
         resources:
           type: array
           items:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1457,6 +1457,22 @@ paths:
               schema:
                 type: string
                 example: "<h1>Gen3 Privacy Policy</h1> ..."
+  /.well-known/openid-configuration:
+    get:
+      tags:
+        - OIDC
+      summary: Get the OpenID Provider Configuration Document
+      description: >-
+        See [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) for detailed
+        specification and an [example
+        response](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse).
+      responses:
+        '200':
+          description: OpenID Configuration
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/OpenIDConfiguration'
 components:
   requestBodies:
     APIKey:
@@ -2103,3 +2119,105 @@ components:
       example:
         error: error_name
         error_description: A description of what caused the error
+      OpenIDConfiguration:
+        type: object
+        required:
+          - issuer
+          - authorization_endpoint
+          - jwks_uri
+          - response_types_supported
+        properties:
+          authorization_endpoint:
+            type: string
+          claim_types_supported:
+            type: array
+            items:
+              type: string
+          claims_locales_supported:
+            type: array
+            items:
+              type: string
+          claims_parameter_supported:
+            type: boolean
+          claims_supported:
+            type: array
+            items:
+              type: string
+          display_values_supported:
+            type: array
+            items:
+              type: string
+          grant_types_supported:
+            type: array
+            items:
+              type: string
+          id_token_encryption_alg_values_supported:
+            type: array
+            items:
+              type: string
+          id_token_encryption_enc_values_supported:
+            type: array
+            items:
+              type: string
+          id_token_signing_alg_values_supported:
+            type: array
+            items:
+              type: string
+          issuer:
+            type: string
+          jwks_uri:
+            type: string
+          op_policy_url:
+            type: string
+          op_tos_uri:
+            type: string
+          registration_endpoint:
+            type: string
+          request_object_encryption_alg_values_supported:
+            type: array
+            items:
+              type: string
+          request_object_encryption_enc_values_supported:
+            type: array
+            items:
+              type: string
+          request_object_signing_alg_values_supported:
+            type: array
+            items:
+              type: string
+          request_parameter_supported:
+            type: boolean
+          request_uri_parameter_supported:
+            type: boolean
+          require_request_uri_registration:
+            type: boolean
+          response_modes_supported:
+            type: array
+            items:
+              type: string
+          response_types_supported:
+            type: array
+            items:
+              type: string
+          scopes_supported:
+            type: array
+            items:
+              type: string
+          service_documentation:
+            type: string
+          subject_types_supported:
+            type: array
+            items:
+              type: string
+          token_endpoint:
+            type: string
+          token_endpoint_auth_methods_supported:
+            type: array
+            items:
+              type: string
+          ui_locales_supported:
+            type: array
+            items:
+              type: string
+          userinfo_endpoint:
+            type: string

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -305,8 +305,8 @@ paths:
       tags:
         - user
       summary: Return info about the current user
-      description: |
-      **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
+      description: >-
+        **IMPORTANT NOTE**: These docs are provided as a courtesy but do _NOT_ include the entirety of the OIDC Standard
         simply because of its length and complexity.
 
         Please [refer to the standard](https://openid.net/specs/openid-connect-core-1_0.html) for complete details.

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1997,10 +1997,11 @@ components:
         - message
       properties:
         user_id:
-          type: string
+          type: number
           description: 'This value is deprecated in favor of sub.'
         sub:
           type: string
+          description: 'Subject Identifier. A locally unique and never reassigned identifier within the Issuer for the end-user.'
         username:
           type: string
           description: 'This value is deprecated in favor of name.'
@@ -2037,9 +2038,24 @@ components:
           items:
             type: string
         groups:
-          type: object
+          type: array
+          items:
+            type: string
         message:
           type: string
+        primary_google_service_account:
+          type: string
+          description: 'email address of the users primary service account used for signing URLs'
+        authz:
+          type: object
+          description: 'end user authorization information'
+        resources:
+          type: array
+          items:
+            type: string
+          description: 'list of resource paths the user has access to'
+        tags:
+          type: object
         azp:
           type: string
           description: 'authorized party - the party to which the ID token was issued.'

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -2119,105 +2119,105 @@ components:
       example:
         error: error_name
         error_description: A description of what caused the error
-      OpenIDConfiguration:
-        type: object
-        required:
-          - issuer
-          - authorization_endpoint
-          - jwks_uri
-          - response_types_supported
-        properties:
-          authorization_endpoint:
+    OpenIDConfiguration:
+      type: object
+      required:
+        - issuer
+        - authorization_endpoint
+        - jwks_uri
+        - response_types_supported
+      properties:
+        authorization_endpoint:
+          type: string
+        claim_types_supported:
+          type: array
+          items:
             type: string
-          claim_types_supported:
-            type: array
-            items:
-              type: string
-          claims_locales_supported:
-            type: array
-            items:
-              type: string
-          claims_parameter_supported:
-            type: boolean
-          claims_supported:
-            type: array
-            items:
-              type: string
-          display_values_supported:
-            type: array
-            items:
-              type: string
-          grant_types_supported:
-            type: array
-            items:
-              type: string
-          id_token_encryption_alg_values_supported:
-            type: array
-            items:
-              type: string
-          id_token_encryption_enc_values_supported:
-            type: array
-            items:
-              type: string
-          id_token_signing_alg_values_supported:
-            type: array
-            items:
-              type: string
-          issuer:
+        claims_locales_supported:
+          type: array
+          items:
             type: string
-          jwks_uri:
+        claims_parameter_supported:
+          type: boolean
+        claims_supported:
+          type: array
+          items:
             type: string
-          op_policy_url:
+        display_values_supported:
+          type: array
+          items:
             type: string
-          op_tos_uri:
+        grant_types_supported:
+          type: array
+          items:
             type: string
-          registration_endpoint:
+        id_token_encryption_alg_values_supported:
+          type: array
+          items:
             type: string
-          request_object_encryption_alg_values_supported:
-            type: array
-            items:
-              type: string
-          request_object_encryption_enc_values_supported:
-            type: array
-            items:
-              type: string
-          request_object_signing_alg_values_supported:
-            type: array
-            items:
-              type: string
-          request_parameter_supported:
-            type: boolean
-          request_uri_parameter_supported:
-            type: boolean
-          require_request_uri_registration:
-            type: boolean
-          response_modes_supported:
-            type: array
-            items:
-              type: string
-          response_types_supported:
-            type: array
-            items:
-              type: string
-          scopes_supported:
-            type: array
-            items:
-              type: string
-          service_documentation:
+        id_token_encryption_enc_values_supported:
+          type: array
+          items:
             type: string
-          subject_types_supported:
-            type: array
-            items:
-              type: string
-          token_endpoint:
+        id_token_signing_alg_values_supported:
+          type: array
+          items:
             type: string
-          token_endpoint_auth_methods_supported:
-            type: array
-            items:
-              type: string
-          ui_locales_supported:
-            type: array
-            items:
-              type: string
-          userinfo_endpoint:
+        issuer:
+          type: string
+        jwks_uri:
+          type: string
+        op_policy_url:
+          type: string
+        op_tos_uri:
+          type: string
+        registration_endpoint:
+          type: string
+        request_object_encryption_alg_values_supported:
+          type: array
+          items:
             type: string
+        request_object_encryption_enc_values_supported:
+          type: array
+          items:
+            type: string
+        request_object_signing_alg_values_supported:
+          type: array
+          items:
+            type: string
+        request_parameter_supported:
+          type: boolean
+        request_uri_parameter_supported:
+          type: boolean
+        require_request_uri_registration:
+          type: boolean
+        response_modes_supported:
+          type: array
+          items:
+            type: string
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        scopes_supported:
+          type: array
+          items:
+            type: string
+        service_documentation:
+          type: string
+        subject_types_supported:
+          type: array
+          items:
+            type: string
+        token_endpoint:
+          type: string
+        token_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        ui_locales_supported:
+          type: array
+          items:
+            type: string
+        userinfo_endpoint:
+          type: string


### PR DESCRIPTION
Updated Swagger Docs for `/user` endpoint and added information about `/.well-known/openid-configuration`

Would probably be easier to review / look at in swagger http://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/fence/chore/update-swagger/openapis/swagger.yaml

I didn't include too much detail on the fields in either of these endpoints as they are pretty standard in OIDC and users should refer to the OIDC spec for additional information.

### Breaking Changes
None

### Bug Fixes
Fix docs

### Improvements
Updated documentation to reflect Fence API behavior


