### PR TITLE
chore(open-source): Skip github action wool for external contributions

### DIFF
--- a/.github/workflows/wool.yml
+++ b/.github/workflows/wool.yml
@@ -13,5 +13,6 @@ jobs:
     - uses: actions/checkout@master
 
     - uses: uc-cdis/wool@master
+      if: github.event.pull_request.head.repo.full_name == 'uc-cdis/cdis-manifest'
       env:
-        GITHUB_TOKEN: ${{ secrets.PLANXCYBORG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PLANXCYBORG_GITHUB_TOKEN || 'ignore' }}


### PR DESCRIPTION
Skip wool for external contributions.

### Improvements
- Skip wool GH Action for external contributions.
