### PR TITLE
PXP-5256 Fix broken authorization page login for users with many projects

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -364,7 +364,7 @@ MAX_ACCESS_TOKEN_TTL: 3600
 # TEMPORARY: The maximum number of projects allowed in token claims.
 # This config var should be removed after sheepdog and peregrine support
 # auth checks against Arborist, and no longer check the token.
-TOKEN_PROJECTS_CUTOFF: 15
+TOKEN_PROJECTS_CUTOFF: 10
 
 
 ########################################################################################

--- a/fence/resources/openid/google_oauth2.py
+++ b/fence/resources/openid/google_oauth2.py
@@ -1,4 +1,5 @@
 from .idp_oauth2 import Oauth2ClientBase
+from fence.config import config
 
 
 class GoogleOauth2Client(Oauth2ClientBase):
@@ -40,6 +41,8 @@ class GoogleOauth2Client(Oauth2ClientBase):
         """
         Get user id
         """
+        if config.get("MOCK_GOOGLE_AUTH", False):
+            return {"email": "test@gmail.com"}
         try:
             token_endpoint = self.get_value_from_discovery_doc(
                 "token_endpoint", "https://oauth2.googleapis.com/token"

--- a/tests/login/test_google_login.py
+++ b/tests/login/test_google_login.py
@@ -1,3 +1,52 @@
+import os
+
+from fence.resources.storage.cdis_jwt import create_session_token
+from fence.config import config
+from fence.sync.sync_users import UserSyncer
+
+
 def test_google_login_error_handling(client):
     r = client.get("/login/google/login?code=abc")
     assert r.status_code == 400
+
+
+def test_google_login_http_headers_are_less_than_4k_for_user_with_many_projects(
+    app, client, monkeypatch, db_session
+):
+    """
+    Test that when the current user has access to a large number of projects,
+    the http headers of the response from a GET to /login/google/login are less
+    than 4k bytes in size.
+    """
+    monkeypatch.setitem(config, "MOCK_GOOGLE_AUTH", True)
+    test_session_jwt = create_session_token(
+        app.keypairs[0],
+        config.get("SESSION_TIMEOUT"),
+        context={
+            "redirect": "https://localhost/user/oauth2/authorize?client_id=7f7kAS4MJraUuo77d7RWHr4mZ6bvGtuzup7hw46I&response_type=id_token&redirect_uri=https://webapp.example/fence&scope=openid+user+data+google_credentials&nonce=randomvalue"
+        },
+    )
+    client.set_cookie("localhost", config["SESSION_COOKIE_NAME"], test_session_jwt)
+
+    user_projects = {
+        "test": {
+            f"project{x}": {
+                "read",
+                "read-storage",
+                "update",
+                "upload",
+                "create",
+                "write-storage",
+                "delete",
+            }
+            for x in range(20)
+        }
+    }
+    user_info = {"test": {"tags": {},}}
+    dbGaP = os.environ.get("dbGaP") or config.get("dbGaP")
+    syncer = UserSyncer(dbGaP, config["DB"], {})
+    syncer.sync_to_db_and_storage_backend(user_projects, user_info, db_session)
+
+    resp = client.get("/login/google/login")
+    assert len(str(resp.headers)) < 4096
+    assert resp.status_code == 302


### PR DESCRIPTION
### Bug Fixes
Enable a user who has access to a large number of projects to be able to login successfully when loading the Gen3 authorization page. Previously, for users with access to too many projects, attempting to login and load the authorization page resulted in 502 and 400 errors.

