### PR TITLE
PXP-4787 Enable allowed scopes to be specified in fence-create’s client-create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,11 @@ If there are more than one URL to add, use space to delimit them like this:
 fence-create client-create --urls 'https://url1/' 'https://url2/' --client ...
 ```
 
+To specify allowed scopes, use the `allowed-scopes` argument:
+```bash
+fence-create client-create ...  --allowed-scopes openid user data
+```
+
 #### Modify OAuth Client
 
 ```bash

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -97,6 +97,11 @@ def parse_arguments():
     client_create.add_argument(
         "--policies", help="which ABAC policies are granted to this client", nargs="*"
     )
+    client_create.add_argument(
+        "--allowed-scopes",
+        help="which scopes are allowed for this client",
+        nargs="+"
+    )
 
     client_modify = subparsers.add_parser("client-modify")
     client_modify.add_argument("--client", required=True)
@@ -381,6 +386,7 @@ def main():
             confidential=confidential,
             arborist=arborist,
             policies=args.policies,
+            allowed_scopes=args.allowed_scopes
         )
     elif args.action == "client-modify":
         modify_client_action(

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -9,6 +9,7 @@ import requests
 from urllib.parse import urlencode
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
+from cdislogging import get_logger
 import flask
 from userdatamodel.driver import SQLAlchemyDriver
 from werkzeug.datastructures import ImmutableMultiDict
@@ -20,6 +21,7 @@ from fence.config import config
 
 rng = SystemRandom()
 alphanumeric = string.ascii_uppercase + string.ascii_lowercase + string.digits
+logger = get_logger(__name__)
 
 
 def random_str(length):
@@ -65,7 +67,8 @@ def create_client(
             )
         )
     if "openid" not in allowed_scopes:
-        raise ValueError("One of the allowed scopes must be openid")
+        allowed_scopes.append("openid")
+        logger.warning('Adding required "openid" scope to list of allowed scopes.')
     with driver.session as s:
         user = query_for_user(session=s, username=username)
 

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -81,7 +81,7 @@ def create_client(
             client_secret=hashed_secret,
             user=user,
             redirect_uris=urls,
-            allowed_scopes=allowed_scopes,
+            _allowed_scopes=" ".join(allowed_scopes),
             description=description,
             name=name,
             auto_approve=auto_approve,

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -42,7 +42,7 @@ def create_client(
     confidential=True,
     arborist=None,
     policies=None,
-    allowed_scopes=None
+    allowed_scopes=None,
 ):
     client_id = random_str(40)
     if arborist is not None:
@@ -59,7 +59,11 @@ def create_client(
     auth_method = "client_secret_basic" if confidential else "none"
     allowed_scopes = allowed_scopes or config["CLIENT_ALLOWED_SCOPES"]
     if not set(allowed_scopes).issubset(set(config["CLIENT_ALLOWED_SCOPES"])):
-        raise ValueError("Each allowed scope must be one of: {}".format(config["CLIENT_ALLOWED_SCOPES"]))
+        raise ValueError(
+            "Each allowed scope must be one of: {}".format(
+                config["CLIENT_ALLOWED_SCOPES"]
+            )
+        )
     if "openid" not in allowed_scopes:
         raise ValueError("One of the allowed scopes must be openid")
     with driver.session as s:

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -120,16 +120,17 @@ def test_create_client_inits_passed_allowed_scopes(db_session):
     )
 
 
-def test_create_client_doesnt_create_client_without_openid_scope(db_session):
+def test_create_client_adds_openid_when_not_in_allowed_scopes(db_session):
     """
-    Test that create_client_action does not create a client record in the
-    database when the allowed scopes passed in do not include openid scope.
+    Test that when the allowed scopes passed to create_client_action do not
+    include the "openid" scope, that it still gets initialized as one of the
+    client's allowed scopes.
     """
     client_name = "exampleapp"
 
     def to_test():
-        client_after = db_session.query(Client).filter_by(name=client_name).all()
-        assert len(client_after) == 0
+        saved_client = db_session.query(Client).filter_by(name=client_name).first()
+        assert saved_client._allowed_scopes == "user data openid"
 
     create_client_action_wrapper(
         to_test, client_name=client_name, allowed_scopes=["user", "data"],


### PR DESCRIPTION
Enable an admin running `fence-create client-create` to specify the allowed scopes when creating a client. Previously a client’s allowed scopes were initialized based on `fence.config.config[“CLIENT_ALLOWED_SCOPES”]`. With this PR, an admin can be more restrictive with what scopes are allowed for a client.

### New Features
- Enabled `fence-create client-create` to accept space-separated `allowed-scopes` arguments

### Breaking Changes

### Bug Fixes

### Improvements
- Added tests for `fence.scripting.fence_create.create_client_action`

### Dependency updates

### Deployment changes
