### PR TITLE
PXP-2802 feat(usync-emails)

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -14,6 +14,7 @@ from stat import S_ISDIR
 
 import paramiko
 from cdislogging import get_logger
+from email_validator import validate_email, EmailNotValidError
 from gen3authz.client.arborist.client import ArboristError
 from gen3users.validation import validate_user_yaml
 from paramiko.proxy import ProxyCommand
@@ -217,12 +218,20 @@ class UserYAML(object):
                 resource_permissions[resource] = set(project["privilege"])
 
             user_info[username] = {
-                "email": details.get("email", username),
+                "email": details.get("email", ""),
                 "display_name": details.get("display_name", ""),
                 "phone_number": details.get("phone_number", ""),
                 "tags": details.get("tags", {}),
                 "admin": details.get("admin", False),
             }
+            if not details.get("email"):
+                try:
+                    valid = validate_email(
+                        username, allow_smtputf8=False, check_deliverability=False
+                    )
+                    user_info[username]["email"] = valid.email
+                except EmailNotValidError:
+                    pass
             projects[username] = privileges
             user_abac[username] = resource_permissions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ cdiserrors==0.1.2
 cdispyutils==1.0.4
 cryptography==2.8
 datamodelutils==0.4.5
+email_validator==1.1.1
 Flask==1.1.1
 Flask-CORS==3.0.3
 Flask_OAuthlib==0.9.4

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "boto3>=1.5,<1.6",
         "cached_property>=1.5.1,<2.0.0",
         "cryptography==2.8",
+        "email_validator~=1.1.1",
         "flask-restful>=0.3.6,<1.0.0",
         "Flask>=1.1.1,<2.0.0",
         "Flask-CORS>=3.0.3,<4.0.0",


### PR DESCRIPTION
Q: Mightn't we as well validate actual _provided_ emails including deliverability checks??
A: Not in usersync; if at all, then in useryaml validation

### New Features
- In usersync, populate user email iff email is provided in useryaml OR username is an email addr

### Breaking Changes
- Usersync will no longer populate user's email field in Fence db with the user's username, UNLESS the username is an email address, in which case previous behavior applies (email field is populated with the username). In other words, nothing should change except in cases where usersync was putting invalid emails into user email fields anyway. 


### Dependency updates
- Added dependency email_validator v1.1.1

