### PR TITLE
(PXP-7565): User registration, plus CSRF changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,10 +67,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -100,12 +96,6 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "poetry.lock"
-      ]
     }
   ],
   "results": {
@@ -193,18 +183,25 @@
     ],
     "tests/conftest.py": [
       {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "9801ff058ba790388c9efc095cb3e89a819d5ed6",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
         "type": "Private Key",
         "filename": "tests/conftest.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1174
+        "line_number": 1357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/conftest.py",
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1197
+        "line_number": 1380
       }
     ],
     "tests/credentials/google/test_credentials.py": [
@@ -254,7 +251,7 @@
         "filename": "tests/ras/test_ras.py",
         "hashed_secret": "d9db6fe5c14dc55edd34115cdf3958845ac30882",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 95
       }
     ],
     "tests/scripting/test_fence-create.py": [
@@ -263,7 +260,7 @@
         "filename": "tests/scripting/test_fence-create.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 1120
+        "line_number": 1122
       }
     ],
     "tests/test-fence-config.yaml": [
@@ -283,5 +280,5 @@
       }
     ]
   },
-  "generated_at": "2021-07-28T16:10:55Z"
+  "generated_at": "2021-08-18T02:36:18Z"
 }

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,0 +1,19 @@
+# Description:
+This register functionality enables user to register before downloading from any commons. Registration means that a user provides their name, organization, and email, in order to gain some predefined permissions (i.e. to be automatically added to a preconfigured Arborist group). This functionality adds the registration form itself along with an admin endpoint to list registered users and their information.
+
+# How to enable:
+- Set up a useryaml that has a GROUP with a policy (for example: "registered_users" with "data_upload" policy)
+- Your test user should not be in this group
+- Set up and run your Arborist
+- Run usersync
+- Put the name of the group in fence config's REGISTERED_USERS_GROUP; also set fence REGISTER_USERS_ON to true.
+- Look in the Fence db and confirm that your test user is not registered (he has no registration_info block in his additional_info column)
+- Look in Arborist db and confirm that your test user is not part of the group and does not have the group's policies
+- Set up and run your Fence, which is talking to your Arborist
+- Log in. You should be redirected to the registration form!
+- Register.
+- Check Arborist db and confirm that now your test user IS part of the group and DOES have the group's policies.
+- Check Fence db and confirm that the registration info you entered is now in the additional_info column.
+- Log out. Log in again. There should be no redirect to the registration form.
+- You can hit /user/register directly to re-register.
+- Now log in with a user that is an admin. Hit the /user/register/list endpoint. You should see your first test user's registration info.

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -550,7 +550,9 @@ def set_csrf(response):
     """
     if not flask.request.cookies.get("csrftoken"):
         secure = config.get("SESSION_COOKIE_SECURE", True)
-        response.set_cookie("csrftoken", random_str(40), secure=secure, httponly=True)
+        # response.set_cookie("csrftoken", random_str(40), secure=secure, httponly=True)
+        # TODO ^ this broke oauthorize form but we probs don't want to revert
+        response.set_cookie("csrftoken", random_str(40), secure=secure, httponly=False)
 
     if flask.request.method in ["POST", "PUT", "DELETE"]:
         current_session.commit()

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -138,9 +138,7 @@ def app_register_blueprints(app):
         fence.blueprints.privacy.blueprint, url_prefix="/privacy-policy"
     )
 
-    app.register_blueprint(
-        fence.blueprints.register.blueprint, url_prefix="/register-user"
-    )
+    app.register_blueprint(fence.blueprints.register.blueprint, url_prefix="/register")
 
     fence.blueprints.misc.register_misc(app)
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -51,6 +51,7 @@ import fence.blueprints.well_known
 import fence.blueprints.link
 import fence.blueprints.google
 import fence.blueprints.privacy
+import fence.blueprints.register
 
 
 # for some reason the temp dir does not get created properly if we move
@@ -134,6 +135,10 @@ def app_register_blueprints(app):
 
     app.register_blueprint(
         fence.blueprints.privacy.blueprint, url_prefix="/privacy-policy"
+    )
+
+    app.register_blueprint(
+        fence.blueprints.register.blueprint, url_prefix="/register-user"
     )
 
     fence.blueprints.misc.register_misc(app)

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -132,7 +132,9 @@ def _login(username, idp_name, email=None):
 
     if config["REGISTER_USERS_ON"]:
         if not flask.g.user.additional_info.get("registration_info"):
-            return flask.redirect(flask.url_for("register-user.register_user"))
+            return flask.redirect(
+                config["BASE_URL"] + flask.url_for("register-user.register_user")
+            )
 
     if flask.session.get("redirect"):
         return flask.redirect(flask.session.get("redirect"))

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -133,7 +133,7 @@ def _login(username, idp_name, email=None):
     if config["REGISTER_USERS_ON"]:
         if not flask.g.user.additional_info.get("registration_info"):
             return flask.redirect(
-                config["BASE_URL"] + flask.url_for("register-user.register_user")
+                config["BASE_URL"] + flask.url_for("register.register_user")
             )
 
     if flask.session.get("redirect"):

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -128,6 +128,12 @@ def _login(username, idp_name, email=None):
     redirect.
     """
     login_user(username, idp_name, email=email)
+    assert flask.g.user is not None
+
+    if config["REGISTER_USERS_ON"]:
+        if not flask.g.user.additional_info.get("registration_info"):
+            return flask.redirect(flask.url_for("register-user.register_user"))
+
     if flask.session.get("redirect"):
         return flask.redirect(flask.session.get("redirect"))
     return flask.jsonify({"username": username})

--- a/fence/blueprints/login/fence_login.py
+++ b/fence/blueprints/login/fence_login.py
@@ -127,7 +127,7 @@ class FenceCallback(DefaultOAuth2Callback):
         if config["REGISTER_USERS_ON"]:
             if not flask.g.user.additional_info.get("registration_info"):
                 return flask.redirect(
-                    config["BASE_URL"] + flask.url_for("register-user.register_user")
+                    config["BASE_URL"] + flask.url_for("register.register_user")
                 )
 
         if "redirect" in flask.session:

--- a/fence/blueprints/login/fence_login.py
+++ b/fence/blueprints/login/fence_login.py
@@ -124,6 +124,12 @@ class FenceCallback(DefaultOAuth2Callback):
         )
         self.post_login()
 
+        if config["REGISTER_USERS_ON"]:
+            if not flask.g.user.additional_info.get("registration_info"):
+                return flask.redirect(
+                    config["BASE_URL"] + flask.url_for("register-user.register_user")
+                )
+
         if "redirect" in flask.session:
             return flask.redirect(flask.session.get("redirect"))
         return flask.jsonify({"username": username})

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -93,7 +93,9 @@ def register_user():
         raise UserError("Form validation failed: {}".format(str(form.errors)))
 
     # Validation passed--don't check form data here.
-    name = flask.request.form["name"]
+    # name = flask.request.form["name"]
+    firstname = flask.request.form["firstname"]
+    lastname = flask.request.form["lastname"]
     org = flask.request.form["organization"]
     email = flask.g.user.email or flask.request.form["email"]
 
@@ -101,7 +103,12 @@ def register_user():
     if flask.g.user.additional_info is not None:
         combined_info.update(flask.g.user.additional_info)
     registration_info = {
-        "registration_info": {"name": name, "org": org, "email": email}
+        "registration_info": {
+            "firstname": firstname,
+            "lastname": lastname,
+            "org": org,
+            "email": email,
+        }
     }
     combined_info.update(registration_info)
     flask.g.user.additional_info = combined_info

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -1,32 +1,7 @@
 """
 Endpoints for user registration.
-
-register_user:
-  - If config["REGISTER_USERS_ON"] is True, then unregistered users are redirected
-    here after logging in.
-  - Users may then register or decline to register.
-  - Users may access this endpoint directly if they initially declined to register.
-  - At the moment, registration involves providing name, org, and (if user.email for
-    the user is None) email.
-  - If a user registers, add the new information to the user's additional_info column,
-    and add the user to the Arborist group specified in
-    config["REGISTERED_USERS_GROUP"].
-    The idea is that users can register in order to obtain certain permissions (where
-    the permissions are defined by the group definition in the useryaml).
-
-  | The registration info is added as a dict under user.additional_info["registration_info"];
-  | it is a separate blob in order to avoid namespace collision and make clear that the
-  | information was self-declared by the user during registration.
-
-  | The HTML form performs some dumb client-side validation, but actual verification
-  | (for example, checking organization info against some trusted authority's records)
-  | has been deemed out of scope.
-
-get_registered_users:
-  - List registration info for every user for which there exists registration info.
-  - Endpoint accessible to admins only.
-  - Response json structure is provisional.
-
+Registration means that a user provides their name, org, and email,
+in order to gain some predefined permissions.
 """
 
 import flask
@@ -42,6 +17,27 @@ blueprint = flask.Blueprint("register-user", __name__)
 @blueprint.route("/", methods=["GET", "POST"])
 @login_required()
 def register_user():
+    """
+    - If config["REGISTER_USERS_ON"] is True, then unregistered users are redirected
+      here after logging in.
+    - Users may then register or decline to register.
+    - Users may access this endpoint directly if they initially declined to register.
+    - At the moment, registration involves providing name, org, and (if user.email for
+      the user is None) email.
+    - If a user registers, add the new information to the user's additional_info column,
+      and add the user to the Arborist group specified in
+      config["REGISTERED_USERS_GROUP"].
+      The idea is that users can register in order to obtain certain permissions (where
+      the permissions are defined by the group definition in the useryaml).
+
+    The registration info is added as a dict under user.additional_info["registration_info"];
+    it is a separate blob in order to avoid namespace collision and make clear that the
+    information was self-declared by the user during registration.
+
+    The HTML form performs some dumb client-side validation, but actual verification
+    (for example, checking organization info against some trusted authority's records)
+    has been deemed out of scope.
+    """
     if flask.request.method == "GET":
         on_decline_redirect = flask.session.get("redirect") or config["BASE_URL"]
         return flask.render_template(
@@ -91,6 +87,11 @@ def register_user():
 @blueprint.route("/list", methods=["GET"])
 @admin_login_required
 def get_registered_users():
+    """
+    - List registration info for every user for which there exists registration info.
+    - Endpoint accessible to admins only.
+    - Response json structure is provisional.
+    """
     registered_users = (
         current_session.query(User)
         .filter(User.additional_info["registration_info"] != "{}")

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -1,0 +1,80 @@
+"""
+Endpoint for user registration.
+
+- If config["REGISTER_USERS_ON"] is True, then unregistered users are redirected
+  here after logging in.
+- Users may then register or decline to register.
+- Users may access this endpoint directly if they initially declined to register.
+- At the moment, registration involves providing name, org, and (if user.email for
+  the user is None) email.
+- If a user registers, add the new information to the user's additional_info column,
+  and add the user to the Arborist group specified in
+  config["REGISTERED_USERS_GROUP"].
+  The idea is that users can register in order to obtain certain permissions (where
+  the permissions are defined by the group definition in the useryaml).
+
+The registration info is added as a dict under user.additional_info["registration_info"];
+it is a separate blob in order to avoid namespace collision and make clear that the
+information was self-declared by the user during registration.
+
+The HTML form performs some dumb client-side validation, but actual verification
+(for example, checking organization info against some trusted authority's records)
+has been deemed out of scope.
+"""
+
+import flask
+from flask_sqlalchemy_session import current_session
+
+from fence import config
+from fence.auth import login_required
+
+blueprint = flask.Blueprint("register-user", __name__)
+
+
+@blueprint.route("/", methods=["GET", "POST"])
+@login_required()
+def register_user():
+    if flask.request.method == "GET":
+        on_decline_redirect = flask.session.get("redirect") or config["BASE_URL"]
+        return flask.render_template(
+            "register_user.html",
+            user=flask.g.user,
+            on_decline_redirect=on_decline_redirect,
+        )
+
+    assert flask.request.method == "POST"
+
+    # HTML form should require all fields, so no gets.
+    name = flask.request.form["name"]
+    org = flask.request.form["organization"]
+
+    if flask.g.user.email:
+        # If user.email is populated, the form should not have had an email field.
+        assert flask.request.form.get("email") is None
+        email = flask.g.user.email
+    else:
+        email = flask.request.form["email"]
+
+    combined_info = {}
+    if flask.g.user.additional_info is not None:
+        combined_info.update(flask.g.user.additional_info)
+    registration_info = {
+        "registration_info": {"name": name, "org": org, "email": email}
+    }
+    combined_info.update(registration_info)
+    flask.g.user.additional_info = combined_info
+    current_session.add(flask.g.user)
+    current_session.commit()
+
+    with flask.current_app.arborist.context():
+        # make sure the user exists in Arborist
+        flask.current_app.arborist.create_user(dict(name=flask.g.user.username))
+        flask.current_app.arborist.add_user_to_group(
+            flask.g.user.username,
+            config["REGISTERED_USERS_GROUP"],
+        )
+
+    # Respect session redirect--important when redirected here from login flow
+    if flask.session.get("redirect"):
+        return flask.redirect(flask.session.get("redirect"))
+    return flask.jsonify(registration_info)

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -47,7 +47,9 @@ def xor_with_user_email(form, field):
 
 
 class RegistrationForm(FlaskForm):
-    name = StringField(label="Name", validators=[DataRequired()])
+    # name = StringField(label="Name", validators=[DataRequired()])
+    firstname = StringField(label="FirstName", validators=[DataRequired()])
+    lastname = StringField(label="LastName", validators=[DataRequired()])
     organization = StringField(label="Organization", validators=[DataRequired()])
     email = StringField(label="Email", validators=[xor_with_user_email, Email()])
 

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -16,7 +16,7 @@ from fence.errors import UserError
 from fence.models import User
 
 
-blueprint = flask.Blueprint("register-user", __name__)
+blueprint = flask.Blueprint("register", __name__)
 
 
 def xor_with_user_email(form, field):
@@ -47,7 +47,6 @@ def xor_with_user_email(form, field):
 
 
 class RegistrationForm(FlaskForm):
-    # name = StringField(label="Name", validators=[DataRequired()])
     firstname = StringField(label="First Name", validators=[DataRequired()])
     lastname = StringField(label="Last Name", validators=[DataRequired()])
     organization = StringField(label="Organization", validators=[DataRequired()])
@@ -95,7 +94,6 @@ def register_user():
         raise UserError("Form validation failed: {}".format(str(form.errors)))
 
     # Validation passed--don't check form data here.
-    # name = flask.request.form["name"]
     firstname = flask.request.form["firstname"]
     lastname = flask.request.form["lastname"]
     org = flask.request.form["organization"]

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -60,10 +60,10 @@ def register_user():
     """
     - If config["REGISTER_USERS_ON"] is True, then unregistered users are redirected
       here after logging in.
-    - Users may then register or decline to register.
-    - Users may access this endpoint directly if they initially declined to register.
-    - At the moment, registration involves providing name, org, and (if user.email for
-      the user is None) email.
+    - Users may then register.
+    - Users may access this endpoint directly.
+    - At the moment, registration involves providing firstname, lastname, org, and
+      (if user.email for the user is None) email.
     - If a user registers, add the new information to the user's additional_info column,
       and add the user to the Arborist group specified in
       config["REGISTERED_USERS_GROUP"].
@@ -81,11 +81,9 @@ def register_user():
     form = RegistrationForm()
 
     if flask.request.method == "GET":
-        on_decline_redirect = flask.session.get("redirect") or config["BASE_URL"]
         return flask.render_template(
             "register_user.html",
             user=flask.g.user,
-            on_decline_redirect=on_decline_redirect,
             form=form,
         )
 

--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -48,10 +48,12 @@ def xor_with_user_email(form, field):
 
 class RegistrationForm(FlaskForm):
     # name = StringField(label="Name", validators=[DataRequired()])
-    firstname = StringField(label="FirstName", validators=[DataRequired()])
-    lastname = StringField(label="LastName", validators=[DataRequired()])
+    firstname = StringField(label="First Name", validators=[DataRequired()])
+    lastname = StringField(label="Last Name", validators=[DataRequired()])
     organization = StringField(label="Organization", validators=[DataRequired()])
-    email = StringField(label="Email", validators=[xor_with_user_email, Email()])
+    email = StringField(
+        label="Email", validators=[xor_with_user_email, Email(), DataRequired()]
+    )
 
 
 @blueprint.route("/", methods=["GET", "POST"])

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -854,8 +854,8 @@ ASSUME_ROLE_CACHE_SECONDS: 1800
 # MIDRC user registration feature: Ask users to register (provide name/org/email) on login.
 # If user registers, add them to configured Arborist group; idea is that the Arborist group
 # will have access to download data.
-REGISTER_USERS_ON: false
-REGISTERED_USERS_GROUP: ''
+REGISTER_USERS_ON: true
+REGISTERED_USERS_GROUP: 'data_uploaders'
 # RAS refresh_tokens expire in 15 days
 RAS_REFRESH_EXPIRATION: 1296000
 # List of JWT issuers from which Fence will accept GA4GH visas

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -848,6 +848,11 @@ SYNAPSE_AUTHZ_TTL: 86400
 MAX_ROLE_SESSION_INCREASE: false
 ASSUME_ROLE_CACHE_SECONDS: 1800
 
+# MIDRC user registration feature: Ask users to register (provide name/org/email) on login.
+# If user registers, add them to configured Arborist group; idea is that the Arborist group
+# will have access to download data.
+REGISTER_USERS_ON: false
+REGISTERED_USERS_GROUP: ''
 # RAS refresh_tokens expire in 15 days
 RAS_REFRESH_EXPIRATION: 1296000
 # List of JWT issuers from which Fence will accept GA4GH visas

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -630,7 +630,7 @@ INDEXD_PASSWORD: ''
 AZ_BLOB_CREDENTIALS:
 
 # AZ_BLOB_CONTAINER_URL: 'https://storageaccount.blob.core.windows.net/container/'
-# this is the container used for uploading, and should match the storage account 
+# this is the container used for uploading, and should match the storage account
 # used in the connection string for AZ_BLOB_CREDENTIALS
 AZ_BLOB_CONTAINER_URL: 'https://myfakeblob.blob.core.windows.net/my-fake-container/'
 
@@ -854,8 +854,8 @@ ASSUME_ROLE_CACHE_SECONDS: 1800
 # MIDRC user registration feature: Ask users to register (provide name/org/email) on login.
 # If user registers, add them to configured Arborist group; idea is that the Arborist group
 # will have access to download data.
-REGISTER_USERS_ON: true
-REGISTERED_USERS_GROUP: 'data_uploaders'
+REGISTER_USERS_ON: false
+REGISTERED_USERS_GROUP: ''
 # RAS refresh_tokens expire in 15 days
 RAS_REFRESH_EXPIRATION: 1296000
 # List of JWT issuers from which Fence will accept GA4GH visas

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -72,6 +72,9 @@ SESSION_COOKIE_SECURE: true
 
 ENABLE_CSRF_PROTECTION: true
 
+# Signing key for WTForms to sign CSRF tokens with
+WTF_CSRF_SECRET_KEY: '{{ENCRYPTION_KEY}}'
+
 # fence (at the moment) attempts a migration on startup. setting this to false will disable that
 # WARNING: ONLY set to false if you do NOT want to automatically migrate your database.
 #          You should be careful about incompatible versions of your db schema with what

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>Register</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 </head>
 
 
@@ -111,4 +112,55 @@ button {
     opacity: 0.8;
 }
 </style>
+<script>
+    function getCookie(name) {
+        var value = "; " + document.cookie;
+        var parts = value.split("; " + name + "=");
+        if (parts.length == 2) return parts.pop().split(";").shift();
+    }
+
+
+    window.addEventListener( "load", function () {
+      function sendData() {
+
+        const XHR = new XMLHttpRequest();
+
+        // Bind the FormData object and the form element
+        const FD = new FormData( form );
+
+        // Define what happens on successful data submission
+        // TODO handle redirect... somehow
+        XHR.addEventListener( "load", function(event) {
+          alert( event.target.responseText );
+        } );
+
+        // Define what happens in case of error
+        XHR.addEventListener( "error", function( event ) {
+          alert( 'Oops! Something went wrong.' );
+        } );
+
+        // Set up our request
+        XHR.open( "POST", form.action);
+
+        // TODO because the cookie is now HttpOnly, the browser cannot read document.cookie.
+        // This only works if I set HttpOnly back to False, but obv the pentesters want it True.
+        // Yes, this means the oauthorize form has also been broken since that change
+        // Well, that's a problem. Options: Make a hidden form field? At that point just use WTForms right?
+        XHR.setRequestHeader('x-csrf-token', getCookie('csrftoken'));
+
+        // The data sent is what the user provided in the form
+        XHR.send( FD );
+      }
+
+      // Access the form element...
+      const form = document.querySelector("form");
+
+      // ...and take over its submit event.
+      form.addEventListener( "submit", function ( event ) {
+        event.preventDefault();
+
+        sendData();
+      } );
+    } );
+</script>
 </html>

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -18,7 +18,8 @@
     <h1 class="introduction">Register in order to get access to download data</h1>
     {{ form.csrf_token }}
     <ul>
-      <li> {{ form.name.label }} {{ form.name }} </li>
+      <li> {{ form.firstname.label }} {{ form.firstname }} </li>
+      <li> {{ form.lastname.label }} {{ form.lastname }} </li>
       <li> {{ form.organization.label }} {{ form.organization }} </li>
       <li>
           {% if user.email %}

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Register</title>
+</head>
+
+
+{% block header %}
+  <h1>{% block title %}Register{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+
+    <h1 class="introduction">Register in order to get access to download data</h1>
+    <ul>
+      <li>
+          <label for="name">Name</label>
+          <input name="name" id="name" required>
+      </li>
+      <li>
+          <label for="organization">Organization</label>
+          <input name="organization" id="organization" required>
+      </li>
+
+      <li>
+          {% if user.email %}
+            <p> This account is connected to the email: <strong>{{ user.email }}</strong> </p>
+          {% else %}
+            <label for="email">Email</label>
+            <input type="email" name="email" id="email" required>
+          {% endif %}
+      </li>
+
+    </ul>
+    <button class="button-primary-orange" type="submit">Register</button>
+    <a href={{ on_decline_redirect }}>
+      <button class="button-primary-white" type="button">Maybe Later</button>
+    </a>
+  </form>
+{% endblock %}
+
+
+<!--styling is mostly taken from the OAuth authorize form-->
+<style>
+body {
+    background-color: #F5F5F5;
+    font-family: 'Source Sans Pro', sans-serif;
+}
+ul {
+    list-style: none;
+}
+label {
+    display: inline-block;
+    width: 90px;
+    text-align: right;
+}
+button {
+  border-radius: 4px;
+  width: 152px;
+  height: 40px;
+  font-size: 14px;
+  font-weight: 500;
+  display: inline-block;
+  vertical-align: middle;
+  cursor: pointer;
+  margin-left: 16px;
+}
+.introduction {
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 18px;
+    letter-spacing: .03rem;
+    color: #000000;
+    display: inline-block;
+}
+.button-primary-white {
+    border: 1px solid #9B9B9B;
+    background-color: #FFFFFF;
+    font-weight: 500;
+    color: #606060;
+    fill: #606060;
+}
+.button-primary-white:hover svg path,
+.button-primary-white:hover {
+    border: 1px solid #000000;
+    font-weight: 600;
+    color: #000000;
+    fill: #000000;
+}
+.button-primary-white:active {
+    border: 1px solid #ef8523;
+    color: #ef8523;
+}
+.button-primary-orange {
+  border: 1px solid #9b9b9b;
+  background-color: #ef8523;
+  letter-spacing: .06rem;
+  color: #FFFFFF;
+  fill: #FFFFFF;
+  font-weight: 500;
+}
+.button-primary-orange:hover {
+    border: 1px solid #606060;
+    font-weight: 600;
+    background-color: #ff9635;
+}
+.button-primary-orange:active {
+    opacity: 0.8;
+}
+</style>
+</html>

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -16,25 +16,17 @@
   <form method="post">
 
     <h1 class="introduction">Register in order to get access to download data</h1>
+    {{ form.csrf_token }}
     <ul>
-      <li>
-          <label for="name">Name</label>
-          <input name="name" id="name" required>
-      </li>
-      <li>
-          <label for="organization">Organization</label>
-          <input name="organization" id="organization" required>
-      </li>
-
+      <li> {{ form.name.label }} {{ form.name }} </li>
+      <li> {{ form.organization.label }} {{ form.organization }} </li>
       <li>
           {% if user.email %}
             <p> This account is connected to the email: <strong>{{ user.email }}</strong> </p>
           {% else %}
-            <label for="email">Email</label>
-            <input type="email" name="email" id="email" required>
+            {{ form.email.label }} {{ form.email }}
           {% endif %}
       </li>
-
     </ul>
     <button class="button-primary-orange" type="submit">Register</button>
     <a href={{ on_decline_redirect }}>
@@ -112,55 +104,4 @@ button {
     opacity: 0.8;
 }
 </style>
-<script>
-    function getCookie(name) {
-        var value = "; " + document.cookie;
-        var parts = value.split("; " + name + "=");
-        if (parts.length == 2) return parts.pop().split(";").shift();
-    }
-
-
-    window.addEventListener( "load", function () {
-      function sendData() {
-
-        const XHR = new XMLHttpRequest();
-
-        // Bind the FormData object and the form element
-        const FD = new FormData( form );
-
-        // Define what happens on successful data submission
-        // TODO handle redirect... somehow
-        XHR.addEventListener( "load", function(event) {
-          alert( event.target.responseText );
-        } );
-
-        // Define what happens in case of error
-        XHR.addEventListener( "error", function( event ) {
-          alert( 'Oops! Something went wrong.' );
-        } );
-
-        // Set up our request
-        XHR.open( "POST", form.action);
-
-        // TODO because the cookie is now HttpOnly, the browser cannot read document.cookie.
-        // This only works if I set HttpOnly back to False, but obv the pentesters want it True.
-        // Yes, this means the oauthorize form has also been broken since that change
-        // Well, that's a problem. Options: Make a hidden form field? At that point just use WTForms right?
-        XHR.setRequestHeader('x-csrf-token', getCookie('csrftoken'));
-
-        // The data sent is what the user provided in the form
-        XHR.send( FD );
-      }
-
-      // Access the form element...
-      const form = document.querySelector("form");
-
-      // ...and take over its submit event.
-      form.addEventListener( "submit", function ( event ) {
-        event.preventDefault();
-
-        sendData();
-      } );
-    } );
-</script>
 </html>

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -30,9 +30,6 @@
       </li>
     </ul>
     <button class="button-primary-orange" type="submit">Register</button>
-    <a href={{ on_decline_redirect }}>
-      <button class="button-primary-white" type="button">Maybe Later</button>
-    </a>
   </form>
 {% endblock %}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,8 +80,21 @@ flask = ["Flask (>=0.10.1)"]
 fastapi = ["fastapi (>=0.54.1,<0.55.0)"]
 
 [[package]]
+name = "aws-xray-sdk"
+version = "0.95"
+description = "The AWS X-Ray SDK for Python (the SDK) enables Python developers to record and emit information from within their applications to the AWS X-Ray service."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+jsonpickle = "*"
+requests = "*"
+wrapt = "*"
+
+[[package]]
 name = "azure-core"
-version = "1.13.0"
+version = "1.17.0"
 description = "Microsoft Azure Core Library for Python"
 category = "main"
 optional = false
@@ -93,7 +106,7 @@ six = ">=1.11.0"
 
 [[package]]
 name = "azure-storage-blob"
-version = "12.8.0"
+version = "12.8.1"
 description = "Microsoft Azure Blob Storage Client Library for Python"
 category = "main"
 optional = false
@@ -384,6 +397,23 @@ curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
 trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
 
 [[package]]
+name = "docker"
+version = "5.0.0"
+description = "A Python library for the Docker Engine API."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
+requests = ">=2.14.2,<2.18.0 || >2.18.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.2)"]
+tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"
@@ -491,6 +521,19 @@ Werkzeug = ">=0.6.1"
 docs = ["Sphinx (>=1.2.3)", "alabaster (>=0.6.3)"]
 
 [[package]]
+name = "flask-wtf"
+version = "0.14.3"
+description = "Simple integration of Flask and WTForms."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = "*"
+itsdangerous = "*"
+WTForms = "*"
+
+[[package]]
 name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
@@ -559,7 +602,7 @@ PyYAML = ">=5.1,<6.0"
 
 [[package]]
 name = "google-api-core"
-version = "1.31.1"
+version = "1.31.2"
 description = "Google API client core library"
 category = "main"
 optional = false
@@ -597,7 +640,7 @@ uritemplate = ">=3.0.0,<4dev"
 
 [[package]]
 name = "google-auth"
-version = "1.34.0"
+version = "1.35.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
@@ -645,14 +688,15 @@ grpc = ["grpcio (>=1.8.2,<2.0dev)"]
 
 [[package]]
 name = "google-cloud-storage"
-version = "1.41.1"
+version = "1.42.0"
 description = "Google Cloud Storage API client library"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.dependencies]
-google-auth = {version = ">=1.24.0,<3.0dev", markers = "python_version >= \"3.6\""}
+google-api-core = {version = ">=1.29.0,<3.0dev", markers = "python_version >= \"3.6\""}
+google-auth = {version = ">=1.25.0,<3.0dev", markers = "python_version >= \"3.6\""}
 google-cloud-core = {version = ">=1.6.0,<3.0dev", markers = "python_version >= \"3.6\""}
 google-resumable-media = {version = ">=1.3.0,<3.0dev", markers = "python_version >= \"3.6\""}
 requests = ">=2.18.0,<3.0.0dev"
@@ -764,18 +808,21 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "immutables"
-version = "0.15"
+version = "0.16"
 description = "Immutable Collections"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
 
 [package.extras]
-test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)"]
+test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)", "mypy (>=0.910)", "pytest (>=6.2.4,<6.3.0)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.3"
+version = "4.6.4"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -832,6 +879,30 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "jsondiff"
+version = "1.1.1"
+description = "Diff JSON and JSON-like structures in Python"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "jsonpickle"
+version = "2.0.0"
+description = "Python library for serializing any arbitrary object graph into JSON"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sklearn", "sqlalchemy", "enum34", "jsonlib"]
+"testing.libs" = ["demjson", "simplejson", "ujson", "yajl"]
+
+[[package]]
 name = "markdown"
 version = "3.3.4"
 description = "Python implementation of Markdown."
@@ -847,11 +918,11 @@ testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "markupsafe"
-version = "1.1.1"
+version = "2.0.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "mock"
@@ -879,41 +950,34 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "moto"
-version = "1.3.15"
+version = "1.3.7"
 description = "A library that allows your python tests to easily mock out the boto library"
 category = "dev"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
+aws-xray-sdk = ">=0.93,<0.96"
 boto = ">=2.36.0"
-boto3 = ">=1.9.201"
-botocore = ">=1.12.201"
-Jinja2 = ">=2.10.1"
-MarkupSafe = "<2.0"
+boto3 = ">=1.6.16"
+botocore = ">=1.12.13"
+cryptography = ">=2.3.0"
+docker = ">=2.5.1"
+Jinja2 = ">=2.7.3"
+jsondiff = "1.1.1"
 mock = "*"
-more-itertools = "*"
+pyaml = "*"
 python-dateutil = ">=2.1,<3.0.0"
+python-jose = "<3.0.0"
 pytz = "*"
 requests = ">=2.5"
 responses = ">=0.9.0"
 six = ">1.9"
 werkzeug = "*"
 xmltodict = "*"
-zipp = "*"
 
 [package.extras]
-acm = ["cryptography (>=2.3.0)"]
-all = ["cryptography (>=2.3.0)", "PyYAML (>=5.1)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "ecdsa (<0.15)", "docker (>=2.5.1)", "jsondiff (>=1.1.2)", "aws-xray-sdk (>=0.93,!=0.96)", "idna (>=2.5,<3)", "cfn-lint (>=0.4.0)", "sshpubkeys (>=3.1.0,<4.0)", "sshpubkeys (>=3.1.0)"]
-awslambda = ["docker (>=2.5.1)"]
-batch = ["docker (>=2.5.1)"]
-cloudformation = ["PyYAML (>=5.1)", "cfn-lint (>=0.4.0)"]
-cognitoidp = ["python-jose[cryptography] (>=3.1.0,<4.0.0)", "ecdsa (<0.15)"]
-ec2 = ["cryptography (>=2.3.0)", "sshpubkeys (>=3.1.0,<4.0)", "sshpubkeys (>=3.1.0)"]
-iam = ["cryptography (>=2.3.0)"]
-iotdata = ["jsondiff (>=1.1.2)"]
 server = ["flask"]
-xray = ["aws-xray-sdk (>=0.93,!=0.96)"]
 
 [[package]]
 name = "msrest"
@@ -949,16 +1013,16 @@ six = ">=1.6.1"
 
 [[package]]
 name = "oauthlib"
-version = "3.1.0"
+version = "3.1.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.extras]
-rsa = ["cryptography"]
-signals = ["blinker"]
-signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
+rsa = ["cryptography (>=3.0.0,<4)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0,<4)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "packaging"
@@ -1061,6 +1125,17 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyaml"
+version = "21.8.3"
+description = "PyYAML-based module to produce pretty and readable YAML-serialized data"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+PyYAML = "*"
 
 [[package]]
 name = "pyasn1"
@@ -1226,6 +1301,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pywin32"
+version = "227"
+description = "Python for Window Extensions"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -1268,7 +1351,7 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "responses"
-version = "0.13.3"
+version = "0.13.4"
 description = "A utility library for mocking out the `requests` Python library."
 category = "dev"
 optional = false
@@ -1280,7 +1363,7 @@ six = "*"
 urllib3 = ">=1.25.10"
 
 [package.extras]
-tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "types-six", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
 
 [[package]]
 name = "retry"
@@ -1438,6 +1521,18 @@ cdislogging = "*"
 sqlalchemy = ">=1.3.3,<1.4.0"
 
 [[package]]
+name = "websocket-client"
+version = "1.2.1"
+description = "WebSocket client for Python with low level API options"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
 name = "werkzeug"
 version = "1.0.1"
 description = "The comprehensive WSGI web application library."
@@ -1448,6 +1543,30 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 [package.extras]
 dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
 watchdog = ["watchdog"]
+
+[[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "wtforms"
+version = "2.3.3"
+description = "A flexible forms validation and rendering library for Python web development."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+MarkupSafe = "*"
+
+[package.extras]
+email = ["email-validator"]
+ipaddress = ["ipaddress"]
+locale = ["Babel (>=1.3)"]
 
 [[package]]
 name = "xmltodict"
@@ -1472,7 +1591,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "ecbf6dd7c561d052cd3953c48fb208bfa5181233bf82882cd42a92f398a95ae1"
+content-hash = "d797b83faaedf69db00c086a204145cde81cad1d6365c057c56e4029ec74e7a2"
 
 [metadata.files]
 addict = [
@@ -1503,13 +1622,17 @@ authutils = [
     {file = "authutils-6.0.2-py3-none-any.whl", hash = "sha256:b1ded486669ae181d451052e5c435300b33d3c9cb7edbe75da5ba9530f3e5128"},
     {file = "authutils-6.0.2.tar.gz", hash = "sha256:709e4c1bb95ebe29c7bf3ec1d6b9a0dca030495cdab61afe74064e507cf70ae4"},
 ]
+aws-xray-sdk = [
+    {file = "aws-xray-sdk-0.95.tar.gz", hash = "sha256:9e7ba8dd08fd2939376c21423376206bff01d0deaea7d7721c6b35921fed1943"},
+    {file = "aws_xray_sdk-0.95-py2.py3-none-any.whl", hash = "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c"},
+]
 azure-core = [
-    {file = "azure-core-1.13.0.zip", hash = "sha256:624b46db407dbed9e03134ab65214efab5b5315949a1fbd6cd592c46fb272588"},
-    {file = "azure_core-1.13.0-py2.py3-none-any.whl", hash = "sha256:3c886a5c6e0698360826c08b2685965d8c23e1292c32be9028ce2fa691005849"},
+    {file = "azure-core-1.17.0.zip", hash = "sha256:25407390dde142d3e41ecf78bb18cedda9b7f7a0af558d082dec711c4a334f46"},
+    {file = "azure_core-1.17.0-py2.py3-none-any.whl", hash = "sha256:906e031a8241fe0794ec4137aca77a1aeab2ebde5cd6049c377d05cb6b87b691"},
 ]
 azure-storage-blob = [
-    {file = "azure-storage-blob-12.8.0.zip", hash = "sha256:36b85a3423379d4a93f663022487cf53aa3043a355f8414321dde878c00cb577"},
-    {file = "azure_storage_blob-12.8.0-py2.py3-none-any.whl", hash = "sha256:46999df6e2cde8773739f7c3bd1eb5846d4b7dc1ef6e2161f3b6d1d0f21726ba"},
+    {file = "azure-storage-blob-12.8.1.zip", hash = "sha256:eb37b50ddfb6e558b29f6c8c03b0666514e55d6170bf4624e7261a3af93c6401"},
+    {file = "azure_storage_blob-12.8.1-py2.py3-none-any.whl", hash = "sha256:e74c2c49fd04b80225f5b9734f1dbd417d89f280abfedccced3ac21509e1659d"},
 ]
 backoff = [
     {file = "backoff-1.11.1-py2.py3-none-any.whl", hash = "sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5"},
@@ -1718,6 +1841,10 @@ dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
     {file = "dnspython-2.1.0.zip", hash = "sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4"},
 ]
+docker = [
+    {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},
+    {file = "docker-5.0.0.tar.gz", hash = "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5"},
+]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
@@ -1749,6 +1876,10 @@ flask-restful = [
 flask-sqlalchemy-session = [
     {file = "Flask-SQLAlchemy-Session-1.1.tar.gz", hash = "sha256:0fbc520d587c891c2a0d58aa7952bc37edd73660f10006ff4732a72aa16d8157"},
 ]
+flask-wtf = [
+    {file = "Flask-WTF-0.14.3.tar.gz", hash = "sha256:d417e3a0008b5ba583da1763e4db0f55a1269d9dd91dcc3eb3c026d3c5dbd720"},
+    {file = "Flask_WTF-0.14.3-py2.py3-none-any.whl", hash = "sha256:57b3faf6fe5d6168bda0c36b0df1d05770f8e205e18332d0376ddb954d17aef2"},
+]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
@@ -1766,16 +1897,16 @@ gen3users = [
     {file = "gen3users-0.6.0.tar.gz", hash = "sha256:3b9b56798a7d8b34712389dbbab93c00b0f92524f890513f899c31630ea986da"},
 ]
 google-api-core = [
-    {file = "google-api-core-1.31.1.tar.gz", hash = "sha256:108cf94336aed7e614eafc53933ef02adf63b9f0fd87e8f8212acaa09eaca456"},
-    {file = "google_api_core-1.31.1-py2.py3-none-any.whl", hash = "sha256:1d63e2b28057d79d64795c9a70abcecb5b7e96da732d011abf09606a39b48701"},
+    {file = "google-api-core-1.31.2.tar.gz", hash = "sha256:8500aded318fdb235130bf183c726a05a9cb7c4b09c266bd5119b86cdb8a4d10"},
+    {file = "google_api_core-1.31.2-py2.py3-none-any.whl", hash = "sha256:384459a0dc98c1c8cd90b28dc5800b8705e0275a673a7144a513ae80fc77950b"},
 ]
 google-api-python-client = [
     {file = "google-api-python-client-1.11.0.tar.gz", hash = "sha256:caf4015800ef1a18d06d117f47f0219c0c0641f21978f6b1bb5ede7912fab97b"},
     {file = "google_api_python_client-1.11.0-py2.py3-none-any.whl", hash = "sha256:4f596894f702736da84cf89490a810b55ca02a81f0cddeacb3022e2900b11ec6"},
 ]
 google-auth = [
-    {file = "google-auth-1.34.0.tar.gz", hash = "sha256:f1094088bae046fb06f3d1a3d7df14717e8d959e9105b79c57725bd4e17597a2"},
-    {file = "google_auth-1.34.0-py2.py3-none-any.whl", hash = "sha256:bd6aa5916970a823e76ffb3d5c3ad3f0bedafca0a7fa53bc15149ab21cb71e05"},
+    {file = "google-auth-1.35.0.tar.gz", hash = "sha256:b7033be9028c188ee30200b204ea00ed82ea1162e8ac1df4aa6ded19a191d88e"},
+    {file = "google_auth-1.35.0-py2.py3-none-any.whl", hash = "sha256:997516b42ecb5b63e8d80f5632c1a61dddf41d2a4c2748057837e06e00014258"},
 ]
 google-auth-httplib2 = [
     {file = "google-auth-httplib2-0.1.0.tar.gz", hash = "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"},
@@ -1786,8 +1917,8 @@ google-cloud-core = [
     {file = "google_cloud_core-1.7.2-py2.py3-none-any.whl", hash = "sha256:5b77935f3d9573e27007749a3b522f08d764c5b5930ff1527b2ab2743e9f0c15"},
 ]
 google-cloud-storage = [
-    {file = "google-cloud-storage-1.41.1.tar.gz", hash = "sha256:a81ecc0f382b8e4437cc7f152f74d77ef917c8280a5d1040f5dcfbd0502c7906"},
-    {file = "google_cloud_storage-1.41.1-py2.py3-none-any.whl", hash = "sha256:cd4c9039eb0017fdc75c3f96b0b5ea57759ceefe3a0401d514bcf0111cd7a508"},
+    {file = "google-cloud-storage-1.42.0.tar.gz", hash = "sha256:c1dd3d09198edcf24ec6803dd4545e867d82b998f06a68ead3b6857b1840bdae"},
+    {file = "google_cloud_storage-1.42.0-py2.py3-none-any.whl", hash = "sha256:92a9c8b1a6a278c5c12877fe1a966ecd0cae327cf98c6ae50deedf1a32d6cf2b"},
 ]
 google-crc32c = [
     {file = "google-crc32c-1.1.2.tar.gz", hash = "sha256:dff5bd1236737f66950999d25de7a78144548ebac7788d30ada8c1b6ead60b27"},
@@ -1849,25 +1980,37 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 immutables = [
-    {file = "immutables-0.15-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:6728f4392e3e8e64b593a5a0cd910a1278f07f879795517e09f308daed138631"},
-    {file = "immutables-0.15-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f0836cd3bdc37c8a77b192bbe5f41dbcc3ce654db048ebbba89bdfe6db7a1c7a"},
-    {file = "immutables-0.15-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:8703d8abfd8687932f2a05f38e7de270c3a6ca3bd1c1efb3c938656b3f2f985a"},
-    {file = "immutables-0.15-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b8ad986f9b532c026f19585289384b0769188fcb68b37c7f0bd0df9092a6ca54"},
-    {file = "immutables-0.15-cp36-cp36m-win_amd64.whl", hash = "sha256:6f117d9206165b9dab8fd81c5129db757d1a044953f438654236ed9a7a4224ae"},
-    {file = "immutables-0.15-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b75ade826920c4e490b1bb14cf967ac14e61eb7c5562161c5d7337d61962c226"},
-    {file = "immutables-0.15-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b7e13c061785e34f73c4f659861f1b3e4a5fd918e4395c84b21c4e3d449ebe27"},
-    {file = "immutables-0.15-cp37-cp37m-win_amd64.whl", hash = "sha256:3035849accee4f4e510ed7c94366a40e0f5fef9069fbe04a35f4787b13610a4a"},
-    {file = "immutables-0.15-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:b04fa69174e0c8f815f9c55f2a43fc9e5a68452fab459a08e904a74e8471639f"},
-    {file = "immutables-0.15-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:141c2e9ea515a3a815007a429f0b47a578ebeb42c831edaec882a245a35fffca"},
-    {file = "immutables-0.15-cp38-cp38-win_amd64.whl", hash = "sha256:cbe8c64640637faa5535d539421b293327f119c31507c33ca880bd4f16035eb6"},
-    {file = "immutables-0.15-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:a0a4e4417d5ef4812d7f99470cd39347b58cb927365dd2b8da9161040d260db0"},
-    {file = "immutables-0.15-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3b15c08c71c59e5b7c2470ef949d49ff9f4263bb77f488422eaa157da84d6999"},
-    {file = "immutables-0.15-cp39-cp39-win_amd64.whl", hash = "sha256:2283a93c151566e6830aee0e5bee55fc273455503b43aa004356b50f9182092b"},
-    {file = "immutables-0.15.tar.gz", hash = "sha256:3713ab1ebbb6946b7ce1387bb9d1d7f5e09c45add58c2a2ee65f963c171e746b"},
+    {file = "immutables-0.16-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:acbfa79d44228d96296279068441f980dc63dbed52522d9227ff9f4d96c6627e"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c9ed003eacb92e630ef200e31f47236c2139b39476894f7963b32bd39bafa3"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a396314b9024fa55bf83a27813fd76cf9f27dce51f53b0f19b51de035146251"},
+    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a2a71678348fb95b13ca108d447f559a754c41b47bd1e7e4fb23974e735682d"},
+    {file = "immutables-0.16-cp36-cp36m-win32.whl", hash = "sha256:064001638ab5d36f6aa05b6101446f4a5793fb71e522bc81b8fc65a1894266ff"},
+    {file = "immutables-0.16-cp36-cp36m-win_amd64.whl", hash = "sha256:1de393f1b188740ca7b38f946f2bbc7edf3910d2048f03bbb8d01f17a038d67c"},
+    {file = "immutables-0.16-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fcf678a3074613119385a02a07c469ec5130559f5ea843c85a0840c80b5b71c6"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a307eb0984eb43e815dcacea3ac50c11d00a936ecf694c46991cd5a23bcb0ec0"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a58825ff2254e2612c5a932174398a4ea8fbddd8a64a02c880cc32ee28b8820"},
+    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:798b095381eb42cf40db6876339e7bed84093e5868018a9e73d8e1f7ab4bb21e"},
+    {file = "immutables-0.16-cp37-cp37m-win32.whl", hash = "sha256:19bdede174847c2ef1292df0f23868ab3918b560febb09fcac6eec621bd4812b"},
+    {file = "immutables-0.16-cp37-cp37m-win_amd64.whl", hash = "sha256:9ccf4c0e3e2e3237012b516c74c49de8872ccdf9129739f7a0b9d7444a8c4862"},
+    {file = "immutables-0.16-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d59beef203a3765db72b1d0943547425c8318ecf7d64c451fd1e130b653c2fbb"},
+    {file = "immutables-0.16-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0020aaa4010b136056c20a46ce53204e1407a9e4464246cb2cf95b90808d9161"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd9f67671555af1eb99ad3c7550238487dd7ac0ac5205b40204ed61c9a922ac"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:298a301f85f307b4c056a0825eb30f060e64d73605e783289f3df37dd762bab8"},
+    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b779617f5b94486bfd0f22162cd72eb5f2beb0214a14b75fdafb7b2c908ed0cb"},
+    {file = "immutables-0.16-cp38-cp38-win32.whl", hash = "sha256:511c93d8b1bbbf103ff3f1f120c5a68a9866ce03dea6ac406537f93ca9b19139"},
+    {file = "immutables-0.16-cp38-cp38-win_amd64.whl", hash = "sha256:b651b61c1af6cda2ee201450f2ffe048a5959bc88e43e6c312f4c93e69c9e929"},
+    {file = "immutables-0.16-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:aa7bf572ae1e006104c584be70dc634849cf0dc62f42f4ee194774f97e7fd17d"},
+    {file = "immutables-0.16-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50793a44ba0d228ed8cad4d0925e00dfd62ea32f44ddee8854f8066447272d05"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799621dcdcdcbb2516546a40123b87bf88de75fe7459f7bd8144f079ace6ec3e"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7bcf52aeb983bd803b7c6106eae1b2d9a0c7ab1241bc6b45e2174ba2b7283031"},
+    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:734c269e82e5f307fb6e17945953b67659d1731e65309787b8f7ba267d1468f2"},
+    {file = "immutables-0.16-cp39-cp39-win32.whl", hash = "sha256:a454d5d3fee4b7cc627345791eb2ca4b27fa3bbb062ccf362ecaaa51679a07ed"},
+    {file = "immutables-0.16-cp39-cp39-win_amd64.whl", hash = "sha256:2505d93395d3f8ae4223e21465994c3bc6952015a38dc4f03cb3e07a2b8d8325"},
+    {file = "immutables-0.16.tar.gz", hash = "sha256:d67e86859598eed0d926562da33325dac7767b7b1eff84e232c22abea19f4360"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.3-py3-none-any.whl", hash = "sha256:51c6635429c77cf1ae634c997ff9e53ca3438b495f10a55ba28594dd69764a8b"},
-    {file = "importlib_metadata-4.6.3.tar.gz", hash = "sha256:0645585859e9a6689c523927a5032f2ba5919f1f7d0e84bd4533312320de1ff9"},
+    {file = "importlib_metadata-4.6.4-py3-none-any.whl", hash = "sha256:ed5157fef23a4bc4594615a0dd8eba94b2bb36bf2a343fa3d8bb2fa0a62a99d5"},
+    {file = "importlib_metadata-4.6.4.tar.gz", hash = "sha256:7b30a78db2922d78a6f47fb30683156a14f3c6aa5cc23f77cc8967e9ab2d002f"},
 ]
 isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
@@ -1885,63 +2028,52 @@ jmespath = [
     {file = "jmespath-0.9.2-py2.py3-none-any.whl", hash = "sha256:3f03b90ac8e0f3ba472e8ebff083e460c89501d8d41979771535efe9a343177e"},
     {file = "jmespath-0.9.2.tar.gz", hash = "sha256:54c441e2e08b23f12d7fa7d8e6761768c47c969e6aed10eead57505ba760aee9"},
 ]
+jsondiff = [
+    {file = "jsondiff-1.1.1.tar.gz", hash = "sha256:2d0437782de9418efa34e694aa59f43d7adb1899bd9a793f063867ddba8f7893"},
+]
+jsonpickle = [
+    {file = "jsonpickle-2.0.0-py2.py3-none-any.whl", hash = "sha256:c1010994c1fbda87a48f8a56698605b598cb0fc6bb7e7927559fc1100e69aeac"},
+    {file = "jsonpickle-2.0.0.tar.gz", hash = "sha256:0be49cba80ea6f87a168aa8168d717d00c6ca07ba83df3cec32d3b30bfe6fb9a"},
+]
 markdown = [
     {file = "Markdown-3.3.4-py3-none-any.whl", hash = "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"},
     {file = "Markdown-3.3.4.tar.gz", hash = "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
-    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
-    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
-    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
-    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 mock = [
     {file = "mock-2.0.0-py2.py3-none-any.whl", hash = "sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1"},
@@ -1952,8 +2084,8 @@ more-itertools = [
     {file = "more_itertools-8.8.0-py3-none-any.whl", hash = "sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d"},
 ]
 moto = [
-    {file = "moto-1.3.15-py2.py3-none-any.whl", hash = "sha256:3be7e1f406ef7e9c222dbcbfd8cefa2cb1062200e26deae49b5df446e17be3df"},
-    {file = "moto-1.3.15.tar.gz", hash = "sha256:fd98f7b219084ba8aadad263849c4dbe8be73979e035d8dc5c86e11a86f11b7f"},
+    {file = "moto-1.3.7-py2.py3-none-any.whl", hash = "sha256:4df37936ff8d6a4b8229aab347a7b412cd2ca4823ff47bd1362ddfbc6c5e4ecf"},
+    {file = "moto-1.3.7.tar.gz", hash = "sha256:129de2e04cb250d9f8b2c722ec152ed1b5426ef179b4ebb03e9ec36e6eb3fcc5"},
 ]
 msrest = [
     {file = "msrest-0.6.21-py2.py3-none-any.whl", hash = "sha256:c840511c845330e96886011a236440fafc2c9aff7b2df9c0a92041ee2dee3782"},
@@ -1963,8 +2095,8 @@ oauth2client = [
     {file = "oauth2client-3.0.0.tar.gz", hash = "sha256:5b5b056ec6f2304e7920b632885bd157fa71d1a7f3ddd00a43b1541a8d1a2460"},
 ]
 oauthlib = [
-    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
-    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
+    {file = "oauthlib-3.1.1-py2.py3-none-any.whl", hash = "sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc"},
+    {file = "oauthlib-3.1.1.tar.gz", hash = "sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3"},
 ]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
@@ -2032,6 +2164,10 @@ psycopg2 = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyaml = [
+    {file = "pyaml-21.8.3-py2.py3-none-any.whl", hash = "sha256:aa61d6ebef7cd8ec691620616258d904bfbc152e9cf44557202b8bacc9ce5cce"},
+    {file = "pyaml-21.8.3.tar.gz", hash = "sha256:a1636d63c476328a07213d0b7111bb63570f1ab8a3eddf60522630250c23d975"},
 ]
 pyasn1 = [
     {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
@@ -2151,6 +2287,20 @@ pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
+pywin32 = [
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
+    {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
+    {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
+    {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -2192,8 +2342,8 @@ requests-oauthlib = [
     {file = "requests_oauthlib-1.3.0-py3.7.egg", hash = "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"},
 ]
 responses = [
-    {file = "responses-0.13.3-py2.py3-none-any.whl", hash = "sha256:b54067596f331786f5ed094ff21e8d79e6a1c68ef625180a7d34808d6f36c11b"},
-    {file = "responses-0.13.3.tar.gz", hash = "sha256:18a5b88eb24143adbf2b4100f328a2f5bfa72fbdacf12d97d41f07c26c45553d"},
+    {file = "responses-0.13.4-py2.py3-none-any.whl", hash = "sha256:d8d0f655710c46fd3513b9202a7f0dcedd02ca0f8cf4976f27fa8ab5b81e656d"},
+    {file = "responses-0.13.4.tar.gz", hash = "sha256:9476775d856d3c24ae660bbebe29fb6d789d4ad16acd723efbfb6ee20990b899"},
 ]
 retry = [
     {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},
@@ -2272,9 +2422,20 @@ urllib3 = [
 userdatamodel = [
     {file = "userdatamodel-2.3.3.tar.gz", hash = "sha256:b846b7efd2d002a653474fa3bd7bf2a2c964277ff5f8d9bde8e9d975aca8d130"},
 ]
+websocket-client = [
+    {file = "websocket-client-1.2.1.tar.gz", hash = "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"},
+    {file = "websocket_client-1.2.1-py2.py3-none-any.whl", hash = "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec"},
+]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},
     {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
+]
+wtforms = [
+    {file = "WTForms-2.3.3-py2.py3-none-any.whl", hash = "sha256:7b504fc724d0d1d4d5d5c114e778ec88c37ea53144683e084215eed5155ada4c"},
+    {file = "WTForms-2.3.3.tar.gz", hash = "sha256:81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c"},
 ]
 xmltodict = [
     {file = "xmltodict-0.12.0-py2.py3-none-any.whl", hash = "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ userdatamodel = "^2.3.3"
 werkzeug = "^1.0.0"
 cachelib = "^0.2.0"
 azure-storage-blob = "^12.6.0"
+Flask-WTF = "^0.14.3"
 
 [tool.poetry.dev-dependencies]
 addict = "^2.2.1"


### PR DESCRIPTION
Jira Ticket: [PXP-7565](https://ctds-planx.atlassian.net/browse/PXP-7565)

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

Two pieces to this PR: (1) Add user registration endpoints, and (2) update CSRF handling.

Registration means that a user provides their name, organization, and email, in order to gain some predefined permissions (i.e. to be automatically added to a preconfigured Arborist group). For more information see the docstrings in the diff. This PR adds the registration form itself along with an admin endpoint to list registered users and their information.

The registration form presents some difficulties with existing CSRF protection, so this PR also includes CSRF changes alongside a sister cloud-automation PR https://github.com/uc-cdis/cloud-automation/pull/1580. More info below.

---

**Instructions for testing/using:**
- Set up a useryaml that has a GROUP with a policy (for example: "registered_users" with "data_upload" policy)
- Your test user should not be in this group
- Set up and run your Arborist
- Run usersync
- Put the name of the group in fence config's REGISTERED_USERS_GROUP; also set fence REGISTER_USERS_ON to true.
- Look in the Fence db and confirm that your test user is not registered (he has no registration_info block in his additional_info column)
- Look in Arborist db and confirm that your test user is not part of the group and does not have the group's policies
- Set up and run your Fence, which is talking to your Arborist
- Log in. You should be redirected to the registration form!
- Register.
- Check Arborist db and confirm that now your test user IS part of the group and DOES have the group's policies.
- Check Fence db and confirm that the registration info you entered is now in the additional_info column.
- Log out. Log in again. There should be no redirect to the registration form.
- You can hit /user/register-user directly to re-register.
- Now log in with a user that is an admin. Hit the /user/register-user/list endpoint. You should see your first test user's registration info.

**NOT implemented in this PR:**
- Nicer UI feedback upon successful registration!
- On login and redirect to registration form, if user declines to register, don't ask again on next login. (Do we want this?) Could set flag in additional_info or could do it cookie-based.


**Background on CSRF:**

Prior to this PR, CSRF protection was being implemented at two levels--once in Fence, and the other in the revproxy. Both Fence and the revproxy used the cookie-to-header method for CSRF prevention. There were multiple problems with this.

First problem: HTML forms. The new registration form, like other HTML forms, is not compatible with the cookie-to-header method. (The usual way to implement CSRF protection with HTML forms is using a hidden form field.) Fence's other, existing HTML form, the OAuth consent form, up until recently [was using AJAX](https://github.com/uc-cdis/fence/blob/61be960499434b39db8793f9cde37741f0709b26/fence/templates/oauthorize.html#L170-L219) instead of a plain form submit to get around this. This additionally necessitated some [interesting](https://github.com/uc-cdis/fence/blob/61be960499434b39db8793f9cde37741f0709b26/fence/templates/oauthorize.html#L188-L190) [gymnastics](https://github.com/uc-cdis/fence/blob/61be960499434b39db8793f9cde37741f0709b26/fence/blueprints/oauth2.py#L129-L133) for redirects to work. Then, recently, Fence began to [only issue HttpOnly cookies](https://github.com/uc-cdis/fence/commit/537c9370f92e4c7cfcb4fb946650b683d61c2391) in response to pen testing, and so the AJAX method technically broke--except that the revproxy was rewriting the csrf cookies anyway, see below, and so things happened to keep working.

Second problem: Fence cookie was being overwritten. Fence [has been operating](https://github.com/uc-cdis/fence/blob/61be960499434b39db8793f9cde37741f0709b26/fence/__init__.py#L398-L427) under the assumption that it manages its own CSRF token. But actually the revproxy [rewrites the token](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/nginx.conf#L260-L264) and [performs its own CSRF checking](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/nginx.conf#L331-L345). Apart from being confusing (see above), this also meant that Fence effectively couldn't implement its own CSRF protection (for example, requests with the correct token in a form field would still fail the revproxy CSRF check), while at the same time the revproxy CSRF fails to accommodate verification via HTML hidden form fields. 

A full reconsideration of CSRF protection in Gen3 (involving revproxy, Fence, and all the other services) was outside the scope of this ticket. The present solution makes partial improvements while maintaining [existing behavior](https://github.com/uc-cdis/fence/blob/6055e4bab45c16623ba9f9a7b778b34b23838cbf/fence/__init__.py#L400-L405) around CSRF checks. (NB: This existing behavior is also the reason why this PR does not fully discard all the current CSRF code in favor of built-in WTForms protection. Further work in that direction might want to start [here](https://flask-wtf.readthedocs.io/en/stable/csrf.html#exclude-views-from-protection).) The changes consist of the following:

1. Remove the Fence code that sets the CSRF cookie
2. In Fence, use [Flask-WTF](https://flask-wtf.readthedocs.io/en/stable/index.html), which wraps [WTForms](https://wtforms.readthedocs.io/en/2.3.x/), to generate a CSRF token that is stored in the session
3. Extend the Fence-specific CSRF check to allow verification against this token either via a header or via a hidden form field
4. Exclude the registration endpoints from the revproxy CSRF check.

See https://github.com/uc-cdis/cloud-automation/pull/1580 for the required revproxy change.



### New Features
Add registration endpoints (registration form endpoint and admin-only list endpoint)

### Breaking Changes


### Bug Fixes


### Improvements
Improvements around CSRF handling

### Dependency updates
New dependency Flask-WTF

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
Requires these cloud-automation updates to revproxy: https://github.com/uc-cdis/cloud-automation/pull/1580 