### PR TITLE
chore(google-manage-keys): Handle key deletion attempt that returns 400 FAILED_PRECONDITION

### DIFF
--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -555,6 +555,7 @@ def remove_expired_google_service_account_keys(db):
                     account=sa.email, key_name=expired_user_key.key_id
                 )
                 response_error_code = response.get("error", {}).get("code")
+                response_error_status = response.get("error", {}).get("status")
 
                 if not response_error_code:
                     current_session.delete(expired_user_key)
@@ -564,7 +565,10 @@ def remove_expired_google_service_account_keys(db):
                             expired_user_key.key_id, sa.email, sa.user_id
                         )
                     )
-                elif response_error_code == 404:
+                elif (
+                    response_error_code == 404
+                    or response_error_status == "FAILED_PRECONDITION"
+                ):
                     logger.info(
                         "INFO: Service account key {} for service account {} "
                         "(owned by user with id {}) does not exist in Google. "

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -543,6 +543,7 @@ def remove_expired_google_service_account_keys(db):
 
             # handle service accounts with custom expiration
             for expired_user_key in expired_sa_keys_for_users:
+                logger.info("expired_user_key: {}\n".format(expired_user_key))
                 sa = (
                     current_session.query(GoogleServiceAccount)
                     .filter(
@@ -556,6 +557,8 @@ def remove_expired_google_service_account_keys(db):
                 )
                 response_error_code = response.get("error", {}).get("code")
                 response_error_status = response.get("error", {}).get("status")
+                logger.info("response_error_code: {}\n".format(response_error_code))
+                logger.info("response_error_status: {}\n".format(response_error_status))
 
                 if not response_error_code:
                     current_session.delete(expired_user_key)


### PR DESCRIPTION
Our `fence-create google-manage-keys` CLI command is returning 400 FAILED_PRECONDITION while attempting to delete a key that no longer exists in GCP (only exists in fence's database).

The description from the official documentation is quite misleading... 🤔 
https://cloud.google.com/apis/design/errors
> 400 FAILED_PRECONDITION Resource xxx is a non-empty directory, so it cannot be deleted.

logs:
```
{
  "error": {
    "code": 400,
    "message": "Precondition check failed.",
    "status": "FAILED_PRECONDITION"
  }
}
>
ERROR: (gcloud.iam.service-accounts.keys.delete) FAILED_PRECONDITION: Precondition check failed.
```

Because it is trying to delete a key that no longer existing in Google Cloud. Hence we should just allow the CLI operation to delete the orphan key in fence's db and unblock the Continuous Integration pipeline.