### PR TITLE
(PXP-7319): Fix oauth flow when fence idp not in LOGIN_OPTIONS

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -315,13 +315,6 @@ def _set_authlib_cfgs(app):
 
 
 def _setup_oidc_clients(app):
-    if config["LOGIN_OPTIONS"]:
-        enabled_idp_ids = [option["idp"] for option in config["LOGIN_OPTIONS"]]
-    else:
-        # fall back on "providers"
-        enabled_idp_ids = list(
-            config.get("ENABLED_IDENTITY_PROVIDERS", {}).get("providers", {}).keys()
-        )
     oidc = config.get("OPENID_CONNECT", {})
 
     # Add OIDC client for Google if configured.
@@ -369,8 +362,7 @@ def _setup_oidc_clients(app):
         )
 
     # Add OIDC client for multi-tenant fence if configured.
-    configured_fence = "fence" in oidc and "fence" in enabled_idp_ids
-    if configured_fence:
+    if "fence" in oidc:
         app.fence_client = OAuthClient(**config["OPENID_CONNECT"]["fence"])
 
 


### PR DESCRIPTION
Jira Ticket: [PXP-7319](https://ctds-planx.atlassian.net/browse/PXP-7319)

This is a small bug fix so that `fence` idp is not required in `LOGIN_OPTIONS` config in order for `fence` idp oauth flow to work. `LOGIN_OPTIONS` is actually intended to be used for configuring which login buttons to show on the frontend. Please see ticket above for more details.

### Bug Fixes
- Fix oauth flow to work even when fence idp not in LOGIN_OPTIONS config
