### PR TITLE
chore(observability): Adopt latest py base img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run --rm -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
 # To check running container: docker exec -it fence /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.3.0
+FROM quay.io/cdis/python-nginx:pybase3-1.4.0
 
 ENV appname=fence
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ At the moment, supported IDPs include:
 - Cognito
 - Synapse
 - Microsoft
+- ORCID
 - RAS
 
 ## OIDC & OAuth2


### PR DESCRIPTION
Update fence's base image to enable Status endpoints and aggregated metrics to be scraped by Prometheus.

### New Features
- New base image `pybase3-1.4.0`