### PR TITLE
Use PLANXCYBORG_GITHUB_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/wool.yml
+++ b/.github/workflows/wool.yml
@@ -14,4 +14,4 @@ jobs:
 
     - uses: uc-cdis/wool@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PLANXCYBORG_GITHUB_TOKEN }}

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -72,7 +72,6 @@ def app_init(
     config_path=None,
     config_file_name=None,
 ):
-    print('test trigger wool')
     app.__dict__["logger"] = warn_about_logger
 
     app_config(

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -72,6 +72,7 @@ def app_init(
     config_path=None,
     config_file_name=None,
 ):
+    print('test trigger wool')
     app.__dict__["logger"] = warn_about_logger
 
     app_config(


### PR DESCRIPTION
The GITHUB_TOKEN provided automatically in GitHub workflows only has "read" access when a workflows runs on a fork (see https://github.community/t/github-actions-are-severely-limited-on-prs/18179#M9249), so it's blocking our tests on PRs from external contributors. Switch to using `PLANXCYBORG_GITHUB_TOKEN` which will always have write access