### PR TITLE
Add support to accept userid in RAS

### DIFF
--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -73,6 +73,9 @@ class RASOauth2Client(Oauth2ClientBase):
             if userinfo.get("UserID"):
                 username = userinfo["UserID"]
                 field_name = "UserID"
+            elif userinfo.get("userid"):
+                username = userinfo["userid"]
+                field_name = "userid"
             elif userinfo.get("preferred_username"):
                 username = userinfo["preferred_username"]
                 field_name = "preferred_username"


### PR DESCRIPTION
Currently, we look for `UserID` for username from RAS's userinfo payload. This is specified in the [RAS's Userinfo Paylod](https://auth.nih.gov/docs/RAS/serviceofferings.html#AppendixA). However, they are sending us `UserID` for eraCommons users and `userid` for NIH users.

We want to support both of these for now and remove `UserID` later on once RAS adds a fix to only use `userid`. 

### Improvements
- add support for `userid` from RAS userinfo payload as a valid username.


