### PR TITLE
(PXP-7846): Visa refresh token expiration parameter

### DIFF
--- a/fence/blueprints/login/ras.py
+++ b/fence/blueprints/login/ras.py
@@ -68,20 +68,22 @@ class RASCallback(DefaultOAuth2Callback):
         refresh_token = flask.g.tokens.get("refresh_token")
         id_token = flask.g.tokens.get("id_token")
         decoded_id = jwt.decode(id_token, verify=False)
-        
+
         # Add 15 days to iat to calculate refresh token expiration time
         expires = int(decoded_id.get("iat")) + config["RAS_REFRESH_EXPIRATION"]
-        
+
         # User definied RAS refresh token expiration time
         parsed_url = urllib.parse.parse_qs(flask.redirect_url)
         if parsed_url.get("visa_refresh_exp"):
-            custom_refresh_expiration = int(decoded_id.get("iat")) + int(parsed_url.get("visa_refresh_exp")[0])
+            custom_refresh_expiration = int(decoded_id.get("iat")) + int(
+                parsed_url.get("visa_refresh_exp")[0]
+            )
             expires = get_valid_expiration(
                 custom_refresh_expiration,
                 expires,
                 expires,
             )
-            
+
         flask.current_app.ras_client.store_refresh_token(
             user=user, refresh_token=refresh_token, expires=expires
         )

--- a/fence/job/visa_update_cronjob.py
+++ b/fence/job/visa_update_cronjob.py
@@ -152,6 +152,10 @@ class Visa_Token_Update(object):
                     )
                     client.update_user_visas(user, db_session)
             else:
+                if user.upstream_refresh_tokens:
+                    user.upstream_refresh_tokens = []
+                    db_session.commit()
+
                 self.logger.info(
                     "User {} doesnt have visa. Skipping . . .".format(user.username)
                 )

--- a/fence/job/visa_update_cronjob.py
+++ b/fence/job/visa_update_cronjob.py
@@ -152,6 +152,7 @@ class Visa_Token_Update(object):
                     )
                     client.update_user_visas(user, db_session)
             else:
+                # clear expired refresh tokens
                 if user.upstream_refresh_tokens:
                     user.upstream_refresh_tokens = []
                     db_session.commit()

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -156,11 +156,11 @@ class Oauth2ClientBase(object):
             proxies=self.get_proxies(),
             refresh_token=refresh_token,
         )
-        new_refresh_token = token_response["refresh_token"]
+        refresh_token = token_response["refresh_token"]
 
         self.store_refresh_token(
             user,
-            refresh_token=new_refresh_token,
+            refresh_token=refresh_token,
             expires=expires,
             db_session=db_session,
         )


### PR DESCRIPTION
This was an ask from ISB-CGC. It's mostly for testing purposes. Basically [#848](https://github.com/uc-cdis/fence/pull/848) but for RAS or any other Visa provider we might have in the future. 

### New Features
- Added `upstream_expires_in` parameter in the `/authorization` endpoint to manually add refresh token expiration time. 

### Bug Fixes
- Fixed Visa Update cronjob not clearing expired refresh tokens. 
