### PR TITLE
fix(client-create-output): Improve output for fence-create client-create

### DIFF
--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -109,14 +109,17 @@ def create_client_action(
     DB, username=None, client=None, urls=None, auto_approve=False, **kwargs
 ):
     try:
-        client_id, client_secret = create_client(
-            username, urls, DB, name=client, auto_approve=auto_approve, **kwargs
-        )
         print(
-            "\nSave these credentials! Fence will not save the unhashed client_secret."
+            "\nSave these credentials! Fence will not save the unhashed client secret."
         )
-        print("client_id    : {}".format(client_id))
-        print("client_secret: {}".format(client_secret))
+        print("client id, client secret:")
+        # This should always be the last line of output and should remain in this format--
+        # cloud-auto and gen3-qa use the output programmatically.
+        print(
+            create_client(
+                username, urls, DB, name=client, auto_approve=auto_approve, **kwargs
+            )
+        )
     except Exception as e:
         logger.error(str(e))
 

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -109,11 +109,14 @@ def create_client_action(
     DB, username=None, client=None, urls=None, auto_approve=False, **kwargs
 ):
     try:
-        print(
-            create_client(
-                username, urls, DB, name=client, auto_approve=auto_approve, **kwargs
-            )
+        client_id, client_secret = create_client(
+            username, urls, DB, name=client, auto_approve=auto_approve, **kwargs
         )
+        print(
+            "\nSave these credentials! Fence will not save the unhashed client_secret."
+        )
+        print("client_id    : {}".format(client_id))
+        print("client_secret: {}".format(client_secret))
     except Exception as e:
         logger.error(str(e))
 


### PR DESCRIPTION
~(I'm pretty sure nothing uses the output of this command programmatically~
Note: gen3-qa and cloud-auto use the fence-create client-create output programmatically, but they take the last line of output. So this PR keeps the last line of output the same. 

### Improvements
Improve output for fence-create client-create (label the id/secret, add instructions to save the creds)

