### PR TITLE
PXP-7447 Do not try to record audit logs for upload presigned URLs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-03-24T19:39:53Z",
+  "generated_at": "2021-03-29T22:29:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1090,
+        "line_number": 1104,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1127,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -79,9 +79,10 @@ def get_signed_url_for_file(action, file_id, file_name=None):
         file_name=file_name,
     )
 
-    create_presigned_url_audit_log(
-        protocol=requested_protocol, indexed_file=indexed_file, action=action
-    )
+    if action == "download":  # for now only record download requests
+        create_presigned_url_audit_log(
+            protocol=requested_protocol, indexed_file=indexed_file, action=action
+        )
 
     return {"url": signed_url}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,6 +475,20 @@ def indexd_client(app, request):
             "created_date": "",
             "updated_date": "",
         }
+    elif protocol == "no_urls":
+        record = {
+            "did": "",
+            "baseid": "",
+            "rev": "",
+            "size": 10,
+            "file_name": "file2",
+            "urls": [],
+            "hashes": {},
+            "acl": ["phs000178", "phs000218"],
+            "form": "",
+            "created_date": "",
+            "updated_date": "",
+        }
     elif protocol == "nonexistent_guid":
         # throw an error when requested to simulate the GUID not existing
         # TODO (rudyardrichter, 2018-11-03): consolidate things needing to do this patch

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -60,7 +60,9 @@ def test_indexd_download_file(
 
 
 @pytest.mark.parametrize(
-    "indexd_client", ["gs", "s3", "gs_acl", "s3_acl", "s3_external"], indirect=True
+    "indexd_client",
+    ["gs", "s3", "gs_acl", "s3_acl", "s3_external", "no_urls"],
+    indirect=True,
 )
 def test_indexd_upload_file(
     client,


### PR DESCRIPTION
Jira Ticket: [PXP-7447](https://ctds-planx.atlassian.net/browse/PXP-7447)

Fix bug when hitting the `/data/upload/<guid>` endpoint for a record with no existing URLs:
```
  File "/fence/fence/blueprints/data/blueprint.py", line 290, in upload_file
    result = get_signed_url_for_file("upload", file_id, file_name=file_name)
  File "/fence/fence/blueprints/data/indexd.py", line 83, in get_signed_url_for_file
    protocol=requested_protocol, indexed_file=indexed_file, action=action
  File "/fence/fence/blueprints/data/indexd.py", line 98, in create_presigned_url_audit_log
    protocol = indexed_file.indexed_file_locations[0].protocol
IndexError: list index out of range
```

and add upload test case for a record with no existing URLs

### Bug Fixes
- Do not try to record audit logs for upload presigned URLs - fixes issue when hitting the `/data/upload/<guid>` endpoint
