### PR TITLE
Add Client_ID to Audiences

### DIFF
--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -27,7 +27,7 @@ SCOPE_DESCRIPTION = {
     "google_credentials": "Receive temporary Google credentials to access data on Google.",
     "google_service_account": "Allow registration of external Google service accounts to access data.",
     "admin": "View and update user authorizations.",
-    "ga4gh_passport_v1": "Retrieve ga4gh passports and visas",
+    "ga4gh_passport_v1": "Retrieve GA4GH Passports and Visas",
 }
 
 
@@ -377,10 +377,14 @@ def generate_signed_access_token(
                 "must provide value for `iss` (issuer) field if"
                 " running outside of flask application"
             )
+    audiences = scopes.copy()
+    # include client_id in audiences as required by GA4GH
+    if client_id:
+        audiences.append(client_id)
 
     claims = {
         "pur": "access",
-        "aud": scopes,
+        "aud": audiences,
         "sub": sub,
         "iss": iss,
         "iat": iat,

--- a/fence/jwt/token.py
+++ b/fence/jwt/token.py
@@ -377,10 +377,12 @@ def generate_signed_access_token(
                 "must provide value for `iss` (issuer) field if"
                 " running outside of flask application"
             )
-    audiences = scopes.copy()
-    # include client_id in audiences as required by GA4GH
+    audiences = []
     if client_id:
         audiences.append(client_id)
+    # append scopes for backwards compatibility
+    # eventual goal is to remove scopes from `aud`
+    audiences = audiences + scopes
 
     claims = {
         "pur": "access",

--- a/tests/jwt/test_tokens.py
+++ b/tests/jwt/test_tokens.py
@@ -33,5 +33,6 @@ def test_passport_access_token(app, kid, rsa_private_key, test_user_a):
     assert payload["iat"] is not None
     assert payload["exp"] == payload["iat"] + exp
     assert payload["scope"] == ["openid", "user", "ga4gh_passport_v1"]
+    assert isinstance(payload["aud"], list)
     # assert client_id in audiences
     assert "client_a" in payload["aud"]

--- a/tests/jwt/test_tokens.py
+++ b/tests/jwt/test_tokens.py
@@ -1,0 +1,37 @@
+import pytest
+import random
+import string
+import jwt
+
+from tests.utils import iat_and_exp
+
+from fence.jwt.token import generate_signed_access_token, generate_signed_session_token
+from fence.jwt.errors import JWTSizeError
+
+
+def test_passport_access_token(app, kid, rsa_private_key, test_user_a):
+    """
+    Test that generate_signed_access_token is a valid GA4GH Passport Access Token
+    as specified: https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md#ga4gh-jwt-format
+
+    The scopes argument is ["openid", "user", "ga4gh_passport_v1"] because there is currently no fixture for scopes in /tests/conftest.py,
+    but default_claims() in /tests/utils/__init__.py sets aud = ["openid", "user"].
+    """
+    _, exp = iat_and_exp()
+    jwt_token = generate_signed_access_token(
+        kid,
+        rsa_private_key,
+        test_user_a,
+        exp,
+        ["openid", "user", "ga4gh_passport_v1"],
+        client_id="client_a",
+    )
+    payload = jwt.decode(jwt_token.token, verify=False)
+    # assert required fields exist
+    assert payload["iss"] is not None or ""
+    assert payload["sub"] is not None or ""
+    assert payload["iat"] is not None
+    assert payload["exp"] == payload["iat"] + exp
+    assert payload["scope"] == ["openid", "user", "ga4gh_passport_v1"]
+    # assert client_id in audiences
+    assert "client_a" in payload["aud"]


### PR DESCRIPTION
GA4GH AAI requires that client ID be in `aud` in the access token if the `aud` claim is provided. Adding client id and also adding a test to check for compatibility with GA4GH spec. 

This might impact our existing validation if we're checking for audiences. 