### PR TITLE
fix(dependency): pin cirrus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 gen3authz==0.4.0
 gen3config==0.1.7
-gen3cirrus==1.1.2
+gen3cirrus>=1.2.0
 gen3users
 httplib2==0.17.0
 markdown==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ flask-restful==0.3.6
 Flask_SQLAlchemy_Session==1.1
 gen3authz==0.4.0
 gen3config==0.1.7
-gen3cirrus>=1.2.0
+gen3cirrus>=1.2.0,<2.0.0
 gen3users
 httplib2==0.17.0
 markdown==3.1.1


### PR DESCRIPTION
To resolve `error: six 1.11.0 is installed but six<2dev,>=1.13.0 is required by {'google-api-python-client'}`. Pinned google-api-python-client in cirrus [uc-cdis/cirrus#82](https://github.com/uc-cdis/cirrus/pull/82)


### Dependency updates
- Change gen3cirrus to >=1.2.0 