### PR TITLE
Fix/logout encoding

### DIFF
--- a/fence/auth.py
+++ b/fence/auth.py
@@ -103,7 +103,6 @@ def logout(next_url):
         provider_logout = config["ITRUST_GLOBAL_LOGOUT"] + safe_url
     elif provider == IdentityProvider.fence:
         base = config["OPENID_CONNECT"]["fence"]["api_base_url"]
-        safe_url = urllib.parse.quote_plus(next_url)
         provider_logout = base + "/logout?" + urllib.parse.urlencode({"next": next_url})
 
     flask.session.clear()

--- a/fence/auth.py
+++ b/fence/auth.py
@@ -104,7 +104,7 @@ def logout(next_url):
     elif provider == IdentityProvider.fence:
         base = config["OPENID_CONNECT"]["fence"]["api_base_url"]
         safe_url = urllib.parse.quote_plus(next_url)
-        provider_logout = base + "/logout?" + urllib.parse.urlencode({"next": safe_url})
+        provider_logout = base + "/logout?" + urllib.parse.urlencode({"next": next_url})
 
     flask.session.clear()
     redirect_response = flask.make_response(

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -77,6 +77,5 @@ def test_logout_fence(app, client, user_with_fence_provider, monkeypatch):
         assert r.location.startswith(other_fence_logout_url)
 
         parsed_url = urllib.parse.urlparse(r.location)
-        raw_redirect = urllib.parse.parse_qs(parsed_url.query).get("next")[0]
-        result_redirect = urllib.parse.unquote(raw_redirect)
+        result_redirect = urllib.parse.parse_qs(parsed_url.query).get("next")[0]
         assert result_redirect == redirect


### PR DESCRIPTION
Jira Ticket: [PXP-6631](https://ctds-planx.atlassian.net/browse/PXP-6631)

* fix `next=` query parameter sent to `fence` idp being double encoded

### New Features

### Breaking Changes


### Bug Fixes
* fix `next=` query parameter sent to `fence` idp being double encoded


### Improvements


### Dependency updates


### Deployment changes
