### PR TITLE
refactor(auth-code): use code from Grant class attrs

### DIFF
--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -61,17 +61,8 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         if not user:
             raise InvalidRequestError('There is no "user" for this code.')
 
-        scope = authorization_code.get_scope()
-
-        query_args = dict(self.request.query_params)
-        code = self.request.body.get("code") or query_args.get("code")
-        with flask.current_app.db.session as session:
-            authorization_code = (
-                session.query(AuthorizationCode)
-                .filter_by(code=code, client_id=client.client_id)
-                .first()
-            )
-            nonce = authorization_code.nonce
+        scope = authorization_code.scope
+        nonce = authorization_code.nonce
 
         token = self.generate_token(
             client,


### PR DESCRIPTION
### Improvements
- Use authorization_code object saved in Grant class attributes; remove unnecessary db query


