### PR TITLE
(PXP-6693): Fix generation of signed upload urls for public Indexd records for authz-permitted users.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-03-15T22:04:08Z",
+  "generated_at": "2021-03-29T19:15:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1090,
+        "line_number": 1109,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1132,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-03-31T04:23:12Z",
+  "generated_at": "2021-04-01T15:04:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1109,
+        "line_number": 1123,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1132,
+        "line_number": 1146,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-03-29T19:15:20Z",
+  "generated_at": "2021-03-31T04:23:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -93,9 +93,10 @@ def create_presigned_url_audit_log(indexed_file, action, protocol):
         # fall back on ACL
         resource_paths = indexed_file.index_document.get("acl", [])
     if not protocol:
-        # we can assume there are locations since `get_signed_url()`
-        # used the same logic before this code runs
-        protocol = indexed_file.indexed_file_locations[0].protocol
+        protocol = (
+            indexed_file.indexed_file_locations
+            and indexed_file.indexed_file_locations[0].protocol
+        )
     flask.current_app.audit_service_client.create_presigned_url_log(
         username=user_info["username"],
         sub=user_info["user_id"],
@@ -369,7 +370,7 @@ class IndexedFile(object):
             }
             if not self.check_authz(action_to_permission[action]):
                 raise Unauthorized(
-                    f"Authz check failed: you don't have "
+                    f"Either you weren't logged in or you don't have "
                     f"{action_to_permission[action]} permission "
                     f"on {self.index_document['authz']} for fence"
                 )

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -465,9 +465,6 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        #  authz_resources = list(self.set_acls)
-        #  authz_resources.extend(self.index_document.get("authz", []))
-        #  return "*" in authz_resources or "/open" in authz_resources
         return self.public_acl or self.public_authz
 
     @cached_property
@@ -494,21 +491,7 @@ class IndexedFile(object):
             )
             return self.index_document.get("uploader") == username
 
-        try:
-            action_to_method = {"upload": "write-storage", "download": "read-storage"}
-            method = action_to_method[action]
-            # action should be upload or download
-            # return bool for authorization
-            return self.check_authz(method)
-        except ValueError:
-            # this is ok; we'll default to ACL field (previous behavior)
-            # may want to deprecate in future
-            logger.info(
-                "Couldn't find `authz` field on indexd record, falling back to `acl`."
-            )
-
         given_acls = set(filter_auth_ids(action, flask.g.user.project_access))
-
         return len(self.set_acls & given_acls) > 0
 
     @login_required({"data"})

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -453,6 +453,9 @@ class IndexedFile(object):
         try:
             token = get_jwt()
         except Unauthorized:
+            #  get_jwt raises an Unauthorized error when user is anonymous (no
+            #  availble token), so to allow anonymous users possible access to
+            #  public data, we still make the request to Arborist
             token = None
 
         return flask.current_app.arborist.auth_request(

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -369,7 +369,7 @@ class IndexedFile(object):
             }
             if not self.check_authz(action_to_permission[action]):
                 raise Unauthorized(
-                    f"You are either not logged in or don't have "
+                    f"Authz check failed: you don't have "
                     f"{action_to_permission[action]} permission "
                     f"on {self.index_document['authz']} for fence"
                 )
@@ -452,8 +452,18 @@ class IndexedFile(object):
         logger.debug(
             f"authz check can user {action} on {self.index_document['authz']} for fence?"
         )
+
+        header = flask.request.headers.get("Authorization")
+        if header:
+            try:
+                bearer, token = header.split(" ")
+            except ValueError:
+                raise Unauthorized("authorization header not in expected format")
+        else:
+            token = None
+
         return flask.current_app.arborist.auth_request(
-            jwt=get_jwt(),
+            jwt=token,
             service="fence",
             methods=action,
             resources=self.index_document["authz"],

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -362,24 +362,31 @@ class IndexedFile(object):
         r_pays_project=None,
         file_name=None,
     ):
-        method = "write-storage"
-        if self.public_authz and action == "upload":
-            #  this check has to be nested to handle when authz and acl are
-            #  both public. in that case we want authz to take precedence
-            if not self.check_authz(method):
+        if self.index_document.get("authz"):
+            action_to_permission = {
+                "upload": "write-storage",
+                "download": "read-storage",
+            }
+            if not self.check_authz(action_to_permission[action]):
                 raise Unauthorized(
-                    f"Failed authz check: you don't have {method} permission "
+                    f"You are either not logged in or don't have "
+                    f"{action_to_permission[action]} permission "
                     f"on {self.index_document['authz']} for fence"
                 )
-        elif self.public_acl and action == "upload":
-            raise Unauthorized("Cannot upload on public files")
+        else:
+            if self.public_acl and action == "upload":
+                raise Unauthorized(
+                    "Cannot upload on public files while using acl field"
+                )
+            # don't check the authorization if the file is public
+            # (downloading public files with no auth is fine)
+            if not self.public_acl and not self.check_authorization(action):
+                raise Unauthorized(
+                    "You don't have access permission on this file: {}".format(
+                        self.file_id
+                    )
+                )
 
-        # don't check the authorization if the file is public
-        # (downloading public files with no auth is fine)
-        if not self.public and not self.check_authorization(action):
-            raise Unauthorized(
-                "You don't have access permission on this file: {}".format(self.file_id)
-            )
         if action is not None and action not in SUPPORTED_ACTIONS:
             raise NotSupported("action {} is not supported".format(action))
         return self._get_signed_url(
@@ -458,6 +465,9 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
+        #  authz_resources = list(self.set_acls)
+        #  authz_resources.extend(self.index_document.get("authz", []))
+        #  return "*" in authz_resources or "/open" in authz_resources
         return self.public_acl or self.public_authz
 
     @cached_property

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -458,7 +458,7 @@ class IndexedFile(object):
         header = flask.request.headers.get("Authorization")
         if header:
             try:
-                bearer, token = header.split(" ")
+                _, token = header.split(" ")
             except ValueError:
                 raise Unauthorized("authorization header not in expected format")
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -668,6 +668,25 @@ def indexd_client_with_arborist(app, request):
 
 
 @pytest.fixture(scope="function")
+def indexd_client_accepting_record():
+    """
+    Patches IndexedFile's index_document with a caller-supplied dictionary
+    representing an Indexd record.
+    """
+
+    def do_patch(record):
+        mocker = Mocker()
+        mocker.mock_functions()
+
+        indexd_patcher = patch(
+            "fence.blueprints.data.indexd.IndexedFile.index_document", record
+        )
+        mocker.add_mock(indexd_patcher)
+
+    return do_patch
+
+
+@pytest.fixture(scope="function")
 def unauthorized_indexd_client(app, request):
     mocker = Mocker()
     mocker.mock_functions()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from cryptography.fernet import Fernet
 import bcrypt
 from cdisutilstest.code.storage_client_mock import get_client
 import jwt
-from mock import patch, MagicMock
+from mock import patch, MagicMock, PropertyMock
 from moto import mock_sts
 import pytest
 import requests
@@ -478,7 +478,7 @@ def indexd_client(app, request):
     elif protocol == "nonexistent_guid":
         # throw an error when requested to simulate the GUID not existing
         # TODO (rudyardrichter, 2018-11-03): consolidate things needing to do this patch
-        mock = MagicMock(side_effect=NotFound("no guid"))
+        mock = PropertyMock(side_effect=NotFound("no guid"))
         indexd_patcher = patch(
             "fence.blueprints.data.indexd.IndexedFile.index_document", mock
         )

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -197,7 +197,7 @@ def test_indexd_upload_file_doesnt_exist(
     }
     response = client.get(path, headers=headers)
 
-    assert response.status_code == 401
+    assert response.status_code == 404
 
 
 @pytest.mark.parametrize(

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import cirrus
 from cirrus import GoogleCloudManager
 
-INDEXD_RECORD_WITH_AUTHZ_POPULATED = {
+INDEXD_RECORD_WITH_PUBLIC_AUTHZ_POPULATED = {
     "did": "1",
     "baseid": "",
     "rev": "",
@@ -29,22 +29,6 @@ INDEXD_RECORD_WITH_AUTHZ_POPULATED = {
     "metadata": {},
     "authz": ["/open"],
     "acl": [],
-    "form": "",
-    "created_date": "",
-    "updated_date": "",
-}
-
-INDEXD_RECORD_WITH_AUTHZ_AND_ACL_POPULATED = {
-    "did": "1",
-    "baseid": "",
-    "rev": "",
-    "size": 10,
-    "file_name": "file1",
-    "urls": ["s3://bucket1/key"],
-    "hashes": {},
-    "metadata": {},
-    "authz": ["/open"],
-    "acl": ["*"],
     "form": "",
     "created_date": "",
     "updated_date": "",
@@ -618,7 +602,7 @@ def test_public_authz_object_upload_file(
     Test `GET /data/upload/1` in which the `1` Indexd record has authz
     populated with the public value.
     """
-    indexd_client_accepting_record(INDEXD_RECORD_WITH_AUTHZ_POPULATED)
+    indexd_client_accepting_record(INDEXD_RECORD_WITH_PUBLIC_AUTHZ_POPULATED)
     mock_arborist_requests({"arborist/auth/request": {"POST": ({"auth": True}, 200)}})
     headers = {
         "Authorization": "Bearer "
@@ -650,7 +634,7 @@ def test_public_authz_object_upload_file_with_failed_authz_check(
     populated with the public value, but the user doesn't have the correct
     authz permission'
     """
-    indexd_client_accepting_record(INDEXD_RECORD_WITH_AUTHZ_POPULATED)
+    indexd_client_accepting_record(INDEXD_RECORD_WITH_PUBLIC_AUTHZ_POPULATED)
     mock_arborist_requests({"arborist/auth/request": {"POST": ({"auth": False}, 200)}})
     headers = {
         "Authorization": "Bearer "
@@ -684,7 +668,23 @@ def test_public_authz_and_acl_object_upload_file(
     acl populated with public values. In this case, authz takes precedence over
     acl.
     """
-    indexd_client_accepting_record(INDEXD_RECORD_WITH_AUTHZ_AND_ACL_POPULATED)
+    indexd_record_with_public_authz_and_acl_populated = {
+        "did": "1",
+        "baseid": "",
+        "rev": "",
+        "size": 10,
+        "file_name": "file1",
+        "urls": ["s3://bucket1/key"],
+        "hashes": {},
+        "metadata": {},
+        "authz": ["/open"],
+        "acl": ["*"],
+        "form": "",
+        "created_date": "",
+        "updated_date": "",
+    }
+
+    indexd_client_accepting_record(indexd_record_with_public_authz_and_acl_populated)
     mock_arborist_requests({"arborist/auth/request": {"POST": ({"auth": True}, 200)}})
     headers = {
         "Authorization": "Bearer "


### PR DESCRIPTION
Jira Ticket: [PXP-6693](https://ctds-planx.atlassian.net/browse/PXP-6693)

With the old logic for generating a signed url for public records, Fence did not allow upload urls to be generated for records with public `authz` or `acl` values ("/open" and "*", respectively). However, users with a `write-storage` permission on "/open" for Fence should be permitted to generate upload urls.

### Bug Fixes
- Allow permitted users to generate a signed upload url for public records (i.e. those records with `authz=[“/open”]`)