### PR TITLE
re-fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Authlib==0.11
 addict==2.2.1
-authutils>=4.0.0<5.0.0
-awscli
-boto>=2.36.0<3.0.0
-botocore>=1.7<1.10.39
-boto3>=1.5<1.6
+authutils>=4.0.0,<5.0.0
+awscli=>1.18.0,<2.0.0
+boto>=2.36.0,<3.0.0
+botocore>=1.7,<1.10.39
+boto3>=1.5,<1.6
 cached_property==1.5.1
 cdislogging>=1.0.0,<2.0.0
 cdiserrors==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
+
 Authlib==0.11
 addict==2.2.1
 authutils>=4.0.0,<5.0.0
 awscli>=1.18.0,<2.0.0
 boto>=2.36.0,<3.0.0
-botocore>=1.7,<1.10.39
-boto3>=1.5,<1.6
+botocore>=1.12.91,<1.13.0
+boto3>=1.9.91,<1.10.0
 cached_property==1.5.1
 cdislogging>=1.0.0,<2.0.0
 cdiserrors==0.1.2
@@ -37,9 +38,8 @@ setuptools>=40.3.0
 six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
-userdatamodel==2.3.2
+userdatamodel>=2.3.3
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2
-
-git+https://github.com/uc-cdis/storage-client.git@1.0.0#egg=storageclient
+git+https://github.com/uc-cdis/storage-client.git@fix/dependency_fix#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 Authlib==0.11
 addict==2.2.1
 authutils>=4.0.0,<5.0.0
@@ -42,4 +41,4 @@ userdatamodel>=2.3.3
 Werkzeug==0.16.0
 pyyaml==5.1
 retry==0.9.2
-git+https://github.com/uc-cdis/storage-client.git@fix/dependency_fix#egg=storageclient
+git+https://github.com/uc-cdis/storage-client.git@1.0.1#egg=storageclient

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Authlib==0.11
 addict==2.2.1
 authutils>=4.0.0,<5.0.0
-awscli=>1.18.0,<2.0.0
+awscli>=1.18.0,<2.0.0
 boto>=2.36.0,<3.0.0
 botocore>=1.7,<1.10.39
 boto3>=1.5,<1.6

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-
 from setuptools import setup, find_packages
+
 setup(
     name="fence",
     version="0.2.0",
@@ -37,7 +37,7 @@ setup(
         "six>=1.11.0,<2.0.0",
         "SQLAlchemy>=1.3.3,<1.4.0",
         "temps>=0.3.0,<1.0.0",
-        "userdatamodel",
+        "userdatamodel>=2.3.3,<3.0.0",
         "Werkzeug>=0.16.0,<1.0.0",
         "storageclient",
         "pyyaml~=5.1",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from setuptools import setup, find_packages
 
+from setuptools import setup, find_packages
 setup(
     name="fence",
     version="0.2.0",
@@ -8,8 +8,8 @@ setup(
         "oauth2client<4.0dev,>=2.0.0",
         "addict>=2.1.1, <3.0.0",
         "boto>=2.36.0,<3.0.0",
-        "botocore>=1.7,<1.9.0",
-        "boto3>=1.5,<1.6",
+        "botocore>=1.12.91,<1.13.0",
+        "boto3>=1.9.91,<1.10.0",
         "cached_property>=1.5.1,<2.0.0",
         "cryptography==2.8",
         "email_validator~=1.1.1",
@@ -37,7 +37,7 @@ setup(
         "six>=1.11.0,<2.0.0",
         "SQLAlchemy>=1.3.3,<1.4.0",
         "temps>=0.3.0,<1.0.0",
-        "userdatamodel>=2.0.1,<3.0.0",
+        "userdatamodel",
         "Werkzeug>=0.16.0,<1.0.0",
         "storageclient",
         "pyyaml~=5.1",


### PR DESCRIPTION
Add back the changes from https://github.com/uc-cdis/fence/pull/783 that got inadvertently removed by https://github.com/uc-cdis/fence/pull/745

Also, pin `awscli` dependency (@diw2 could you check if that version is fine?)

### Dependency updates
- Fix dependencies so pip parses correctly
- storage-client to 1.0.1