### PR TITLE
fix(google_sa): new endpoint should replicate exactly what SA signed …

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-05-25T15:36:55Z",
+  "generated_at": "2021-05-25T21:22:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -154,13 +154,13 @@
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1151,
+        "line_number": 1177,
         "type": "Private Key"
       },
       {
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1174,
+        "line_number": 1200,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/fence/blueprints/google.py
+++ b/fence/blueprints/google.py
@@ -620,10 +620,10 @@ class GoogleCredentialsPrimarySA(Resource):
 
         # do the same thing signed URL creation is doing, but don't use the resulting
         # key, just extract the service account email
-        _, key_db_entry = get_or_create_primary_service_account_key(
+        sa_private_key, _ = get_or_create_primary_service_account_key(
             user_id=user_id, username=username, proxy_group_id=proxy_group_id
         )
-        service_account_email = key_db_entry.google_service_account.email
+        service_account_email = sa_private_key.get("client_email")
 
         # NOTE: service_account_from_db.email is what gets populated in the UserInfo endpoint's
         #       "primary_google_service_account" as well, so this remains consistent

--- a/fence/blueprints/google.py
+++ b/fence/blueprints/google.py
@@ -32,7 +32,6 @@ from fence.resources.google.access_utils import (
 )
 from fence.resources.google.utils import (
     get_or_create_proxy_group_id,
-    get_or_create_service_account,
     get_monitoring_service_account_email,
     get_registered_service_accounts,
     get_project_access_from_service_accounts,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1112,7 +1112,7 @@ def primary_google_service_account_google(
     db_session.commit()
 
     service_account_key_db_entry = models.GoogleServiceAccountKey(
-        key_id=1, service_account_id=service_account.id, expires=int(time.time()) - 3600
+        key_id=1, service_account_id=service_account.id, expires=int(time.time()) + 3600
     )
 
     db_session.add(service_account_key_db_entry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1122,7 +1122,7 @@ def primary_google_service_account_google(
         "type": "service_account",
         "project_id": "project-id",
         "private_key_id": "some_number",
-        "client_email": "<api-name>api@project-id.iam.gserviceaccount.com",
+        "client_email": email,
         "client_id": "...",
         "auth_uri": "https://accounts.google.com/o/oauth2/auth",
         "token_uri": "https://accounts.google.com/o/oauth2/token",


### PR DESCRIPTION
…URLs are using, correct


### New Features


### Breaking Changes


### Bug Fixes
- /google/primary_google_service_account was returning the client/user SA, which is NOT what is used for signed urls. this PR corrects the behavior to create and return the user's single primary service account

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
