### PR TITLE
Feat/refresh expires in

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -64,10 +64,11 @@ def get_signed_url_for_file(action, file_id, file_name=None):
         force_signed_url = False
 
     indexed_file = IndexedFile(file_id)
-    expires_in = config.get("MAX_PRESIGNED_URL_TTL", 3600)
-    requested_expires_in = get_valid_expiration_from_request()
-    if requested_expires_in:
-        expires_in = min(requested_expires_in, expires_in)
+    default_expires_in = config.get("MAX_PRESIGNED_URL_TTL", 3600)
+    expires_in = get_valid_expiration_from_request(
+        max_limit=default_expires_in,
+        default=default_expires_in,
+    )
 
     signed_url = indexed_file.get_signed_url(
         requested_protocol,

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -29,7 +29,7 @@ from fence.jwt.token import SCOPE_DESCRIPTION
 from fence.models import Client
 from fence.oidc.endpoints import RevocationEndpoint
 from fence.oidc.server import server
-from fence.utils import clear_cookies, get_valid_expiration_from_request
+from fence.utils import clear_cookies
 from fence.user import get_current_user
 from fence.config import config
 
@@ -70,19 +70,6 @@ def authorize(*args, **kwargs):
         user = get_current_user()
     except Unauthorized:
         need_authentication = True
-
-        
-    ### Matt dev'ing ###
-
-    # requested lifetime (in seconds) of the refresh token
-    requested_expires_in = get_valid_expiration_from_request()
-
-    print("HERE! -> /authorize - token expiration: ", requested_expires_in)
-
-    if requested_expires_in:
-        flask.session["refresh_token_expires_in"] = requested_expires_in
-
-    ### ------ ###
 
     if need_authentication or not user:
         redirect_url = config.get("BASE_URL") + flask.request.full_path

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -29,7 +29,7 @@ from fence.jwt.token import SCOPE_DESCRIPTION
 from fence.models import Client
 from fence.oidc.endpoints import RevocationEndpoint
 from fence.oidc.server import server
-from fence.utils import clear_cookies
+from fence.utils import clear_cookies, get_valid_expiration_from_request
 from fence.user import get_current_user
 from fence.config import config
 
@@ -70,6 +70,16 @@ def authorize(*args, **kwargs):
         user = get_current_user()
     except Unauthorized:
         need_authentication = True
+
+        
+    ### Matt dev'ing ###
+
+    # requested lifetime (in seconds) of the refresh token
+    requested_expires_in = get_valid_expiration_from_request()
+    if requested_expires_in:
+        flask.session["refresh_token_expires_in"] = requested_expires_in
+
+    ### ------ ###
 
     if need_authentication or not user:
         redirect_url = config.get("BASE_URL") + flask.request.full_path

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -76,6 +76,9 @@ def authorize(*args, **kwargs):
 
     # requested lifetime (in seconds) of the refresh token
     requested_expires_in = get_valid_expiration_from_request()
+
+    print("HERE! -> /authorize - token expiration: ", requested_expires_in)
+
     if requested_expires_in:
         flask.session["refresh_token_expires_in"] = requested_expires_in
 

--- a/fence/blueprints/storage_creds/google.py
+++ b/fence/blueprints/storage_creds/google.py
@@ -232,10 +232,11 @@ class GoogleCredentialsList(Resource):
         """
         # requested time (in seconds) during which the access key will be valid
         # x days * 24 hr/day * 60 min/hr * 60 s/min = y seconds
-        expires_in = cirrus_config.SERVICE_KEY_EXPIRATION_IN_DAYS * 24 * 60 * 60
-        requested_expires_in = get_valid_expiration_from_request()
-        if requested_expires_in:
-            expires_in = min(expires_in, requested_expires_in)
+        default_expires_in = cirrus_config.SERVICE_KEY_EXPIRATION_IN_DAYS * 24 * 60 * 60
+        expires_in = get_valid_expiration_from_request(
+            max_limit=default_expires_in,
+            default=default_expires_in,
+        )
 
         expiration_time = int(time.time()) + int(expires_in)
         key_id = key.get("private_key_id")

--- a/fence/models.py
+++ b/fence/models.py
@@ -245,7 +245,18 @@ class AuthorizationCode(Base, OAuth2AuthorizationCodeMixin):
 
     nonce = Column(String, nullable=True)
 
-    refresh_token_expires_in = Column(Integer, nullable=True)
+    # only init this column if it actually exists in the db
+    # for handling case of pre-db-migration
+    with flask.current_app.db.session as session:
+        results = session.execute(
+            """
+            SELECT column_name 
+            FROM information_schema.columns
+            WHERE table_name = 'authorization_code' AND column_name = 'refresh_token_expires_in'
+            """
+        )
+    if results.rowcount > 0:
+        refresh_token_expires_in = Column(Integer, nullable=True)
 
     _scope = Column(Text, default="")
 

--- a/fence/models.py
+++ b/fence/models.py
@@ -245,18 +245,7 @@ class AuthorizationCode(Base, OAuth2AuthorizationCodeMixin):
 
     nonce = Column(String, nullable=True)
 
-    # only init this column if it actually exists in the db
-    # for handling case of pre-db-migration
-    with flask.current_app.db.session as session:
-        results = session.execute(
-            """
-            SELECT column_name 
-            FROM information_schema.columns
-            WHERE table_name = 'authorization_code' AND column_name = 'refresh_token_expires_in'
-            """
-        )
-    if results.rowcount > 0:
-        refresh_token_expires_in = Column(Integer, nullable=True)
+    refresh_token_expires_in = Column(Integer, nullable=True)
 
     _scope = Column(Text, default="")
 

--- a/fence/models.py
+++ b/fence/models.py
@@ -245,6 +245,8 @@ class AuthorizationCode(Base, OAuth2AuthorizationCodeMixin):
 
     nonce = Column(String, nullable=True)
 
+    refresh_token_expires_in = Column(Integer, nullable=True)
+
     _scope = Column(Text, default="")
 
     def __init__(self, **kwargs):

--- a/fence/models.py
+++ b/fence/models.py
@@ -662,6 +662,14 @@ def migrate(driver):
         metadata=md,
     )
 
+    #here
+    add_column_if_not_exist(
+        table_name=AuthorizationCode.__tablename__,
+        column=Column("refresh_token_expires_in", Integer),
+        driver=driver,
+        metadata=md,
+    )
+
     drop_foreign_key_column_if_exist(
         table_name=GoogleProxyGroup.__tablename__,
         column_name="user_id",

--- a/fence/models.py
+++ b/fence/models.py
@@ -662,7 +662,6 @@ def migrate(driver):
         metadata=md,
     )
 
-    #here
     add_column_if_not_exist(
         table_name=AuthorizationCode.__tablename__,
         column=Column("refresh_token_expires_in", Integer),

--- a/fence/models.py
+++ b/fence/models.py
@@ -256,21 +256,6 @@ class AuthorizationCode(Base, OAuth2AuthorizationCodeMixin):
                 kwargs["_scope"] = " ".join(scope)
             else:
                 kwargs["_scope"] = scope
-        
-        #here - handle case of pre-db-migration
-        # only include "refresh_token_expires_in" if that column exists
-        if "refresh_token_expires_in" in kwargs:
-            refresh_token_expires_in = kwargs.pop("refresh_token_expires_in")
-            with flask.current_app.db.session as session:
-                results = session.execute(
-                    """
-                    SELECT column_name 
-                    FROM information_schema.columns
-                    WHERE table_name = 'authorization_code' AND column_name = 'refresh_token_expires_in'
-                    """
-                )
-            if results.rowcount > 0:
-                kwargs["refresh_token_expires_in"] = refresh_token_expires_in
         super(AuthorizationCode, self).__init__(**kwargs)
 
     @property

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -10,10 +10,12 @@ import flask
 from fence.utils import get_valid_expiration_from_request
 from fence.config import config
 from fence.models import AuthorizationCode, ClientAuthType, User
+from sqlalchemy.ext.automap import automap_base
 from sqlalchemy import (
     MetaData,
     Table,
 )
+
 
 
 class OpenIDCodeGrant(grants.OpenIDCodeGrant):
@@ -80,7 +82,10 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         else:
             # db hasn't been migrated yet
             # i.e., the "refresh_token_expires_in" column hasn't been added to this table yet
-            code = dbAuthorizationCodeTable(
+            Base = automap_base()
+            Base.prepare(flask.current_app.db.engine, reflect=True)
+            reflectedAuthorizationCode = Base.classes.authorization_code
+            code = reflectedAuthorizationCode(
                 code=generate_token(50),
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -39,14 +39,10 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
         # requested lifetime (in seconds) for the refresh token
         refresh_token_expires_in = get_valid_expiration_from_request(
-            expiry_param="refresh_token_expires_in"
+            expiry_param="refresh_token_expires_in",
+            max_limit=config["REFRESH_TOKEN_EXPIRES_IN"],
+            default=config["REFRESH_TOKEN_EXPIRES_IN"],
         )
-        if refresh_token_expires_in:
-            refresh_token_expires_in = min(
-                refresh_token_expires_in, config["REFRESH_TOKEN_EXPIRES_IN"]
-            )
-        else:
-            refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
 
         code = AuthorizationCode(
             code=generate_token(50),

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -85,11 +85,20 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
             Base = automap_base()
             Base.prepare(flask.current_app.db.engine, reflect=True)
             reflectedAuthorizationCode = Base.classes.authorization_code
+
+            # handle this pre-processing check/step
+            # see AuthorizationCode class for why this is here.
+            scope = request.scope
+            if isinstance(scope, list):
+                _scope = " ".join(scope)
+            else:
+                _scope = scope
+
             code = reflectedAuthorizationCode(
                 code=generate_token(50),
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                _scope=_scope,
                 user_id=grant_user.id,
                 nonce=request.data.get("nonce"),
             )

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -58,6 +58,8 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         # >>> [c.name for c in messages.columns]
         # ['message_id', 'message_name', 'date']
 
+        ## see: https://docs.sqlalchemy.org/en/13/core/reflection.html
+
         dbAuthorizationCodeTable = Table(
             "authorization_code",
             MetaData(),

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -10,6 +10,10 @@ import flask
 from fence.utils import get_valid_expiration_from_request
 from fence.config import config
 from fence.models import AuthorizationCode, ClientAuthType, User
+from sqlalchemy import (
+    MetaData,
+    Table,
+)
 
 
 class OpenIDCodeGrant(grants.OpenIDCodeGrant):
@@ -46,15 +50,42 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         else:
             refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
 
-        code = AuthorizationCode(
-            code=generate_token(50),
-            client_id=client.client_id,
-            redirect_uri=request.redirect_uri,
-            scope=request.scope,
-            user_id=grant_user.id,
-            nonce=request.data.get("nonce"),
-            refresh_token_expires_in=refresh_token_expires_in,
+
+        #here
+        ### doing some introspection ###
+        # app.db = SQLAlchemyDriver(config["DB"])
+        # >>> messages = Table('messages', meta, autoload=True, autoload_with=engine)
+        # >>> [c.name for c in messages.columns]
+        # ['message_id', 'message_name', 'date']
+
+        dbAuthorizationCodeTable = Table(
+            "authorization_code",
+            MetaData(),
+            autoload=True,
+            autoload_with=flask.current_app.db.engine
         )
+
+        if "refresh_token_expires_in" in dbAuthorizationCodeTable.columns:
+            code = AuthorizationCode(
+                code=generate_token(50),
+                client_id=client.client_id,
+                redirect_uri=request.redirect_uri,
+                scope=request.scope,
+                user_id=grant_user.id,
+                nonce=request.data.get("nonce"),
+                refresh_token_expires_in=refresh_token_expires_in,
+            )
+        else:
+            # db hasn't been migrated yet
+            # i.e., the "refresh_token_expires_in" column hasn't been added to this table yet
+            code = dbAuthorizationCodeTable(
+                code=generate_token(50),
+                client_id=client.client_id,
+                redirect_uri=request.redirect_uri,
+                scope=request.scope,
+                user_id=grant_user.id,
+                nonce=request.data.get("nonce"),
+            )
 
         with flask.current_app.db.session as session:
             session.add(code)
@@ -75,6 +106,12 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
         scope = authorization_code.scope
         nonce = authorization_code.nonce
+
+        # might cause an error if that name doesn't exist
+        # hopefully it just returns None?
+        # probably will error.
+        # if so, do try / except - if err, log warning db needs to be migrated
+        #here
         refresh_token_expires_in = authorization_code.refresh_token_expires_in
 
         token = self.generate_token(

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -40,7 +40,9 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         # requested lifetime (in seconds) for the refresh token
         refresh_token_expires_in = get_valid_expiration_from_request()
         if refresh_token_expires_in:
-            refresh_token_expires_in = min(refresh_token_expires_in, config["REFRESH_TOKEN_EXPIRES_IN"])
+            refresh_token_expires_in = min(
+                refresh_token_expires_in, config["REFRESH_TOKEN_EXPIRES_IN"]
+            )
         else:
             refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
 

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -123,12 +123,17 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         scope = authorization_code.scope
         nonce = authorization_code.nonce
 
-        # might cause an error if that name doesn't exist
-        # hopefully it just returns None?
-        # probably will error.
-        # if so, do try / except - if err, log warning db needs to be migrated
         #here
-        refresh_token_expires_in = authorization_code.refresh_token_expires_in
+        dbAuthorizationCodeTable = Table(
+            "authorization_code",
+            MetaData(),
+            autoload=True,
+            autoload_with=flask.current_app.db.engine
+        )
+        if "refresh_token_expires_in" in dbAuthorizationCodeTable.columns:
+            refresh_token_expires_in = authorization_code.refresh_token_expires_in
+        else:
+            refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
 
         token = self.generate_token(
             client,

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -46,16 +46,40 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         else:
             refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
 
-        code = AuthorizationCode(
-            code=generate_token(50),
-            client_id=client.client_id,
-            redirect_uri=request.redirect_uri,
-            scope=request.scope,
-            user_id=grant_user.id,
-            nonce=request.data.get("nonce"),
-            refresh_token_expires_in=refresh_token_expires_in,
-        )
+        #here - handle case - db migration hasn't occurred yet
+        with flask.current_app.db.session as session:
+            result = session.execute(
+                """
+                SELECT column_name 
+                FROM information_schema.columns
+                WHERE table_name = 'authorization_code' AND column_name = 'refresh_token_expires_in'
+                """
+            )
 
+        if result.rowcount > 0:
+            code = AuthorizationCode(
+                code=generate_token(50),
+                client_id=client.client_id,
+                redirect_uri=request.redirect_uri,
+                scope=request.scope,
+                user_id=grant_user.id,
+                nonce=request.data.get("nonce"),
+                refresh_token_expires_in=refresh_token_expires_in,
+            )
+        else:
+            # don't include "refresh_token_expires_in" param
+            # because db migration hasn't occurred yet
+            # i.e., that "refresh_token_expires_in" col doesn't exist
+            # in the authorization_code table
+            code = AuthorizationCode(
+                code=generate_token(50),
+                client_id=client.client_id,
+                redirect_uri=request.redirect_uri,
+                scope=request.scope,
+                user_id=grant_user.id,
+                nonce=request.data.get("nonce"),
+            )
+            
         with flask.current_app.db.session as session:
             session.add(code)
             session.commit()

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -73,6 +73,7 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
 
         scope = authorization_code.scope
         nonce = authorization_code.nonce
+        refresh_token_expires_in = authorization_code.refresh_token_expires_in
 
         token = self.generate_token(
             client,
@@ -81,6 +82,7 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
             scope=scope,
             include_refresh_token=client.has_client_secret(),
             nonce=nonce,
+            refresh_token_expires_in=refresh_token_expires_in,
         )
 
         self.request.user = user

--- a/fence/oidc/grants/oidc_code_grant.py
+++ b/fence/oidc/grants/oidc_code_grant.py
@@ -38,7 +38,9 @@ class OpenIDCodeGrant(grants.OpenIDCodeGrant):
         """
 
         # requested lifetime (in seconds) for the refresh token
-        refresh_token_expires_in = get_valid_expiration_from_request()
+        refresh_token_expires_in = get_valid_expiration_from_request(
+            expiry_param="refresh_token_expires_in"
+        )
         if refresh_token_expires_in:
             refresh_token_expires_in = min(
                 refresh_token_expires_in, config["REFRESH_TOKEN_EXPIRES_IN"]

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -132,6 +132,7 @@ def generate_token_response(
     client,
     grant_type,
     expires_in=None,
+    refresh_token_expires_in=None,
     user=None,
     scope=None,
     include_refresh_token=True,
@@ -201,11 +202,13 @@ def generate_token_response(
     # If ``refresh_token`` was passed (for instance from the refresh
     # grant), use that instead of generating a new one.
     if refresh_token is None:
+        if refresh_token_expires_in is None:
+            refresh_token_expires_in = config["REFRESH_TOKEN_EXPIRES_IN"]
         refresh_token = generate_signed_refresh_token(
             kid=keypair.kid,
             private_key=keypair.private_key,
             user=user,
-            expires_in=config["REFRESH_TOKEN_EXPIRES_IN"],
+            expires_in=refresh_token_expires_in,
             scopes=scope,
             client_id=client.client_id,
         ).token

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -201,23 +201,11 @@ def generate_token_response(
     # If ``refresh_token`` was passed (for instance from the refresh
     # grant), use that instead of generating a new one.
     if refresh_token is None:
-        
-        ### Matt dev'ing ###
-
-        exp = config["REFRESH_TOKEN_EXPIRES_IN"]
-        if "refresh_token_expires_in" in flask.session:
-            exp = min(flask.session["refresh_token_expires_in"], exp)
-
-        print("HERE! /token -> refresh_token expire time: ", exp)
-
-        ### ------------ ###
-
         refresh_token = generate_signed_refresh_token(
             kid=keypair.kid,
             private_key=keypair.private_key,
             user=user,
-            # expires_in=config["REFRESH_TOKEN_EXPIRES_IN"], # prev
-            expires_in=exp,
+            expires_in=config["REFRESH_TOKEN_EXPIRES_IN"],
             scopes=scope,
             client_id=client.client_id,
         ).token

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -201,11 +201,21 @@ def generate_token_response(
     # If ``refresh_token`` was passed (for instance from the refresh
     # grant), use that instead of generating a new one.
     if refresh_token is None:
+        
+        ### Matt dev'ing ###
+
+        exp = config["REFRESH_TOKEN_EXPIRES_IN"]
+        if flask.session["refresh_token_expires_in"]:
+            exp = min(flask.session["refresh_token_expires_in"], exp)
+
+        ### ------------ ###
+
         refresh_token = generate_signed_refresh_token(
             kid=keypair.kid,
             private_key=keypair.private_key,
             user=user,
-            expires_in=config["REFRESH_TOKEN_EXPIRES_IN"],
+            # expires_in=config["REFRESH_TOKEN_EXPIRES_IN"], # prev
+            expires_in=exp,
             scopes=scope,
             client_id=client.client_id,
         ).token

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -208,6 +208,8 @@ def generate_token_response(
         if "refresh_token_expires_in" in flask.session:
             exp = min(flask.session["refresh_token_expires_in"], exp)
 
+        print("HERE! /token -> refresh_token expire time: ", exp)
+
         ### ------------ ###
 
         refresh_token = generate_signed_refresh_token(

--- a/fence/oidc/jwt_generator.py
+++ b/fence/oidc/jwt_generator.py
@@ -205,7 +205,7 @@ def generate_token_response(
         ### Matt dev'ing ###
 
         exp = config["REFRESH_TOKEN_EXPIRES_IN"]
-        if flask.session["refresh_token_expires_in"]:
+        if "refresh_token_expires_in" in flask.session:
             exp = min(flask.session["refresh_token_expires_in"], exp)
 
         ### ------------ ###

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -52,7 +52,7 @@ from fence.models import (
 from fence.scripting.google_monitor import email_users_without_access, validation_check
 from fence.config import config
 from fence.sync.sync_users import UserSyncer
-from fence.utils import create_client, is_valid_expiration
+from fence.utils import create_client, get_valid_expiration
 
 logger = get_logger(__name__)
 
@@ -1444,16 +1444,17 @@ def force_update_google_link(DB, username, google_email, expires_in=None):
                 user_id, google_email, session
             )
 
-        # timestamp at which the SA will lose bucket access
+        # time until the SA will lose bucket access
         # by default: use configured time or 7 days
-        expiration = int(time.time()) + config.get(
+        default_expires_in = config.get(
             "GOOGLE_USER_SERVICE_ACCOUNT_ACCESS_EXPIRES_IN", 604800
         )
-        if expires_in:
-            is_valid_expiration(expires_in)
-            # convert it to timestamp
-            requested_expiration = int(time.time()) + expires_in
-            expiration = min(expiration, requested_expiration)
+        # use expires_in from arg if it was provided and it was not greater than the default
+        expires_in = get_valid_expiration(
+            expires_in, max_limit=default_expires_in, default=default_expires_in
+        )
+        # convert expires_in to timestamp
+        expiration = int(time.time() + expires_in)
 
         force_update_user_google_account_expiration(
             user_google_account, proxy_group_id, google_email, expiration, session

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -275,14 +275,14 @@ def send_email(from_email, to_emails, subject, text, smtp_domain):
     )
 
 
-def get_valid_expiration_from_request():
+def get_valid_expiration_from_request(expiry_param="expires_in"):
     """
-    Return the expires_in param if it is in the request, None otherwise.
-    Throw an error if the requested expires_in is not a positive integer.
+    Get the specified expiry_param (default "expires_in") from the request params.
+    Throw an error if the result is not a positive integer.
     """
-    if "expires_in" in flask.request.args:
-        is_valid_expiration(flask.request.args["expires_in"])
-        return int(flask.request.args["expires_in"])
+    if expiry_param in flask.request.args:
+        is_valid_expiration(flask.request.args[expiry_param])
+        return int(flask.request.args[expiry_param])
     else:
         return None
 
@@ -292,10 +292,14 @@ def is_valid_expiration(expires_in):
     Throw an error if expires_in is not a positive integer.
     """
     try:
-        expires_in = int(flask.request.args["expires_in"])
+        expires_in = int(expires_in)
         assert expires_in > 0
     except (ValueError, AssertionError):
-        raise UserError("expires_in must be a positive integer")
+        raise UserError(
+            "Requested expiry must be a positive integer; instead got {}".format(
+                expires_in
+            )
+        )
 
 
 def _print_func_name(function):

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -275,29 +275,38 @@ def send_email(from_email, to_emails, subject, text, smtp_domain):
     )
 
 
-def get_valid_expiration_from_request(expiry_param="expires_in"):
+def get_valid_expiration_from_request(
+    expiry_param="expires_in", max_limit=None, default=None
+):
     """
-    Get the specified expiry_param (default "expires_in") from the request params.
-    Throw an error if the result is not a positive integer.
+    Thin wrapper around get_valid_expiration; looks for default query parameter "expires_in"
+    in flask request, unless a different parameter name was specified.
     """
-    if expiry_param in flask.request.args:
-        is_valid_expiration(flask.request.args[expiry_param])
-        return int(flask.request.args[expiry_param])
-    else:
-        return None
+    return get_valid_expiration(
+        flask.request.args.get(expiry_param), max_limit=max_limit, default=default
+    )
 
 
-def is_valid_expiration(expires_in):
+def get_valid_expiration(requested_expiration, max_limit=None, default=None):
     """
-    Throw an error if expires_in is not a positive integer.
+    If requested_expiration is not a positive integer and not None, throw error.
+    If max_limit is provided and requested_expiration exceeds max_limit,
+      return max_limit.
+    If requested_expiration is None, return default (which may also be None).
+    Else return requested_expiration.
     """
+    if requested_expiration is None:
+        return default
     try:
-        expires_in = int(expires_in)
-        assert expires_in > 0
+        rv = int(requested_expiration)
+        assert rv > 0
+        if max_limit:
+            rv = min(rv, max_limit)
+        return rv
     except (ValueError, AssertionError):
         raise UserError(
             "Requested expiry must be a positive integer; instead got {}".format(
-                expires_in
+                requested_expiration
             )
         )
 


### PR DESCRIPTION
Ticket: https://ctds-planx.atlassian.net/browse/PXP-6563

Allow user/client to specify a lifetime of a refresh token - specified in seconds as param expires_in at the /authorize endpoint - must be a positive integer, and any request greater than the config default value (30 days) results in a refresh_token lifetime of the default 30 days.

Primarily this feature is for testing purposes, for interop, for developers of other systems and apps who want to test what happens in the case of an expired refresh token.

### New Features
- Implemented support for specifying lifetime of refresh token at the /authorize endpoint via param expires_in

### Deployment changes
- REQUIRES A FENCE DB MIGRATION, since with this update there is now an additional column in the authorization_code table "refresh_token_expires_in"
