### PR TITLE
(PXP-6618) Use fence-create to modify urls and allowed scopes.

### DIFF
--- a/bin/fence-create
+++ b/bin/fence-create
@@ -107,7 +107,7 @@ def parse_arguments():
     client_modify.add_argument("--urls", required=False, nargs="+")
     client_modify.add_argument("--name", required=False)
     client_modify.add_argument("--description", required=False)
-    client_modify.add_argument("--allowed_scopes", required=False)
+    client_modify.add_argument("--allowed-scopes", required=False, nargs="+")
     client_modify.add_argument(
         "--append", 
         help="set the oidc process to skip user consent step",

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -108,7 +108,12 @@ def parse_arguments():
     client_modify.add_argument("--name", required=False)
     client_modify.add_argument("--description", required=False)
     client_modify.add_argument("--allowed_scopes", required=False)
-    client_modify.add_argument("--append", required=False)
+    client_modify.add_argument(
+        "--append", 
+        help="set the oidc process to skip user consent step",
+        action="store_true",
+        default=False,
+        )
     client_modify.add_argument(
         "--set-auto-approve",
         help="set the oidc process to skip user consent step",

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -107,6 +107,8 @@ def parse_arguments():
     client_modify.add_argument("--urls", required=False, nargs="+")
     client_modify.add_argument("--name", required=False)
     client_modify.add_argument("--description", required=False)
+    client_modify.add_argument("--allowed_scopes", required=False)
+    client_modify.add_argument("--append", required=False)
     client_modify.add_argument(
         "--set-auto-approve",
         help="set the oidc process to skip user consent step",
@@ -413,6 +415,8 @@ def main():
             unset_auto_approve=args.unset_auto_approve,
             arborist=arborist,
             policies=args.policies,
+            allowed_scopes=args.allowed_scopes,
+            append=args.append,
         )
     elif args.action == "client-delete":
         delete_client_action(DB, args.client)

--- a/bin/fence-create
+++ b/bin/fence-create
@@ -110,7 +110,7 @@ def parse_arguments():
     client_modify.add_argument("--allowed-scopes", required=False, nargs="+")
     client_modify.add_argument(
         "--append", 
-        help="set the oidc process to skip user consent step",
+        help="append either new allowed scopes or urls",
         action="store_true",
         default=False,
         )

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -338,7 +338,9 @@ def _setup_oidc_clients(app):
     # Add OIDC client for RAS if configured.
     if "ras" in oidc:
         app.ras_client = RASClient(
-            oidc["ras"], HTTP_PROXY=config.get("HTTP_PROXY"), logger=logger,
+            oidc["ras"],
+            HTTP_PROXY=config.get("HTTP_PROXY"),
+            logger=logger,
         )
 
     # Add OIDC client for Synapse if configured.

--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -312,23 +312,23 @@ def is_user_member_of_google_project(
     user_id, google_cloud_manager, db=None, membership=None
 ):
     """
-        Return whether or not the given user is a member of the provided
-        Google project ID.
+    Return whether or not the given user is a member of the provided
+    Google project ID.
 
-        This will verify that either the user's email or their linked Google
-        account email exists as a member in the project.
+    This will verify that either the user's email or their linked Google
+    account email exists as a member in the project.
 
-        Args:
-            user_id (int): User identifier
-            google_cloud_manager (GoogleCloudManager): cloud manager instance
-            db(str): db connection string
-            membership (List(GooglePolicyMember) : pre-calculated list of members,
-                Will make call to Google API if membership is None
+    Args:
+        user_id (int): User identifier
+        google_cloud_manager (GoogleCloudManager): cloud manager instance
+        db(str): db connection string
+        membership (List(GooglePolicyMember) : pre-calculated list of members,
+            Will make call to Google API if membership is None
 
-        Returns:
-            bool: whether or not the given user is a member of ALL of the provided
-                  Google project IDs
-        """
+    Returns:
+        bool: whether or not the given user is a member of ALL of the provided
+              Google project IDs
+    """
     session = get_db_session(db)
     user = session.query(User).filter_by(id=user_id).first()
     if not user:
@@ -404,7 +404,7 @@ def is_user_member_of_all_google_projects(
 
 
 def get_user_by_linked_email(linked_email, db=None):
-    """"
+    """ "
     Return user identified by linked_email address
 
     Args:

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -152,7 +152,9 @@ class Oauth2ClientBase(object):
             raise AuthError("Refresh token expired. Please login again.")
 
         token_response = self.session.refresh_token(
-            url=token_endpoint, proxies=self.get_proxies(), refresh_token=refresh_token,
+            url=token_endpoint,
+            proxies=self.get_proxies(),
+            refresh_token=refresh_token,
         )
         new_refresh_token = token_response["refresh_token"]
 
@@ -166,7 +168,9 @@ class Oauth2ClientBase(object):
         """
         user.upstream_refresh_tokens = []
         upstream_refresh_token = UpstreamRefreshToken(
-            user=user, refresh_token=refresh_token, expires=expires,
+            user=user,
+            refresh_token=refresh_token,
+            expires=expires,
         )
         current_db_session = current_session.object_session(upstream_refresh_token)
         current_db_session.add(upstream_refresh_token)

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -77,7 +77,7 @@ def modify_client_action(
     arborist=None,
     policies=None,
     allowed_scopes=None,
-    append=False
+    append=False,
 ):
     driver = SQLAlchemyDriver(DB)
     with driver.session as s:

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -85,8 +85,13 @@ def modify_client_action(
         if not client:
             raise Exception("client {} does not exist".format(client))
         if urls:
-            client.redirect_uris = urls
-            logger.info("Changing urls to {}".format(urls))
+            print(append)
+            if append:
+                new_uri = client.redirect_uris + urls.split()
+                client.redirect_uris = new_uri
+            else:
+                client.redirect_uris = urls
+                logger.info("Changing urls to {}".format(urls))
         if delete_urls:
             client.redirect_uris = []
             logger.info("Deleting urls")
@@ -104,9 +109,10 @@ def modify_client_action(
             logger.info("Updating description to {}".format(description))
         if allowed_scopes:
             if append:
-                client._allowed_scopes += " " + allowed_scopes
+                new_scopes = client._allowed_scopes.split() + allowed_scopes.split()
+                client._allowed_scopes = " ".join(new_scopes)
             else:
-                client._allowed_scopes = allowed_scopes
+                client._allowed_scopes = "".join(allowed_scopes)
         s.commit()
     if arborist is not None and policies:
         arborist.update_client(client.client_id, policies)

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -85,9 +85,8 @@ def modify_client_action(
         if not client:
             raise Exception("client {} does not exist".format(client))
         if urls:
-            print(append)
             if append:
-                new_uri = client.redirect_uris + urls.split()
+                new_uri = client.redirect_uris + urls
                 client.redirect_uris = new_uri
             else:
                 client.redirect_uris = urls

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -88,6 +88,7 @@ def modify_client_action(
             if append:
                 new_uri = client.redirect_uris + urls
                 client.redirect_uris = new_uri
+                logger.info("Adding {} to urls".format(urls))
             else:
                 client.redirect_uris = urls
                 logger.info("Changing urls to {}".format(urls))
@@ -108,10 +109,12 @@ def modify_client_action(
             logger.info("Updating description to {}".format(description))
         if allowed_scopes:
             if append:
-                new_scopes = client._allowed_scopes.split() + allowed_scopes.split()
+                new_scopes = client._allowed_scopes.split() + allowed_scopes
                 client._allowed_scopes = " ".join(new_scopes)
+                logger.info("Adding {} to allowed_scopes".format(allowed_scopes))
             else:
                 client._allowed_scopes = "".join(allowed_scopes)
+                logger.info("Updating allowed_scopes to {}".format(allowed_scopes))
         s.commit()
     if arborist is not None and policies:
         arborist.update_client(client.client_id, policies)

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -86,8 +86,7 @@ def modify_client_action(
             raise Exception("client {} does not exist".format(client))
         if urls:
             if append:
-                new_uri = client.redirect_uris + urls
-                client.redirect_uris = new_uri
+                client.redirect_uris += urls
                 logger.info("Adding {} to urls".format(urls))
             else:
                 client.redirect_uris = urls

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -113,7 +113,7 @@ def modify_client_action(
                 client._allowed_scopes = " ".join(new_scopes)
                 logger.info("Adding {} to allowed_scopes".format(allowed_scopes))
             else:
-                client._allowed_scopes = "".join(allowed_scopes)
+                client._allowed_scopes = " ".join(allowed_scopes)
                 logger.info("Updating allowed_scopes to {}".format(allowed_scopes))
         s.commit()
     if arborist is not None and policies:

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -104,7 +104,7 @@ def modify_client_action(
             logger.info("Updating description to {}".format(description))
         if allowed_scopes:
             if append:
-                client._allowed_scopes.append(allowed_scopes)
+                client._allowed_scopes += " " + allowed_scopes
             else:
                 client._allowed_scopes = allowed_scopes
         s.commit()

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -76,6 +76,8 @@ def modify_client_action(
     unset_auto_approve=False,
     arborist=None,
     policies=None,
+    allowed_scopes=None,
+    append=False
 ):
     driver = SQLAlchemyDriver(DB)
     with driver.session as s:
@@ -100,6 +102,11 @@ def modify_client_action(
         if description:
             client.description = description
             logger.info("Updating description to {}".format(description))
+        if allowed_scopes:
+            if append:
+                client._allowed_scopes.append(allowed_scopes)
+            else:
+                client._allowed_scopes = allowed_scopes
         s.commit()
     if arborist is not None and policies:
         arborist.update_client(client.client_id, policies)

--- a/fence/scripting/google_monitor.py
+++ b/fence/scripting/google_monitor.py
@@ -159,8 +159,10 @@ def validation_check(db):
             )
 
             try:
-                user_email_list = _get_user_email_list_from_google_project_with_owner_role(
-                    google_project_id
+                user_email_list = (
+                    _get_user_email_list_from_google_project_with_owner_role(
+                        google_project_id
+                    )
                 )
             except GoogleAPIError:
                 logger.warning(
@@ -478,8 +480,10 @@ def _send_emails_informing_service_account_removal(
 
     for email, removal_reasons in invalid_service_account_reasons.items():
         if removal_reasons:
-            content += "\n\t - Service account {} was removed from Google Project {}.".format(
-                email, project_id
+            content += (
+                "\n\t - Service account {} was removed from Google Project {}.".format(
+                    email, project_id
+                )
             )
             for reason in removal_reasons:
                 content += "\n\t\t - {}".format(reason)

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -398,12 +398,14 @@ class UserSyncer(object):
         Returns:
             None
         """
-        execstr = 'lftp -u {},{}  {} -e "set ftp:proxy http://{}; mirror . {}; exit"'.format(
-            server.get("username", ""),
-            server.get("password", ""),
-            server.get("host", ""),
-            server.get("proxy", ""),
-            path,
+        execstr = (
+            'lftp -u {},{}  {} -e "set ftp:proxy http://{}; mirror . {}; exit"'.format(
+                server.get("username", ""),
+                server.get("password", ""),
+                server.get("host", ""),
+                server.get("proxy", ""),
+                path,
+            )
         )
         os.system(execstr)
 

--- a/tests/google/test_access_utils.py
+++ b/tests/google/test_access_utils.py
@@ -196,7 +196,7 @@ def test_project_has_invalid_membership(cloud_manager, db_session):
     """
     Test that a project with a non-users or service acounts
      has invalid membership
-     """
+    """
     (cloud_manager.get_project_membership.return_value) = [
         GooglePolicyMember("user", "user@gmail.com"),
         GooglePolicyMember("otherType", "other@gmail.com"),

--- a/tests/google/test_service_accounts.py
+++ b/tests/google/test_service_accounts.py
@@ -1038,7 +1038,7 @@ def test_valid_project_limit_service_account_registration(
     valid_service_account_patcher,
 ):
     """
-    Test that the projects are registered when there are SERVICE_ACCOUNT_LIMIT number of projects and the database is updated. 
+    Test that the projects are registered when there are SERVICE_ACCOUNT_LIMIT number of projects and the database is updated.
     """
     proj_patcher = valid_google_project_patcher
     project_access = []
@@ -1114,7 +1114,7 @@ def test_invalid_project_limit_service_account_registration(
     valid_google_project_patcher,
 ):
     """
-    Test that we get a 400 when there are SERVICE_ACCOUNT_LIMIT + 1 number of projects and the databse isn't updated. 
+    Test that we get a 400 when there are SERVICE_ACCOUNT_LIMIT + 1 number of projects and the databse isn't updated.
     """
     proj_patcher = valid_google_project_patcher
     project_access = []
@@ -1191,7 +1191,7 @@ def test_patch_service_account_invalid_limit(
 ):
     """
     Test that patching with new project_access returns 400
-    when more than SERVICE_ACCOUNT_LIMIT projects are trying to be registered. 
+    when more than SERVICE_ACCOUNT_LIMIT projects are trying to be registered.
     """
     encoded_creds_jwt = encoded_jwt_service_accounts_access["jwt"]
     service_account = register_user_service_account["service_account"]
@@ -1234,7 +1234,7 @@ def test_patch_service_account_valid_limit(
 ):
     """
     Test that patching with new project_access returns 204
-    when SERVICE_ACCOUNT_LIMIT number of projects is registered. 
+    when SERVICE_ACCOUNT_LIMIT number of projects is registered.
     """
     encoded_creds_jwt = encoded_jwt_service_accounts_access["jwt"]
     service_account = register_user_service_account["service_account"]

--- a/tests/link/test_link.py
+++ b/tests/link/test_link.py
@@ -737,8 +737,7 @@ def test_google_link_when_google_mocked(
     add_google_email_to_proxy_group_mock,
     monkeypatch,
 ):
-    """
-    """
+    """"""
     monkeypatch.setitem(config, "MOCK_GOOGLE_AUTH", True)
 
     user_id = encoded_creds_jwt["user_id"]

--- a/tests/login/test_google_login.py
+++ b/tests/login/test_google_login.py
@@ -42,7 +42,11 @@ def test_google_login_http_headers_are_less_than_4k_for_user_with_many_projects(
             for x in range(20)
         }
     }
-    user_info = {"test": {"tags": {},}}
+    user_info = {
+        "test": {
+            "tags": {},
+        }
+    }
     dbGaP = os.environ.get("dbGaP") or config.get("dbGaP")
     syncer = UserSyncer(dbGaP, config["DB"], {})
     syncer.sync_to_db_and_storage_backend(user_projects, user_info, db_session)

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1102,3 +1102,47 @@ def test_create_group(db_session):
     assert groups_in_db, "no group was created"
     assert len(groups_in_db) == 1
     assert group_name == groups_in_db[0].name
+
+
+def test_modify_client_action_modify_allowed_scopes(db_session):
+    client_id = "testid"
+    client_name = "test123"
+    client = Client(client_id=client_id, client_secret="secret", name=client_name, _allowed_scopes=["openid", "user", "data"])
+    db_session.add(client)
+    db_session.commit()
+    modify_client_action(
+        db_session,
+        client.name,
+        set_auto_approve=True,
+        name="test321",
+        description="test client",
+        urls=["test"],
+        allowed_scopes=["openid"]
+    )
+    list_client_action(db_session)
+    assert client.auto_approve == True
+    assert client.name == "test321"
+    assert client.description == "test client"
+    assert client._allowed_scopes == ["openid"]
+
+def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
+    client_id = "testid"
+    client_name = "test123"
+    client = Client(client_id=client_id, client_secret="secret", name=client_name, _allowed_scopes=["openid", "user", "data"])
+    db_session.add(client)
+    db_session.commit()
+    modify_client_action(
+        db_session,
+        client.name,
+        set_auto_approve=True,
+        name="test321",
+        description="test client",
+        urls=["test"],
+        append=True,
+        allowed_scopes="new_scope",
+    )
+    list_client_action(db_session)
+    assert client.auto_approve == True
+    assert client.name == "test321"
+    assert client.description == "test client"
+    assert client._allowed_scopes == ["openid", "user", "data", "new_scope"]

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1129,6 +1129,7 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
     assert client.name == "test321"
     assert client.description == "test client"
     assert client._allowed_scopes == "openid"
+    assert client.redirect_uris == ["test"]
 
 
 def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
@@ -1148,7 +1149,6 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
         set_auto_approve=True,
         name="test321",
         description="test client",
-        urls=["test"],
         append=True,
         allowed_scopes="new_scope",
     )
@@ -1157,3 +1157,33 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
     assert client.name == "test321"
     assert client.description == "test client"
     assert client._allowed_scopes == "openid user data new_scope"
+
+
+def test_modify_client_action_modify_append_url(db_session):
+    client_id = "testid"
+    client_name = "test123"
+    client = Client(
+        client_id=client_id,
+        client_secret="secret",
+        name=client_name,
+        _allowed_scopes="openid user data",
+        redirect_uris="abcd",
+    )
+    db_session.add(client)
+    db_session.commit()
+    modify_client_action(
+        db_session,
+        client.name,
+        set_auto_approve=True,
+        name="test321",
+        description="test client",
+        urls="test",
+        append=True,
+        allowed_scopes="new_scope",
+    )
+    list_client_action(db_session)
+    assert client.auto_approve == True
+    assert client.name == "test321"
+    assert client.description == "test client"
+    assert client._allowed_scopes == "openid user data new_scope"
+    assert client.redirect_uris == ["abcd", "test"]

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1111,7 +1111,7 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
         client_id=client_id,
         client_secret="secret",
         name=client_name,
-        _allowed_scopes=["openid", "user", "data"],
+        _allowed_scopes="openid user data",
     )
     db_session.add(client)
     db_session.commit()
@@ -1122,13 +1122,13 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
         name="test321",
         description="test client",
         urls=["test"],
-        allowed_scopes=["openid"],
+        allowed_scopes="openid",
     )
     list_client_action(db_session)
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client._allowed_scopes == ["openid"]
+    assert client._allowed_scopes == "openid"
 
 
 def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
@@ -1138,7 +1138,7 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
         client_id=client_id,
         client_secret="secret",
         name=client_name,
-        _allowed_scopes=["openid", "user", "data"],
+        _allowed_scopes="openid user data",
     )
     db_session.add(client)
     db_session.commit()
@@ -1156,4 +1156,4 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client._allowed_scopes == ["openid", "user", "data", "new_scope"]
+    assert client._allowed_scopes == "openid user data new_scope"

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1122,7 +1122,7 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
         name="test321",
         description="test client",
         urls=["test"],
-        allowed_scopes="openid",
+        allowed_scopes=["openid"],
     )
     list_client_action(db_session)
     assert client.auto_approve == True
@@ -1150,7 +1150,7 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
         name="test321",
         description="test client",
         append=True,
-        allowed_scopes="new_scope",
+        allowed_scopes=["new_scope"],
     )
     list_client_action(db_session)
     assert client.auto_approve == True
@@ -1179,11 +1179,9 @@ def test_modify_client_action_modify_append_url(db_session):
         description="test client",
         urls=["test"],
         append=True,
-        allowed_scopes="new_scope",
     )
     list_client_action(db_session)
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client._allowed_scopes == "openid user data new_scope"
     assert client.redirect_uris == ["abcd", "test"]

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1177,7 +1177,7 @@ def test_modify_client_action_modify_append_url(db_session):
         set_auto_approve=True,
         name="test321",
         description="test client",
-        urls="test",
+        urls=["test"],
         append=True,
         allowed_scopes="new_scope",
     )

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1107,7 +1107,12 @@ def test_create_group(db_session):
 def test_modify_client_action_modify_allowed_scopes(db_session):
     client_id = "testid"
     client_name = "test123"
-    client = Client(client_id=client_id, client_secret="secret", name=client_name, _allowed_scopes=["openid", "user", "data"])
+    client = Client(
+        client_id=client_id,
+        client_secret="secret",
+        name=client_name,
+        _allowed_scopes=["openid", "user", "data"],
+    )
     db_session.add(client)
     db_session.commit()
     modify_client_action(
@@ -1117,7 +1122,7 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
         name="test321",
         description="test client",
         urls=["test"],
-        allowed_scopes=["openid"]
+        allowed_scopes=["openid"],
     )
     list_client_action(db_session)
     assert client.auto_approve == True
@@ -1125,10 +1130,16 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
     assert client.description == "test client"
     assert client._allowed_scopes == ["openid"]
 
+
 def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
     client_id = "testid"
     client_name = "test123"
-    client = Client(client_id=client_id, client_secret="secret", name=client_name, _allowed_scopes=["openid", "user", "data"])
+    client = Client(
+        client_id=client_id,
+        client_secret="secret",
+        name=client_name,
+        _allowed_scopes=["openid", "user", "data"],
+    )
     db_session.add(client)
     db_session.commit()
     modify_client_action(

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -99,7 +99,8 @@ def test_create_client_inits_default_allowed_scopes(db_session):
         assert saved_client._allowed_scopes == " ".join(config["CLIENT_ALLOWED_SCOPES"])
 
     create_client_action_wrapper(
-        to_test, client_name=client_name,
+        to_test,
+        client_name=client_name,
     )
 
 
@@ -116,7 +117,9 @@ def test_create_client_inits_passed_allowed_scopes(db_session):
         assert saved_client._allowed_scopes == "openid user data"
 
     create_client_action_wrapper(
-        to_test, client_name=client_name, allowed_scopes=["openid", "user", "data"],
+        to_test,
+        client_name=client_name,
+        allowed_scopes=["openid", "user", "data"],
     )
 
 
@@ -133,7 +136,9 @@ def test_create_client_adds_openid_when_not_in_allowed_scopes(db_session):
         assert saved_client._allowed_scopes == "user data openid"
 
     create_client_action_wrapper(
-        to_test, client_name=client_name, allowed_scopes=["user", "data"],
+        to_test,
+        client_name=client_name,
+        allowed_scopes=["user", "data"],
     )
 
 
@@ -1122,13 +1127,13 @@ def test_modify_client_action_modify_allowed_scopes(db_session):
         name="test321",
         description="test client",
         urls=["test"],
-        allowed_scopes=["openid"],
+        allowed_scopes=["openid", "user", "test"],
     )
     list_client_action(db_session)
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client._allowed_scopes == "openid"
+    assert client._allowed_scopes == "openid user test"
     assert client.redirect_uris == ["test"]
 
 
@@ -1150,13 +1155,15 @@ def test_modify_client_action_modify_allowed_scopes_append_true(db_session):
         name="test321",
         description="test client",
         append=True,
-        allowed_scopes=["new_scope"],
+        allowed_scopes=["new_scope", "new_scope_2", "new_scope_3"],
     )
     list_client_action(db_session)
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client._allowed_scopes == "openid user data new_scope"
+    assert (
+        client._allowed_scopes == "openid user data new_scope new_scope_2 new_scope_3"
+    )
 
 
 def test_modify_client_action_modify_append_url(db_session):
@@ -1177,11 +1184,11 @@ def test_modify_client_action_modify_append_url(db_session):
         set_auto_approve=True,
         name="test321",
         description="test client",
-        urls=["test"],
+        urls=["test1", "test2", "test3"],
         append=True,
     )
     list_client_action(db_session)
     assert client.auto_approve == True
     assert client.name == "test321"
     assert client.description == "test client"
-    assert client.redirect_uris == ["abcd", "test"]
+    assert client.redirect_uris == ["abcd", "test1", "test2", "test3"]


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Added functionality to modify `allowed_scopes` to existing clients using `fence-create client-modify --client CLIENT_NAME --allowed-scopes NEW_SCOPE`
- Added functionality to append `allowed_scopes` to existing clients using `fence-create client-modify --client CLIENT_NAME --allowed-scopes NEW_SCOPE --append`
- Added functionality to append `urls` to existing clients using `fence-create client-modify --client CLIENT_NAME --urls NEW_URL --append`
