### PR TITLE
fix(public-region): do not check region for public s3 bucket

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -173,7 +173,7 @@ def app_register_blueprints(app):
 def _check_s3_buckets(app):
     """
     Function to ensure that all s3_buckets have a valid credential.
-    Additionally, if there is no region it will produce a warning then trys to fetch and cache the region.
+    Additionally, if there is no region it will produce a warning then try to fetch and cache the region.
     """
     buckets = config.get("S3_BUCKETS") or {}
     aws_creds = config.get("AWS_CREDENTIALS") or {}
@@ -185,7 +185,13 @@ def _check_s3_buckets(app):
             raise ValueError(
                 "No cred for S3_BUCKET: {}. cred is required.".format(bucket_name)
             )
-        if cred not in aws_creds and cred != "*":
+
+        # if this is a public bucket, Fence will not try to sign the URL
+        # so it won't need to know the region.
+        if cred == "*":
+            continue
+
+        if cred not in aws_creds:
             raise ValueError(
                 "Credential {} for S3_BUCKET {} is not defined in AWS_CREDENTIALS".format(
                     cred, bucket_name
@@ -194,30 +200,29 @@ def _check_s3_buckets(app):
 
         # only require region when we're not specifying an
         # s3-compatible endpoint URL (ex: no need for region when using cleversafe)
-        if not bucket_details.get("endpoint_url"):
-            if not region:
+        if not region and not bucket_details.get("endpoint_url"):
+            logger.warning(
+                "WARNING: no region for S3_BUCKET: {}. Providing the region will reduce"
+                " response time and avoid a call to GetBucketLocation which you make lack the AWS ACLs for.".format(
+                    bucket_name
+                )
+            )
+            credential = S3IndexedFileLocation.get_credential_to_access_bucket(
+                bucket_name,
+                aws_creds,
+                config.get("MAX_PRESIGNED_URL_TTL", 3600),
+                app.boto,
+            )
+            if not getattr(app, "boto"):
                 logger.warning(
-                    "WARNING: no region for S3_BUCKET: {}. Providing the region will reduce"
-                    " response time and avoid a call to GetBucketLocation which you make lack the AWS ACLs for.".format(
-                        bucket_name
-                    )
+                    "WARNING: boto not setup for app, probably b/c "
+                    "nothing in AWS_CREDENTIALS. Cannot attempt to get bucket "
+                    "bucket regions."
                 )
-                credential = S3IndexedFileLocation.get_credential_to_access_bucket(
-                    bucket_name,
-                    aws_creds,
-                    config.get("MAX_PRESIGNED_URL_TTL", 3600),
-                    app.boto,
-                )
-                if not getattr(app, "boto"):
-                    logger.warning(
-                        "WARNING: boto not setup for app, probably b/c "
-                        "nothing in AWS_CREDENTIALS. Cannot attempt to get bucket "
-                        "bucket regions."
-                    )
-                    return
+                return
 
-                region = app.boto.get_bucket_region(bucket_name, credential)
-                config["S3_BUCKETS"][bucket_name]["region"] = region
+            region = app.boto.get_bucket_region(bucket_name, credential)
+            config["S3_BUCKETS"][bucket_name]["region"] = region
 
 
 def app_config(

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -502,6 +502,7 @@ AWS_CREDENTIALS: {}
 
 # NOTE: the region is optonal for s3_buckets, however it should be specified to avoid a
 # call to GetBucketLocation which you make lack the AWS ACLs for.
+# public buckets do not need the region field.
 S3_BUCKETS: {}
 # NOTE: Remove the {} and supply buckets if needed. Example in comments below
 #   bucket1:
@@ -513,8 +514,7 @@ S3_BUCKETS: {}
 #     cred: 'CRED2'
 #     region: 'us-east-1'
 #   bucket3:
-#     cred: '*'
-#     region: 'us-east-1'
+#     cred: '*' # public bucket
 #   bucket4:
 #     cred: 'CRED1'
 #     region: 'us-east-1'


### PR DESCRIPTION
Fix error at startup for public buckets:
```
S3_BUCKETS:
  mybucket:
    cred: '*'
```
```
  File "/fence/fence/__init__.py", line 218, in _check_s3_buckets
    region = app.boto.get_bucket_region(bucket_name, credential)
  File "/fence/fence/resources/aws/boto_manager.py", line 108, in get_bucket_region
    raise UnavailableError("Fail to reach AWS: {}".format(ex))
fence.errors.UnavailableError: [503] - Fail to reach AWS: Partial credentials found in explicit, missing: aws_secret_access_key
```

### Bug Fixes
- Do not fetch the region at startup for public S3 buckets
