### PR TITLE
Swagger doc: add fence_idp to /oauth2/authorize endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-04-01T15:04:02Z",
+  "generated_at": "2021-04-12T21:59:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -122,31 +122,31 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1903,
+        "line_number": 1914,
         "type": "Private Key"
       },
       {
         "hashed_secret": "bb8e48bd1e73662027a0f0b876b695d4c18f5ed4",
         "is_verified": false,
-        "line_number": 1903,
+        "line_number": 1914,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "7861ab65194de92776ab9cd06d4d7e7e1ec2c36d",
         "is_verified": false,
-        "line_number": 1983,
+        "line_number": 1994,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_verified": false,
-        "line_number": 2005,
+        "line_number": 2016,
         "type": "JSON Web Token"
       },
       {
         "hashed_secret": "98c144f5ecbb4dbe575147a39698b6be1a5649dd",
         "is_verified": false,
-        "line_number": 2017,
+        "line_number": 2028,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -110,9 +110,20 @@ paths:
           required: false
           in: query
           description: >-
-            Upstream identity provider to use. Specifying `idp=shibboleth` lets
-            us specify a `shib_idp`. If no `idp` is specified, defaults to NIH
-            login.
+            Upstream identity provider to use. Specifying `idp=fence` lets
+            us specify a `fence_idp`. Specifying `idp=shibboleth` lets
+            us specify a `shib_idp`. If no `idp` is specified, defaults to
+            the configured default login.
+          schema:
+            type: string
+          example: 'google'
+        - name: fence_idp
+          required: false
+          in: query
+          description: >-
+            Upstream identity provider to use. Specifying `idp=fence` and
+            `fence_idp=shibboleth` lets us specify a `shib_idp`. If no
+            `fence_idp` is specified, defaults to NIH login.
           schema:
             type: string
           example: 'shibboleth'


### PR DESCRIPTION


### Improvements
- Swagger doc: add fence_idp to /oauth2/authorize endpoint