### PR TITLE
Add ga4gh scope description

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -197,7 +197,6 @@ CLIENT_ALLOWED_SCOPES:
   - "google_credentials"
   - "google_service_account"
   - "google_link"
-  - "ras_dbgap_v1"
   - "ga4gh_passport_v1"
 
 # these are the scopes that CAN be included in a user's own access_token

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -27,6 +27,7 @@ SCOPE_DESCRIPTION = {
     "google_credentials": "Receive temporary Google credentials to access data on Google.",
     "google_service_account": "Allow registration of external Google service accounts to access data.",
     "admin": "View and update user authorizations.",
+    "ga4gh_passport_v1": "Retrieve ga4gh passports and visas",
 }
 
 

--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -18,7 +18,7 @@ class RASOauth2Client(Oauth2ClientBase):
         super(RASOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid ga4gh_passport_v1 email profile ras_dbgap_v1",
+            scope="openid ga4gh_passport_v1 email profile",
             discovery_url=self.RAS_DISCOVERY_URL,
             idp="ras",
             HTTP_PROXY=HTTP_PROXY,


### PR DESCRIPTION
It does not seem like the `ras_dbgap_v1` scope its being used since not having the scope does not change anything. It is also not mentioned anywhere in the NIH RAS dev guides. 

### New Features
- Added `ga4gh_passport_v1` scope description. 
- removed `ras_dbgap_v1` scope. 