### PR TITLE
chore(reliability): Introduce OVERRIDE_NGINX_RATE_LIMIT fence configuration (2nd PR)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-05-19T20:49:29Z",
+  "generated_at": "2021-05-24T23:54:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -84,7 +84,7 @@
       {
         "hashed_secret": "5d07e1b80e448a213b392049888111e1779a52db",
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 554,
         "type": "Secret Keyword"
       }
     ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run --rm -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
 # To check running container: docker exec -it fence /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.5.0
+FROM quay.io/cdis/python-nginx:pybase3-1.5.1
 
 ENV appname=fence
 

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -426,6 +426,15 @@ RENEW_ACCESS_TOKEN_BEFORE_EXPIRATION: false
 PRIVACY_POLICY_URL: null
 
 # //////////////////////////////////////////////////////////////////////////////////////
+# RELIABILITY OPTS
+# //////////////////////////////////////////////////////////////////////////////////////
+# Configurations related to resiliency, fault-tolerance and availability
+# This is the number of requests per second that the Nginx proxy will accept before reaching fence
+# The value defined in fence-config-public.yaml takes precedence over this one
+# In the absence of any OVERRIDE_ prefixed config, the legacy NGINX_RATE_LIMIT from the k8s deployment yaml is applied
+OVERRIDE_NGINX_RATE_LIMIT: 18
+
+# //////////////////////////////////////////////////////////////////////////////////////
 # SUPPORT INFO
 # //////////////////////////////////////////////////////////////////////////////////////
 # If you want an email address to show up when an unhandled error occurs, provide one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "4.29.0"
+version = "4.29.1"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
To avoid relying on the current NGINX_RATE_LIMIT set in cloud-automation (https://github.com/uc-cdis/cloud-automation/blob/master/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml#L102)
```
        env:
        - name: NGINX_RATE_LIMIT
           value: "6"
```

This code introduces a way to override the original RATE LIMIT config for NGINX for any subsequent performance improvements that allow us to increase the RPS throughput and still provide backwards compatibility for old Fence images.

### Improvements
- Replace NGINX_RATE_LIMIT if an override value if found in fence-config.