### PR TITLE
fix(qa): Pin authutils 4 due to NIH login issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Authlib==0.11
 addict==2.2.1
-authutils>=4.0.0<5.0.0
+authutils==4.0.0
 boto>=2.36.0<3.0.0
 botocore>=1.7<1.10.39
 boto3>=1.5<1.6


### PR DESCRIPTION
Fence 2020.06 presented issues related to the NIH login transactions.

### Bug Fixes
The new authutils `5.0.0` uses httpx, which affects the NIH login transactions.