### PR TITLE
First commit of CILogon authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ At the moment, supported IDPs include:
   - NIH iTrust
   - InCommon
   - eduGAIN
+- CILogon
 - Cognito
 - Synapse
 - Microsoft

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -18,6 +18,7 @@ from fence.oidc.client import query_client
 from fence.oidc.server import server
 from fence.resources.audit_service_client import AuditServiceClient
 from fence.resources.aws.boto_manager import BotoManager
+from fence.resources.openid.cilogon_oauth2 import CilogonOauth2Client as CilogonClient
 from fence.resources.openid.cognito_oauth2 import CognitoOauth2Client as CognitoClient
 from fence.resources.openid.google_oauth2 import GoogleOauth2Client as GoogleClient
 from fence.resources.openid.microsoft_oauth2 import (
@@ -371,6 +372,14 @@ def _setup_oidc_clients(app):
     if "cognito" in oidc:
         app.cognito_client = CognitoClient(
             oidc["cognito"], HTTP_PROXY=config.get("HTTP_PROXY"), logger=logger
+        )
+
+    # Add OIDC client for CILogon if configured.
+    if "cilogon" in oidc:
+        app.cilogon_client = CilogonClient(
+            config["OPENID_CONNECT"]["cilogon"],
+            HTTP_PROXY=config.get("HTTP_PROXY"),
+            logger=logger,
         )
 
     # Add OIDC client for multi-tenant fence if configured.

--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -12,6 +12,7 @@ import requests
 
 from cdislogging import get_logger
 
+from fence.blueprints.login.cilogon import CilogonLogin, CilogonCallback
 from fence.blueprints.login.cognito import CognitoLogin, CognitoCallback
 from fence.blueprints.login.fence_login import FenceLogin, FenceCallback
 from fence.blueprints.login.google import GoogleLogin, GoogleCallback
@@ -38,6 +39,7 @@ IDP_URL_MAP = {
     "okta": "okta",
     "cognito": "cognito",
     "ras": "ras",
+    "cilogon": "cilogon",
 }
 
 
@@ -292,6 +294,13 @@ def make_login_blueprint(app):
         blueprint_api.add_resource(
             ShibbolethCallback, "/shib/login", strict_slashes=False
         )
+
+    if "cilogon" in configured_idps:
+        blueprint_api.add_resource(CilogonLogin, "/cilogon", strict_slashes=False)
+        blueprint_api.add_resource(
+            CilogonCallback, "/cilogon/login", strict_slashes=False
+        )
+
     return blueprint
 
 

--- a/fence/blueprints/login/cilogon.py
+++ b/fence/blueprints/login/cilogon.py
@@ -1,7 +1,8 @@
 import flask
 
-from fence.resources.openid.cilogon_oauth2 import CILOGON_IDP_NAME
 from fence.blueprints.login.base import DefaultOAuth2Login, DefaultOAuth2Callback
+
+CILOGON_IDP_NAME = "cilogon"
 
 
 class CilogonLogin(DefaultOAuth2Login):

--- a/fence/blueprints/login/cilogon.py
+++ b/fence/blueprints/login/cilogon.py
@@ -1,0 +1,20 @@
+import flask
+
+from fence.resources.openid.cilogon_oauth2 import CILOGON_IDP_NAME
+from fence.blueprints.login.base import DefaultOAuth2Login, DefaultOAuth2Callback
+
+
+class CilogonLogin(DefaultOAuth2Login):
+    def __init__(self):
+        super(CilogonLogin, self).__init__(
+            idp_name=CILOGON_IDP_NAME, client=flask.current_app.cilogon_client
+        )
+
+
+class CilogonCallback(DefaultOAuth2Callback):
+    def __init__(self):
+        super(CilogonCallback, self).__init__(
+            idp_name=CILOGON_IDP_NAME,
+            client=flask.current_app.cilogon_client,
+            username_field="sub",
+        )

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -191,6 +191,19 @@ OPENID_CONNECT:
     # and that IdP is a SAML IdP with no 'email_verified' outgoing claim, but it is safe
     # to assume all emails from this SAML IdP are in fact verified, we may set this to True
     assume_emails_verified: False
+  # CILogon subscribers can create and manage OIDC clients using COmanage Registry.
+  # Free tier users may request OIDC clients at https://cilogon.org/oauth2/register
+  cilogon:
+    client_id: ''
+    client_secret: ''
+    # When registering the Callback URLs for your CILogon OIDC client be
+    # sure to include the FULL url for this deployment, including the https:// scheme
+    # and server FQDN.
+    redirect_url: '{{BASE_URL}}/login/cilogon/login/'
+    # if mock is true, will fake a successful login response for login
+    # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
+    mock: false
+    mock_default_user: 'http://cilogon.org/serverT/users/64703'
   synapse:
     client_id: ''
     client_secret: ''
@@ -279,6 +292,8 @@ LOGIN_OPTIONS: [] # !!! remove the empty list to enable login options!
   # - name: 'ORCID Login through other Fence'
   #   idp: fence
   #   fence_idp: orcid
+  # - name: 'CILogon Login'
+  #   idp: cilogon
   # - name: 'InCommon Login'
   #   idp: fence
   #   fence_idp: shibboleth

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -28,7 +28,7 @@ class CilogonOauth2Client(Oauth2ClientBase):
             "authorization_endpoint", "https://cilogon.org/authorize"
         )
 
-        uri, state = self.session.create_authorization_url(
+        uri, _ = self.session.create_authorization_url(
             authorization_endpoint, prompt="login"
         )
 

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -1,0 +1,53 @@
+from .idp_oauth2 import Oauth2ClientBase
+
+CILOGON_IDP_NAME = "cilogon"
+
+
+class CilogonOauth2Client(Oauth2ClientBase):
+    """
+    client for interacting with CILogon OIDC
+    """
+
+    CILOGON_DISCOVERY_URL = "https://cilogon.org/.well-known/openid-configuration"
+
+    def __init__(self, settings, logger, HTTP_PROXY=None):
+        super(CilogonOauth2Client, self).__init__(
+            settings,
+            logger,
+            scope="openid email profile",
+            discovery_url=self.CILOGON_DISCOVERY_URL,
+            idp="CILogon",
+            HTTP_PROXY=HTTP_PROXY,
+        )
+
+    def get_auth_url(self):
+        """
+        Get authorization uri from discovery doc
+        """
+        authorization_endpoint = self.get_value_from_discovery_doc(
+            "authorization_endpoint", "https://cilogon.org/authorize"
+        )
+
+        uri, state = self.session.create_authorization_url(
+            authorization_endpoint, prompt="login"
+        )
+
+        return uri
+
+    def get_user_id(self, code):
+        try:
+            token_endpoint = self.get_value_from_discovery_doc(
+                "token_endpoint", "https://cilogon.org/oauth2/token"
+            )
+            jwks_endpoint = self.get_value_from_discovery_doc(
+                "jwks_uri", "https://cilogon.org/oauth2/certs"
+            )
+            claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
+
+            if claims["sub"]:
+                return {"sub": claims["sub"]}
+            else:
+                return {"error": "Can't get user's CILogon sub"}
+        except Exception as e:
+            self.logger.exception("Can't get user info")
+            return {"error": "Can't get your CILogon sub: {}".format(e)}

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -1,7 +1,5 @@
 from .idp_oauth2 import Oauth2ClientBase
 
-CILOGON_IDP_NAME = "cilogon"
-
 
 class CilogonOauth2Client(Oauth2ClientBase):
     """

--- a/tests/login/test_login_redirect.py
+++ b/tests/login/test_login_redirect.py
@@ -13,7 +13,9 @@ import mock
 import pytest
 
 
-@pytest.mark.parametrize("idp", ["google", "shib", "microsoft", "okta", "orcid", "ras"])
+@pytest.mark.parametrize(
+    "idp", ["google", "shib", "microsoft", "okta", "orcid", "ras", "cilogon"]
+)
 @mock.patch(
     "fence.resources.openid.ras_oauth2.RASOauth2Client.get_value_from_discovery_doc"
 )
@@ -37,7 +39,9 @@ def test_valid_redirect_base(mock_discovery, app, client, idp):
     """
 
 
-@pytest.mark.parametrize("idp", ["google", "shib", "microsoft", "okta", "orcid", "ras"])
+@pytest.mark.parametrize(
+    "idp", ["google", "shib", "microsoft", "okta", "orcid", "ras", "cilogon"]
+)
 @mock.patch(
     "fence.resources.openid.ras_oauth2.RASOauth2Client.get_value_from_discovery_doc"
 )
@@ -59,7 +63,9 @@ def test_valid_redirect_oauth(mock_discovery, client, oauth_client, idp):
     """
 
 
-@pytest.mark.parametrize("idp", ["google", "shib", "microsoft", "okta", "orcid", "ras"])
+@pytest.mark.parametrize(
+    "idp", ["google", "shib", "microsoft", "okta", "orcid", "ras", "cilogon"]
+)
 def test_invalid_redirect_fails(client, idp):
     """
     Check that giving a bogus redirect to the login endpoint returns an error.

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -84,6 +84,10 @@ OPENID_CONNECT:
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/orcid/login'
+  cilogon:
+    client_id: ''
+    client_secret: ''
+    redirect_url: '{{BASE_URL}}/login/cilogon/login'
   ras:
     client_id: ''
     client_secret: ''
@@ -193,6 +197,8 @@ LOGIN_OPTIONS:
   - name: 'Orcid Login'
     idp: fence
     fence_idp: orcid
+  - name: 'CILogon Login'
+    idp: cilogon
   - name: 'Microsoft Login'
     idp: microsoft
   - name: 'Okta Login'

--- a/tests/test_audit_service.py
+++ b/tests/test_audit_service.py
@@ -336,6 +336,9 @@ def test_login_log_login_endpoint(
     elif idp == "orcid":
         mocked_get_user_id = MagicMock()
         get_user_id_value = {"orcid": username}
+    elif idp == "cilogon":
+        mocked_get_user_id = MagicMock()
+        get_user_id_value = {"sub": username}
     elif idp == "shib":
         headers["persistent_id"] = username
         idp_name = "itrust"


### PR DESCRIPTION
First commit of CILogon authentication. CILogon provides a
standards-compliant OpenID Connect (OAuth 2.0) interface to federated
authentication including InCommon, the Australian Access Federation
(AAF), and eduGAIN. CILogon OpenID Connect (OIDC) client registration
is available to researchers and scholars at
https://cilogon.org/oauth2/register

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
Add CILogon as an authentication option. CILogon provides a standards-compliant OpenID Connect (OAuth 2.0) interface to federated authentication including InCommon, the Australian Access Federation (AAF), and eduGAIN. CILogon OpenID Connect (OIDC) client registration is available to researchers and scholars at https://cilogon.org/oauth2/register
