### PR TITLE
fix(ci-token): use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/wool.yml
+++ b/.github/workflows/wool.yml
@@ -14,4 +14,4 @@ jobs:
 
     - uses: uc-cdis/wool@master
       env:
-        GITHUB_TOKEN: ${{ secrets.PLANXCYBORG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Improvements

* Use GITHUB_TOKEN for wool in CI