### PR TITLE
chore(monitoring): Adopt new pybase img version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# To run: docker run -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
+# To run: docker run --rm -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
 # To check running container: docker exec -it fence /bin/bash
 
 FROM quay.io/cdis/python-nginx:pybase3-1.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
 # To check running container: docker exec -it fence /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.2.0
+FROM quay.io/cdis/python-nginx:pybase3-1.3.0
 
 ENV appname=fence
 


### PR DESCRIPTION
Update fence's base image to enable an Nginx Status endpoint.
This is small / harmless change required to unblock a `cloud-automation` PR: https://github.com/uc-cdis/cloud-automation/pull/1348

### New Features
- New base image `pybase3-1.3.0`

### Breaking Changes
- This Nginx status endpoint is a hard dependency for the `nginx-prometheus-exporter` side car. Any older fence image that is used with the Kubernetes deployment descriptor that is declared with the sidecar below will fail to come up.
```
      - name: nginx-prometheus-exporter
        image: registry.hub.docker.com/nginx/nginx-prometheus-exporter:0.8.0
        args: ["-nginx.scrape-uri", "http://127.0.0.1/nginx_status"]
        ports:
        - containerPort: 9113
```