### PR TITLE
fix(token-revoke): correct behavior to match RFC 7009, 200 on revoke of invalid token

### DIFF
--- a/fence/oidc/endpoints.py
+++ b/fence/oidc/endpoints.py
@@ -30,7 +30,15 @@ class RevocationEndpoint(authlib.oauth2.rfc7009.RevocationEndpoint):
         """
         Revoke a token.
         """
-        fence.jwt.blacklist.blacklist_encoded_token(token)
+        try:
+            fence.jwt.blacklist.blacklist_encoded_token(token)
+        except BlacklistingError as err:
+            logger.info(
+                "Token provided for revocation is not valid. "
+                "Per rfc7009, this should still return a 200. Error: "
+                f"{err}",
+                exc_info=True,
+            )
 
     def validate_authenticate_client(self):
         """

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -209,16 +209,12 @@ paths:
     post:
       tags:
         - oauth2
-      summary: Revoke a refresh token
+      summary: Revoke a refresh token per RFC 7009
       description: Revoke a refresh (not access) token granted to a user.
       operationId: revoke
       responses:
         '200':
           description: 'successful operation, OR invalid token submitted'
-        '400':
-          description: >-
-            invalid token provided: not a refresh token, or token was missing a
-            claim, or token could not be validated
       requestBody:
         content:
           application/x-www-form-urlencoded:

--- a/tests/rfc6749/test_revoke.py
+++ b/tests/rfc6749/test_revoke.py
@@ -20,9 +20,9 @@ def test_blacklisted_token(client, oauth_client, encoded_jwt_refresh_token):
 
 def test_cannot_revoke_access_token(client, oauth_client, encoded_jwt):
     """
-    Test that attempting to revoke an access token fails and returns 400.
+    Test that attempting to revoke an access token fails and return a 200 (per RFC 7009).
     """
     headers = create_basic_header_for_client(oauth_client)
     data = {"token": encoded_jwt}
     response = client.post("/oauth2/revoke", headers=headers, data=data)
-    assert response.status_code == 400, response.data
+    assert response.status_code == 200, response.data


### PR DESCRIPTION


### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes
- token revocation per RFC 7009 should return 200 even if the token is expired

### Improvements


### Dependency updates


### Deployment changes
