### PR TITLE
(PXP-7166): use ras validation endpoint to validate passports

### DIFF
--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -107,7 +107,16 @@ class RASOauth2Client(Oauth2ClientBase):
             self.logger.info("Using {} field as username.".format(field_name))
 
             # Save userinfo and token in flask.g for later use in post_login
-            flask.g.userinfo = userinfo if validation == "Valid" else {}
+            flask.g.userinfo = {}
+            if validation == "Valid":
+                self.logger.info("Passport validated")
+                flask.g.userinfo = userinfo
+            else:
+                self.logger.error(
+                    "Passport validation failed. Not storing passport in database. Error: {}".format(
+                        validation
+                    )
+                )
             flask.g.tokens = token
 
         except Exception as e:
@@ -146,7 +155,16 @@ class RASOauth2Client(Oauth2ClientBase):
         encoded_visas = (
             userinfo.get("ga4gh_passport_v1", []) if validation == "Valid" else []
         )
-        # TODO: add logs for visa validation
+
+        encoded_visas = []
+        if validation == "Valid":
+            encoded_visas = userinfo.get("ga4gh_passport_v1", [])
+        else:
+            self.logger.error(
+                "Passport validation failed. Not storing passport in database. Error: {}".format(
+                    validation
+                )
+            )
 
         for encoded_visa in encoded_visas:
             try:

--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -70,8 +70,10 @@ class RASOauth2Client(Oauth2ClientBase):
             userinfo_endpoint = self.get_value_from_discovery_doc(
                 "userinfo_endpoint", ""
             )
-            validation_endpoint = self.get_value_from_discovery_doc("issuer", "") + "/passport/validate"
-            
+            validation_endpoint = (
+                self.get_value_from_discovery_doc("issuer", "") + "/passport/validate"
+            )
+
             token = self.get_token(token_endpoint, code)
             keys = self.get_jwt_keys(jwks_endpoint)
             userinfo = self.get_userinfo(token, userinfo_endpoint)
@@ -137,9 +139,13 @@ class RASOauth2Client(Oauth2ClientBase):
             self.logger.exception("{}: {}".format(err_msg, e))
             raise
 
-        validation_endpoint = self.get_value_from_discovery_doc("issuer", "") + "/passport/validate"
+        validation_endpoint = (
+            self.get_value_from_discovery_doc("issuer", "") + "/passport/validate"
+        )
         validation = self.validate_passport(validation_endpoint, userinfo)
-        encoded_visas = userinfo.get("ga4gh_passport_v1", []) if validation == "Valid" else []
+        encoded_visas = (
+            userinfo.get("ga4gh_passport_v1", []) if validation == "Valid" else []
+        )
         # TODO: add logs for visa validation
 
         for encoded_visa in encoded_visas:

--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -58,7 +58,7 @@ class RASOauth2Client(Oauth2ClientBase):
         payload = json.dumps(passport)
         headers = {"Content-Type": "application/json"}
         res = requests.post(validation_endpoint, headers=headers, data=payload)
-        return res.text.encode("utf8")
+        return res.text
 
     def get_user_id(self, code):
 

--- a/tests/ras/test_ras.py
+++ b/tests/ras/test_ras.py
@@ -193,6 +193,94 @@ def test_update_visa_token(
 @mock.patch(
     "fence.resources.openid.ras_oauth2.RASOauth2Client.get_value_from_discovery_doc"
 )
+def test_update_visa_token_validation_invalid(
+    mock_discovery,
+    mock_get_token,
+    mock_userinfo,
+    mock_validate_passport,
+    config,
+    db_session,
+    rsa_private_key,
+    kid,
+    kid_2,
+):
+    """
+    Test to check visa table is not updated when passport validation fails
+    """
+
+    mock_discovery.return_value = "https://ras/token_endpoint"
+    new_token = "refresh12345abcdefg"
+    token_response = {
+        "access_token": "abcdef12345",
+        "id_token": "id12345abcdef",
+        "refresh_token": new_token,
+    }
+    mock_get_token.return_value = token_response
+
+    userinfo_response = {
+        "sub": "abcd-asdj-sajpiasj12iojd-asnoin",
+        "name": "",
+        "preferred_username": "someuser@era.com",
+        "UID": "",
+        "UserID": "admin_user",
+        "email": "",
+    }
+
+    test_user = add_test_user(db_session)
+    add_visa_manually(db_session, test_user, rsa_private_key, kid)
+    add_refresh_token(db_session, test_user)
+
+    visa_query = db_session.query(GA4GHVisaV1).filter_by(user=test_user).first()
+    initial_visa = visa_query.ga4gh_visa
+    assert initial_visa
+
+    oidc = config.get("OPENID_CONNECT", {})
+    ras_client = RASClient(
+        oidc["ras"],
+        HTTP_PROXY=config.get("HTTP_PROXY"),
+        logger=logger,
+    )
+
+    new_visa = {
+        "iss": "https://stsstg.nih.gov",
+        "sub": "abcde12345aspdij",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 1000,
+        "scope": "openid ga4gh_passport_v1 email profile",
+        "jti": "jtiajoidasndokmasdl",
+        "txn": "sapidjspa.asipidja",
+        "name": "",
+        "ga4gh_visa_v1": {
+            "type": "https://ras/visa/v1",
+            "asserted": int(time.time()),
+            "value": "https://nig/passport/dbgap",
+            "source": "https://ncbi/gap",
+        },
+    }
+
+    headers = {"kid": kid_2}
+
+    encoded_visa = jwt.encode(
+        new_visa, key=rsa_private_key, headers=headers, algorithm="RS256"
+    ).decode("utf-8")
+
+    userinfo_response["ga4gh_passport_v1"] = [encoded_visa]
+    mock_userinfo.return_value = userinfo_response
+
+    mock_validate_passport.return_value = "Invalid"
+
+    ras_client.update_user_visas(test_user)
+
+    query_visa = db_session.query(GA4GHVisaV1).filter_by(user=test_user).all()
+    assert len(query_visa) == 0
+
+
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.validate_passport")
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_userinfo")
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_access_token")
+@mock.patch(
+    "fence.resources.openid.ras_oauth2.RASOauth2Client.get_value_from_discovery_doc"
+)
 def test_update_visa_empty_visa_returned(
     mock_discovery,
     mock_get_token,

--- a/tests/ras/test_ras.py
+++ b/tests/ras/test_ras.py
@@ -98,6 +98,7 @@ def test_store_refresh_token(db_session):
     assert final_query.expires == new_expire
 
 
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.validate_passport")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_userinfo")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_access_token")
 @mock.patch(
@@ -107,6 +108,7 @@ def test_update_visa_token(
     mock_discovery,
     mock_get_token,
     mock_userinfo,
+    mock_validate_passport,
     config,
     db_session,
     rsa_private_key,
@@ -176,6 +178,8 @@ def test_update_visa_token(
     userinfo_response["ga4gh_passport_v1"] = [encoded_visa]
     mock_userinfo.return_value = userinfo_response
 
+    mock_validate_passport.return_value = "Valid"
+
     ras_client.update_user_visas(test_user)
 
     query_visa = db_session.query(GA4GHVisaV1).first()
@@ -183,6 +187,7 @@ def test_update_visa_token(
     assert query_visa.ga4gh_visa == encoded_visa
 
 
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.validate_passport")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_userinfo")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_access_token")
 @mock.patch(
@@ -192,6 +197,7 @@ def test_update_visa_empty_visa_returned(
     mock_discovery,
     mock_get_token,
     mock_userinfo,
+    mock_validate_passport,
     config,
     db_session,
     rsa_private_key,
@@ -223,6 +229,8 @@ def test_update_visa_empty_visa_returned(
 
     mock_userinfo.return_value = userinfo_response
 
+    mock_validate_passport.return_value = "Valid"
+
     test_user = add_test_user(db_session)
     add_visa_manually(db_session, test_user, rsa_private_key, kid)
     add_refresh_token(db_session, test_user)
@@ -244,6 +252,7 @@ def test_update_visa_empty_visa_returned(
     assert query_visa == None
 
 
+@mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.validate_passport")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_userinfo")
 @mock.patch("fence.resources.openid.ras_oauth2.RASOauth2Client.get_access_token")
 @mock.patch(
@@ -253,6 +262,7 @@ def test_update_visa_token_with_invalid_visa(
     mock_discovery,
     mock_get_token,
     mock_userinfo,
+    mock_validate_passport,
     config,
     db_session,
     rsa_private_key,
@@ -323,6 +333,8 @@ def test_update_visa_token_with_invalid_visa(
 
     userinfo_response["ga4gh_passport_v1"] = [encoded_visa, [], encoded_visa]
     mock_userinfo.return_value = userinfo_response
+
+    mock_validate_passport.return_value = "Valid"
 
     ras_client.update_user_visas(test_user)
 

--- a/tests/ras/test_ras.py
+++ b/tests/ras/test_ras.py
@@ -398,7 +398,7 @@ def test_update_visa_token_with_invalid_visa(
 
     new_visa = {
         "iss": "https://stsstg.nih.gov",
-        "sub": "abcde12345aspdij",
+        "sub": "abcde12345aspdijk",
         "iat": int(time.time()),
         "exp": int(time.time()) + 1000,
         "scope": "openid ga4gh_passport_v1 email profile",


### PR DESCRIPTION
If the passport is not valid then don't add it to the database. 

### New Features
- Validate RAS passports using RAS's `/passport/validation` endpoint. 
