### PR TITLE
fix: remove SIX from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ python_dateutil==2.6.1
 PyJWT==1.5.3
 requests>=2.18.0,<3.0.0
 setuptools>=40.3.0
-six==1.11.0
 SQLAlchemy==1.3.3
 temps==0.3.0
 userdatamodel>=2.3.3


### PR DESCRIPTION
Removing `six` from requirements.txt

This was creating an issue in building the Fence image in Quay