### PR TITLE
fix: "key_ops" is an array, per RFC 7517 #4.3

### DIFF
--- a/fence/jwt/keys.py
+++ b/fence/jwt/keys.py
@@ -188,7 +188,7 @@ class Keypair(object):
             except AttributeError:
                 # there is no need to decode values that are already strings
                 pass
-        jwk_dict.update({"use": "sig", "key_ops": "verify", "kid": self.kid})
+        jwk_dict.update({"use": "sig", "key_ops": ["verify"], "kid": self.kid})
         return jwk_dict
 
 

--- a/tests/rfc7517/test_jwks.py
+++ b/tests/rfc7517/test_jwks.py
@@ -41,7 +41,7 @@ def test_response_values(app, client):
         assert key["alg"] == "RS256"
         assert key["kty"] == "RSA"
         assert key["use"] == "sig"
-        assert key["key_ops"] == "verify"
+        assert key["key_ops"] == ["verify"]
         assert key["kid"] in app_kids
         # Attempt to reproduce the public key from the JWK response.
         key_pem = jwk.construct(key).to_pem().decode("utf-8")


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* Fixes the type of `key_ops` in JWK, it should be an array per [RFC 7517, #4.3](https://datatracker.ietf.org/doc/html/rfc7517#section-4.3):
>Its value is an array of key operation values.  Values defined by this specification are:


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
