### PR TITLE
fix(EA-usersync): Changed usersync to only create the new EA resource…

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1644,8 +1644,11 @@ class UserSyncer(object):
 
         try:
             for resource_namespace in arborist_resource_namespaces:
-                # The update_resourece function creates a put request which will overwrite existing resources. Therefore, only create if get_resource returns the resource doesn't exist.
-                if not self.arborist_client.get_resource(resource_namespace+dbgap_study):
+                # The update_resource function creates a put request which will overwrite
+                # existing resources. Therefore, only create if get_resource returns
+                # the resource doesn't exist.
+                full_resource_path = resource_namespace + dbgap_study
+                if not self.arborist_client.get_resource(full_resource_path):
                     response = self.arborist_client.update_resource(
                         resource_namespace,
                         {"name": dbgap_study, "description": "synced from dbGaP"},
@@ -1657,12 +1660,17 @@ class UserSyncer(object):
                         )
                     )
                     self.logger.debug("Arborist response: {}".format(response))
+                else:
+                    self.logger.debug(
+                        "Arborist resource already exists: {}".format(
+                            full_resource_path
+                        )
+                    )
+
                 if dbgap_study not in self._dbgap_study_to_resources:
                     self._dbgap_study_to_resources[dbgap_study] = []
 
-                self._dbgap_study_to_resources[dbgap_study].append(
-                    resource_namespace + dbgap_study
-                )
+                self._dbgap_study_to_resources[dbgap_study].append(full_resource_path)
 
             return arborist_resource_namespaces
         except ArboristError as e:

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -398,12 +398,14 @@ class UserSyncer(object):
         Returns:
             None
         """
-        execstr = 'lftp -u {},{}  {} -e "set ftp:proxy http://{}; mirror . {}; exit"'.format(
-            server.get("username", ""),
-            server.get("password", ""),
-            server.get("host", ""),
-            server.get("proxy", ""),
-            path,
+        execstr = (
+            'lftp -u {},{}  {} -e "set ftp:proxy http://{}; mirror . {}; exit"'.format(
+                server.get("username", ""),
+                server.get("password", ""),
+                server.get("host", ""),
+                server.get("proxy", ""),
+                path,
+            )
         )
         os.system(execstr)
 

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1644,17 +1644,19 @@ class UserSyncer(object):
 
         try:
             for resource_namespace in arborist_resource_namespaces:
-                response = self.arborist_client.update_resource(
-                    resource_namespace,
-                    {"name": dbgap_study, "description": "synced from dbGaP"},
-                    create_parents=True,
-                )
-                self.logger.info(
-                    "added arborist resource under parent path: {} for dbgap project {}.".format(
-                        resource_namespace, dbgap_study
+                # The update_resourece function creates a put request which will overwrite existing resources. Therefore, only create if get_resource returns the resource doesn't exist.
+                if not self.arborist_client.get_resource(resource_namespace+dbgap_study):
+                    response = self.arborist_client.update_resource(
+                        resource_namespace,
+                        {"name": dbgap_study, "description": "synced from dbGaP"},
+                        create_parents=True,
                     )
-                )
-                self.logger.debug("Arborist response: {}".format(response))
+                    self.logger.info(
+                        "added arborist resource under parent path: {} for dbgap project {}.".format(
+                            resource_namespace, dbgap_study
+                        )
+                    )
+                    self.logger.debug("Arborist response: {}".format(response))
                 if dbgap_study not in self._dbgap_study_to_resources:
                     self._dbgap_study_to_resources[dbgap_study] = []
 

--- a/tests/dbgap_sync/conftest.py
+++ b/tests/dbgap_sync/conftest.py
@@ -159,7 +159,12 @@ def syncer(db_session, request):
         response = {"updated": resource}
         return response
 
+    def mocked_get(path, **kwargs):
+        return None
+
     syncer_obj.arborist_client.update_resource = MagicMock(side_effect=mocked_update)
+
+    syncer_obj.arborist_client.get_resource = MagicMock(side_effect=mocked_get)
 
     syncer_obj.arborist_client.get_policy.side_effect = lambda _: None
 


### PR DESCRIPTION
… if it doesn't exist.

Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- If a project_id mapped to a parent resource in arborist (e.g. /programs/foo) then usersync would PUT and remove all children from arborist at the beginning of usersync (e.g. /programs/foo/projects/bar would be deleted) and then re-added later, effectively removing access for a brief period of time. This fix changes sync so that it only PUTs arborist resources if they don't already exist.

### Improvements


### Dependency updates


### Deployment changes
