### PR TITLE
PXP-2799 Access token hash

### DIFF
--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -98,7 +98,7 @@ def authorize(*args, **kwargs):
     try:
         grant = server.validate_consent_request(end_user=user)
     except OAuth2Error as e:
-        raise Unauthorized("{} failed to authorize".format(str(e)))
+        raise Unauthorized("Failed to authorize: {}".format(str(e)))
 
     client_id = grant.client.client_id
     with flask.current_app.db.session as session:

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -195,6 +195,8 @@ def generate_token_response(
         nonce=nonce,
         linked_google_email=linked_google_email,
         linked_google_account_exp=linked_google_account_exp,
+        auth_flow_type=AuthFlowTypes.CODE,
+        access_token=access_token,
     ).token
     # If ``refresh_token`` was passed (for instance from the refresh
     # grant), use that instead of generating a new one.

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -176,6 +176,15 @@ def generate_token_response(
     if not isinstance(scope, list):
         scope = scope.split(" ")
 
+    access_token = generate_signed_access_token(
+        kid=keypair.kid,
+        private_key=keypair.private_key,
+        user=user,
+        expires_in=config["ACCESS_TOKEN_EXPIRES_IN"],
+        scopes=scope,
+        client_id=client.client_id,
+        linked_google_email=linked_google_email,
+    ).token
     id_token = generate_signed_id_token(
         kid=keypair.kid,
         private_key=keypair.private_key,
@@ -186,15 +195,6 @@ def generate_token_response(
         nonce=nonce,
         linked_google_email=linked_google_email,
         linked_google_account_exp=linked_google_account_exp,
-    ).token
-    access_token = generate_signed_access_token(
-        kid=keypair.kid,
-        private_key=keypair.private_key,
-        user=user,
-        expires_in=config["ACCESS_TOKEN_EXPIRES_IN"],
-        scopes=scope,
-        client_id=client.client_id,
-        linked_google_email=linked_google_email,
     ).token
     # If ``refresh_token`` was passed (for instance from the refresh
     # grant), use that instead of generating a new one.

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -2,6 +2,7 @@ import flask
 from flask_sqlalchemy_session import current_session
 
 from fence.jwt.token import (
+    AuthFlowTypes,
     generate_signed_access_token,
     generate_signed_id_token,
     generate_signed_refresh_token,
@@ -119,6 +120,8 @@ def generate_implicit_response(
         linked_google_email=linked_google_email,
         linked_google_account_exp=linked_google_account_exp,
         include_project_access=False,
+        auth_flow_type=AuthFlowTypes.IMPLICIT,
+        access_token=access_token if include_access_token else None,
     ).token
     response["id_token"] = id_token
 

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -80,28 +80,11 @@ def generate_implicit_response(
     if not "user" in scope:
         scope.append("user")
 
-    # don't provide user projects access in id_tokens for implicit flow
-    # due to issues with "Location" header size during redirect (and b/c
-    # of general deprecation of user access information in tokens)
-    id_token = generate_signed_id_token(
-        kid=keypair.kid,
-        private_key=keypair.private_key,
-        user=user,
-        expires_in=config["ACCESS_TOKEN_EXPIRES_IN"],
-        client_id=client.client_id,
-        audiences=scope,
-        nonce=nonce,
-        linked_google_email=linked_google_email,
-        linked_google_account_exp=linked_google_account_exp,
-        include_project_access=False,
-    ).token
-
     # ``expires_in`` is just the token expiration time.
     expires_in = config["ACCESS_TOKEN_EXPIRES_IN"]
 
     response = {
         "token_type": "Bearer",
-        "id_token": id_token,
         "expires_in": expires_in,
         # "state" handled in authlib
     }
@@ -121,6 +104,23 @@ def generate_implicit_response(
             include_project_access=False,
         ).token
         response["access_token"] = access_token
+
+    # don't provide user projects access in id_tokens for implicit flow
+    # due to issues with "Location" header size during redirect (and b/c
+    # of general deprecation of user access information in tokens)
+    id_token = generate_signed_id_token(
+        kid=keypair.kid,
+        private_key=keypair.private_key,
+        user=user,
+        expires_in=config["ACCESS_TOKEN_EXPIRES_IN"],
+        client_id=client.client_id,
+        audiences=scope,
+        nonce=nonce,
+        linked_google_email=linked_google_email,
+        linked_google_account_exp=linked_google_account_exp,
+        include_project_access=False,
+    ).token
+    response["id_token"] = id_token
 
     return response
 

--- a/tests/oidc/core/token/test_id_token.py
+++ b/tests/oidc/core/token/test_id_token.py
@@ -3,7 +3,11 @@ import time
 
 from authlib.jose.errors import InvalidClaimError
 
-from fence.jwt.token import generate_signed_id_token, UnsignedIDToken
+from fence.jwt.token import (
+    generate_signed_id_token,
+    UnsignedCodeIDToken,
+    UnsignedIDToken,
+)
 from fence.jwt.validate import validate_jwt
 from fence.models import User
 from fence.utils import random_str
@@ -34,7 +38,7 @@ def test_recode_id_token(app, kid, rsa_private_key):
         max_age=max_age,
         nonce=nonce,
     )
-    original_unsigned_token = UnsignedIDToken.from_signed_and_encoded_token(
+    original_unsigned_token = UnsignedCodeIDToken.from_signed_and_encoded_token(
         original_signed_token.token,
         client_id=client_id,
         issuer=issuer,
@@ -45,7 +49,7 @@ def test_recode_id_token(app, kid, rsa_private_key):
     new_signed_token = original_unsigned_token.get_signed_and_encoded_token(
         kid, rsa_private_key
     )
-    new_unsigned_token = UnsignedIDToken.from_signed_and_encoded_token(
+    new_unsigned_token = UnsignedCodeIDToken.from_signed_and_encoded_token(
         new_signed_token,
         client_id=client_id,
         issuer=issuer,


### PR DESCRIPTION

### New Features
- Include at_hash claim in id tokens where an access token is issued alongside

### Improvements
- Refactor UnsignedIDToken class in order to use both CodeIDToken and ImplicitIDToken from Authlib
- id token validation is now sensitive to present auth flow type (some claims like nonce and at_hash are validated differently in implicit vs code flow)


