### PR TITLE
Fix: Consent deny redirect bug

### DIFF
--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -74,7 +74,6 @@ class DefaultOAuth2Callback(Resource):
         # Check if user granted access
         if flask.request.args.get("error"):
 
-           
             request_url = flask.request.url
             received_query_params = parse_qsl(
                 urlparse(request_url).query, keep_blank_values=True
@@ -84,10 +83,14 @@ class DefaultOAuth2Callback(Resource):
                 urlparse(redirect_uri).query, keep_blank_values=True
             )
             if "client_id" in redirect_uri:
-                redirect_query_dict = parse_qs(urlparse(redirect_uri).query, keep_blank_values=True)
+                redirect_query_dict = parse_qs(
+                    urlparse(redirect_uri).query, keep_blank_values=True
+                )
                 client_id = redirect_query_dict["client_id"][0]
                 with flask.current_app.db.session as session:
-                    client = session.query(Client).filter_by(client_id=client_id).first()
+                    client = (
+                        session.query(Client).filter_by(client_id=client_id).first()
+                    )
                     redirect_uri = client.redirect_uri
 
             final_query_params = urlencode(

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -82,7 +82,7 @@ class DefaultOAuth2Callback(Resource):
             redirect_query_params = parse_qsl(
                 urlparse(redirect_uri).query, keep_blank_values=True
             )
-            if "client_id" in redirect_uri:
+            if "client_id" in redirect_query_params:
                 redirect_query_dict = parse_qs(
                     urlparse(redirect_uri).query, keep_blank_values=True
                 )

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -85,9 +85,10 @@ class DefaultOAuth2Callback(Resource):
             )
             if "client_id" in redirect_uri:
                 redirect_query_dict = parse_qs(urlparse(redirect_uri).query, keep_blank_values=True)
-                client_id = redirect_query_dict["client_id"]
+                client_id = redirect_query_dict["client_id"][0]
                 with flask.current_app.db.session as session:
                     client = session.query(Client).filter_by(client_id=client_id).first()
+                    redirect_uri = client.redirect_uri
 
             final_query_params = urlencode(
                 redirect_query_params + received_query_params

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -1,6 +1,6 @@
 import flask
 from flask_restful import Resource
-from urllib.parse import urlparse, urlencode, parse_qsl, parse_qs
+from urllib.parse import urlparse, urlencode, parse_qsl
 
 from fence.auth import login_user
 from fence.blueprints.login.redirect import validate_redirect
@@ -84,7 +84,6 @@ class DefaultOAuth2Callback(Resource):
             )
             client_id = dict(redirect_query_params).get("client_id")
             if client_id:
-                client_id = client_id[0]
                 with flask.current_app.db.session as session:
                     client = (
                         session.query(Client).filter_by(client_id=client_id).first()

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -82,11 +82,9 @@ class DefaultOAuth2Callback(Resource):
             redirect_query_params = parse_qsl(
                 urlparse(redirect_uri).query, keep_blank_values=True
             )
-            if "client_id" in redirect_query_params:
-                redirect_query_dict = parse_qs(
-                    urlparse(redirect_uri).query, keep_blank_values=True
-                )
-                client_id = redirect_query_dict["client_id"][0]
+            client_id = dict(redirect_query_params).get("client_id")
+            if client_id:
+                client_id = client_id[0]
                 with flask.current_app.db.session as session:
                     client = (
                         session.query(Client).filter_by(client_id=client_id).first()


### PR DESCRIPTION
Hitting the 'Deny' button in the consent screen for NIH RAS would redirect you back to the `/authorization` endpoint which in turn would take you back to the RAS Consent Screen when you go through this flow using a different client than the windmill client. 

### Bug Fixes
- Fixed consent Deny redirecting users back to the consent screen. 
