### PR TITLE
(PXP-8159): feat(google): new endpoint & tests for non-lazy creation of primary S…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-05-19T16:49:29Z",
+  "generated_at": "2021-05-19T20:49:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1151,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1148,
+        "line_number": 1174,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-04-12T21:59:04Z",
+  "generated_at": "2021-05-19T16:49:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1123,
+        "line_number": 1125,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1146,
+        "line_number": 1148,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/fence/blueprints/google.py
+++ b/fence/blueprints/google.py
@@ -607,7 +607,7 @@ class GoogleCredentialsPrimarySA(Resource):
     """
 
     @require_auth_header({"google_credentials"})
-    def post():
+    def post(self):
         """
         Force the creation of the User's Primary Google Service Account instead of
         relying on lazy creation at first time of Google Data Access.

--- a/fence/blueprints/google.py
+++ b/fence/blueprints/google.py
@@ -607,7 +607,7 @@ class GoogleCredentialsPrimarySA(Resource):
     """
 
     @require_auth_header({"google_credentials"})
-    def post(self):
+    def post():
         """
         Force the creation of the User's Primary Google Service Account instead of
         relying on lazy creation at first time of Google Data Access.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1086,6 +1086,8 @@ def primary_google_service_account(app, db_session, user_client, google_proxy_gr
     mock.return_value = service_account
     patcher = patch("fence.resources.google.utils.get_or_create_service_account", mock)
     patcher.start()
+    patcher = patch("fence.blueprints.google.get_or_create_service_account", mock)
+    patcher.start()
 
     yield Dict(
         id=service_account_id, email=email, get_or_create_service_account_mock=mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1086,6 +1086,32 @@ def primary_google_service_account(app, db_session, user_client, google_proxy_gr
     mock.return_value = service_account
     patcher = patch("fence.resources.google.utils.get_or_create_service_account", mock)
     patcher.start()
+
+    yield Dict(
+        id=service_account_id, email=email, get_or_create_service_account_mock=mock
+    )
+
+    patcher.stop()
+
+
+@pytest.fixture(scope="function")
+def primary_google_service_account_google(
+    app, db_session, user_client, google_proxy_group
+):
+    service_account_id = "test-service-account-0"
+    email = fence.utils.random_str(40) + "@test.com"
+    service_account = models.GoogleServiceAccount(
+        google_unique_id=service_account_id,
+        email=email,
+        user_id=user_client.user_id,
+        client_id=None,
+        google_project_id="projectId-0",
+    )
+    db_session.add(service_account)
+    db_session.commit()
+
+    mock = MagicMock()
+    mock.return_value = service_account
     patcher = patch("fence.blueprints.google.get_or_create_service_account", mock)
     patcher.start()
 

--- a/tests/google/conftest.py
+++ b/tests/google/conftest.py
@@ -65,6 +65,36 @@ def encoded_jwt_service_accounts_access(
 
 
 @pytest.fixture(scope="function")
+def encoded_jwt_google_data_access(kid, rsa_private_key, user_client, oauth_client):
+    """
+    Return a JWT and user_id for a new user containing the claims and
+    encoded with the private key.
+
+    Args:
+        claims (dict): fixture
+        rsa_private_key (str): fixture
+
+    Return:
+        str: JWT containing claims encoded with private key
+    """
+    headers = {"kid": kid}
+    return Dict(
+        jwt=jwt.encode(
+            utils.authorized_download_credentials_context_claims(
+                user_client["username"],
+                user_client["user_id"],
+                oauth_client["client_id"],
+            ),
+            key=rsa_private_key,
+            headers=headers,
+            algorithm="RS256",
+        ).decode("utf-8"),
+        user_id=user_client["user_id"],
+        client_id=oauth_client["client_id"],
+    )
+
+
+@pytest.fixture(scope="function")
 def valid_service_account_patcher():
     patches = []
 

--- a/tests/google/conftest.py
+++ b/tests/google/conftest.py
@@ -71,11 +71,14 @@ def encoded_jwt_google_data_access(kid, rsa_private_key, user_client, oauth_clie
     encoded with the private key.
 
     Args:
-        claims (dict): fixture
-        rsa_private_key (str): fixture
+        kid (str): fixture for key id
+        rsa_private_key (str): fixture for getting private key
+        user_client: fixture that has dict containing test user info
+        oauth_client: fixture with dict containing test client info
 
     Return:
-        str: JWT containing claims encoded with private key
+        Dict[str]: dict with JWT containing claims encoded with private key, userid,
+                   and clientid
     """
     headers = {"kid": kid}
     return Dict(

--- a/tests/google/test_primary_google_service_account.py
+++ b/tests/google/test_primary_google_service_account.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+def test_primary_google_service_account_valid(
+    client,
+    app,
+    db_session,
+    encoded_jwt_google_data_access,
+    primary_google_service_account,
+):
+    """
+    Test that given valid credentials, the endpoint responds with the user's primary
+    google SA in the response and it matches the mocked value setup in the fixture
+    """
+    encoded_creds_jwt = encoded_jwt_google_data_access["jwt"]
+    mock = primary_google_service_account["get_or_create_service_account_mock"]
+    email = primary_google_service_account["email"]
+
+    response = client.post(
+        "/google/primary_google_service_account",
+        headers={"Authorization": "Bearer " + encoded_creds_jwt},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.json.get("primary_google_service_account") == email
+
+
+def test_primary_google_service_account_invalid(
+    client,
+    app,
+    db_session,
+    encoded_jwt_service_accounts_access,
+    primary_google_service_account,
+):
+    """
+    Test that given invalid credentials (e.g. doesn't have the right scope),
+    this endpoint responds with an HTTP error code and no data
+
+    NOTE: encoded_jwt_service_accounts_access does not have the expected claim in the
+          mocked token.
+    """
+    encoded_creds_jwt = encoded_jwt_service_accounts_access["jwt"]
+    mock = primary_google_service_account["get_or_create_service_account_mock"]
+    email = primary_google_service_account["email"]
+
+    response = client.post(
+        "/google/primary_google_service_account",
+        headers={"Authorization": "Bearer " + encoded_creds_jwt},
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+    assert not (response.json or {}).get("primary_google_service_account")
+
+
+def test_primary_google_service_account_no_creds(
+    client,
+    app,
+    db_session,
+    primary_google_service_account,
+):
+    """
+    Test that given no creds, this endpoint responds with an HTTP error code and no data
+    """
+    mock = primary_google_service_account["get_or_create_service_account_mock"]
+    email = primary_google_service_account["email"]
+
+    response = client.post(
+        "/google/primary_google_service_account",
+        content_type="application/json",
+    )
+    assert response.status_code == 401
+    assert not (response.json or {}).get("primary_google_service_account")

--- a/tests/google/test_primary_google_service_account.py
+++ b/tests/google/test_primary_google_service_account.py
@@ -16,15 +16,15 @@ def test_primary_google_service_account_valid(
     app,
     db_session,
     encoded_jwt_google_data_access,
-    primary_google_service_account,
+    primary_google_service_account_google,
 ):
     """
     Test that given valid credentials, the endpoint responds with the user's primary
     google SA in the response and it matches the mocked value setup in the fixture
     """
     encoded_creds_jwt = encoded_jwt_google_data_access["jwt"]
-    mock = primary_google_service_account["get_or_create_service_account_mock"]
-    email = primary_google_service_account["email"]
+    mock = primary_google_service_account_google["get_or_create_service_account_mock"]
+    email = primary_google_service_account_google["email"]
 
     response = client.post(
         "/google/primary_google_service_account",
@@ -40,7 +40,7 @@ def test_primary_google_service_account_invalid(
     app,
     db_session,
     encoded_jwt_service_accounts_access,
-    primary_google_service_account,
+    primary_google_service_account_google,
 ):
     """
     Test that given invalid credentials (e.g. doesn't have the right scope),
@@ -50,8 +50,8 @@ def test_primary_google_service_account_invalid(
           mocked token.
     """
     encoded_creds_jwt = encoded_jwt_service_accounts_access["jwt"]
-    mock = primary_google_service_account["get_or_create_service_account_mock"]
-    email = primary_google_service_account["email"]
+    mock = primary_google_service_account_google["get_or_create_service_account_mock"]
+    email = primary_google_service_account_google["email"]
 
     response = client.post(
         "/google/primary_google_service_account",
@@ -66,13 +66,13 @@ def test_primary_google_service_account_no_creds(
     client,
     app,
     db_session,
-    primary_google_service_account,
+    primary_google_service_account_google,
 ):
     """
     Test that given no creds, this endpoint responds with an HTTP error code and no data
     """
-    mock = primary_google_service_account["get_or_create_service_account_mock"]
-    email = primary_google_service_account["email"]
+    mock = primary_google_service_account_google["get_or_create_service_account_mock"]
+    email = primary_google_service_account_google["email"]
 
     response = client.post(
         "/google/primary_google_service_account",


### PR DESCRIPTION
…A for a user

Jira Ticket: [PXP-8159](https://ctds-planx.atlassian.net/browse/PXP-8159)

This effectively allows a client to choose whether or not they want "lazy creation" of a user's Primary Google Service Account. Current state is that we don't create this Google resource for a user until their first data access attempt or creds generation attempt (e.g. lazy creation). There are use cases that clients have where they want to prepopulate/configure IAM privileges (specifically for requester pays) where knowing the service account before the first data access would improve user UX / speed. For those clients/use cases we are adding this endpoint to simply force the creation of this Google resource for a given user.

### New Features
- new `/google/primary_google_service_account` endpoint which will get_or_create a user's Primary Google Service Account and return the SA email (only available to authed users/clients with authority to generate  google creds)

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
