### PR TITLE
Jira Ticket: [PXP-8121] (https://ctds-planx.atlassian.net/browse/PXP-8121)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,20 +3,17 @@
     "files": "poetry.lock",
     "lines": null
   },
-  "generated_at": "2021-05-25T21:22:19Z",
+  "generated_at": "2021-06-03T19:27:58Z",
   "plugins_used": [
-    {
-      "name": "ArtifactoryDetector"
-    },
     {
       "name": "AWSKeyDetector"
     },
     {
-      "name": "AzureStorageKeyDetector"
+      "name": "ArtifactoryDetector"
     },
     {
-      "name": "Base64HighEntropyString",
-      "limit": 4.5
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
     },
     {
       "name": "BasicAuthDetector"
@@ -25,8 +22,8 @@
       "name": "CloudantDetector"
     },
     {
-      "name": "HexHighEntropyString",
-      "limit": 3.0
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,14 +35,11 @@
       "name": "JwtTokenDetector"
     },
     {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
     },
     {
       "name": "MailchimpDetector"
-    },
-    {
-      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -57,262 +51,163 @@
       "name": "SoftlayerDetector"
     },
     {
-      "name": "SquareOAuthDetector"
-    },
-    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    }
-  ],
   "results": {
     "fence/blueprints/storage_creds/google.py": [
       {
-        "type": "Private Key",
-        "filename": "fence/blueprints/storage_creds/google.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 139,
+        "type": "Private Key"
       }
     ],
     "fence/blueprints/storage_creds/other.py": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "fence/blueprints/storage_creds/other.py",
         "hashed_secret": "98c144f5ecbb4dbe575147a39698b6be1a5649dd",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 66,
+        "type": "Base64 High Entropy String"
       }
     ],
     "fence/config-default.yaml": [
       {
-        "type": "Basic Auth Credentials",
-        "filename": "fence/config-default.yaml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 31,
+        "type": "Basic Auth Credentials"
       },
       {
-        "type": "Secret Keyword",
-        "filename": "fence/config-default.yaml",
-        "hashed_secret": "dd29ecf524b030a65261e3059c48ab9e1ecb2585",
+        "hashed_secret": "5d07e1b80e448a213b392049888111e1779a52db",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 554,
+        "type": "Secret Keyword"
       }
     ],
     "fence/local_settings.example.py": [
       {
-        "type": "Basic Auth Credentials",
-        "filename": "fence/local_settings.example.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Basic Auth Credentials"
       },
       {
-        "type": "Secret Keyword",
-        "filename": "fence/local_settings.example.py",
         "hashed_secret": "5d07e1b80e448a213b392049888111e1779a52db",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 63,
+        "type": "Secret Keyword"
       }
     ],
     "fence/resources/google/utils.py": [
       {
-        "type": "Private Key",
-        "filename": "fence/resources/google/utils.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 277,
+        "type": "Private Key"
       }
     ],
     "fence/utils.py": [
       {
-        "type": "Secret Keyword",
-        "filename": "fence/utils.py",
         "hashed_secret": "8318df9ecda039deac9868adf1944a29a95c7114",
         "is_verified": false,
-        "line_number": 104
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "fence/utils.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 248
+        "line_number": 104,
+        "type": "Secret Keyword"
       }
     ],
     "openapis/swagger.yaml": [
       {
-        "type": "Private Key",
-        "filename": "openapis/swagger.yaml",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1927
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "openapis/swagger.yaml",
-        "hashed_secret": "8cb81a55dff48721f04fe341f33ee5b623dd9144",
-        "is_verified": false,
-        "line_number": 1927
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "openapis/swagger.yaml",
-        "hashed_secret": "41c39979fd01095376b3e9456f1058c33483dbbe",
-        "is_verified": false,
-        "line_number": 1994
-      },
-      {
-        "type": "JSON Web Token",
-        "filename": "openapis/swagger.yaml",
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false,
-        "line_number": 1994
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "openapis/swagger.yaml",
-        "hashed_secret": "98c144f5ecbb4dbe575147a39698b6be1a5649dd",
-        "is_verified": false,
-        "line_number": 2041
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "openapis/swagger.yaml",
-        "hashed_secret": "2f58edc671a89190115ecebddf4c70bdd87e3267",
-        "is_verified": false,
-        "line_number": 2084
-      }
-    ],
-    "poetry.lock": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "poetry.lock",
-        "hashed_secret": "640e60795f08744221f6816fe9dc949c58465256",
-        "is_verified": false,
-        "line_number": 1177,
+        "line_number": 1927,
         "type": "Private Key"
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "poetry.lock",
-        "hashed_secret": "6642e431aaa417100a91214385af6657acb3fab7",
+        "hashed_secret": "bb8e48bd1e73662027a0f0b876b695d4c18f5ed4",
         "is_verified": false,
-        "line_number": 1368
+        "line_number": 1927,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "poetry.lock",
-        "hashed_secret": "205b95ce89ff252c6045d78ca9d007e73b45dc00",
+        "hashed_secret": "7861ab65194de92776ab9cd06d4d7e7e1ec2c36d",
         "is_verified": false,
-        "line_number": 1200,
+        "line_number": 2007,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_verified": false,
+        "line_number": 2029,
+        "type": "JSON Web Token"
+      },
+      {
+        "hashed_secret": "98c144f5ecbb4dbe575147a39698b6be1a5649dd",
+        "is_verified": false,
+        "line_number": 2041,
         "type": "Base64 High Entropy String"
       }
     ],
     "tests/conftest.py": [
       {
-        "type": "Private Key",
-        "filename": "tests/conftest.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1151
+        "line_number": 1161,
+        "type": "Private Key"
       },
       {
-        "type": "Base64 High Entropy String",
-        "filename": "tests/conftest.py",
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1174
+        "line_number": 1184,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "tests/credentials/google/test_credentials.py": [
+      {
+        "hashed_secret": "22afbfecd4124e2eb0e2a79fafdf62b207a8f8c7",
+        "is_verified": false,
+        "line_number": 579,
+        "type": "Secret Keyword"
       }
     ],
     "tests/keys/2018-05-01T21:29:02Z/jwt_private_key.pem": [
       {
-        "type": "Private Key",
-        "filename": "tests/keys/2018-05-01T21:29:02Z/jwt_private_key.pem",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1
+        "line_number": 1,
+        "type": "Private Key"
       }
     ],
     "tests/login/test_fence_login.py": [
       {
-        "type": "Secret Keyword",
-        "filename": "tests/login/test_fence_login.py",
         "hashed_secret": "d300421e208bfd0d432294de15169fd9b8975def",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 41,
+        "type": "Secret Keyword"
       }
     ],
     "tests/ras/test_ras.py": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "tests/ras/test_ras.py",
         "hashed_secret": "d9db6fe5c14dc55edd34115cdf3958845ac30882",
         "is_verified": false,
-        "line_number": 90
-      }
-    ],
-    "tests/scripting/test_fence-create.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/scripting/test_fence-create.py",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 1117
+        "line_number": 327,
+        "type": "Hex High Entropy String"
       }
     ],
     "tests/test-fence-config.yaml": [
       {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/test-fence-config.yaml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 31
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-fence-config.yaml",
-        "hashed_secret": "dd29ecf524b030a65261e3059c48ab9e1ecb2585",
-        "is_verified": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-fence-config.yaml",
-        "hashed_secret": "1627df13b5cd8b3521d02bd8eb2ca31334b3aef2",
-        "is_verified": false,
-        "line_number": 472
+        "line_number": 31,
+        "type": "Basic Auth Credentials"
       }
     ]
   },
-  "generated_at": "2021-05-26T14:24:12Z"
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
 }

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -647,10 +647,8 @@ class S3IndexedFileLocation(IndexedFileLocation):
 
         # checking fence config if aws session can be longer than one hour
         role_cache_increase = 0
-        if flask.current_app.config["MAX_ROLE_SESSION_INCREASE"]:
-            role_cache_increase = int(
-                flask.current_app.config["ASSUME_ROLE_CACHE_SECONDS"]
-            )
+        if config["MAX_ROLE_SESSION_INCREASE"]:
+            role_cache_increase = int(config["ASSUME_ROLE_CACHE_SECONDS"])
 
         assumed_role = boto.assume_role(
             role_arn,

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -821,7 +821,7 @@ SYNAPSE_AUTHZ_TTL: 86400
 # then we can increase the amount of time that a session is valid for
 MAX_ROLE_SESSION_INCREASE: false
 ASSUME_ROLE_CACHE_SECONDS: 1800
-
+AWS_ASSUME_ROLE_MIN_LIMIT: 900
 # RAS refresh_tokens expire in 15 days
 RAS_REFRESH_EXPIRATION: 1296000
 # Number of projects that can be registered to a Google Service Accont

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -66,6 +66,9 @@ class BotoManager(object):
             if config and "aws_access_key_id" in config:
                 self.sts_client = client("sts", **config)
             session_name_postfix = uuid.uuid4()
+            duration_seconds = max(
+                900, duration_seconds
+            )  # Since minimum time for aws assume role is 900 seconds as per boto docs
             return self.sts_client.assume_role(
                 RoleArn=role_arn,
                 DurationSeconds=duration_seconds,

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -13,6 +13,7 @@ class BotoManager(object):
 
     URL_EXPIRATION_DEFAULT = 1800  # 30 minutes
     URL_EXPIRATION_MAX = 86400  # 1 day
+    AWS_ASSUME_ROLE_MIN_LIMIT = 900  # 15 minutes
 
     def __init__(self, config, logger):
         self.sts_client = client("sts", **config)
@@ -67,7 +68,7 @@ class BotoManager(object):
                 self.sts_client = client("sts", **config)
             session_name_postfix = uuid.uuid4()
             duration_seconds = max(
-                900, duration_seconds
+                self.AWS_ASSUME_ROLE_MIN_LIMIT, duration_seconds
             )  # Since minimum time for aws assume role is 900 seconds as per boto docs
             return self.sts_client.assume_role(
                 RoleArn=role_arn,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,17 +59,6 @@ def mock_get_bucket_location(self, bucket, config):
     return "us-east-1"
 
 
-@mock_sts
-def mock_assume_role(self, role_arn, duration_seconds, config=None):
-    sts_client = client("sts", **config)
-    session_name_postfix = uuid.uuid4()
-    return sts_client.assume_role(
-        RoleArn=role_arn,
-        DurationSeconds=duration_seconds,
-        RoleSessionName="{}-{}".format("gen3", session_name_postfix),
-    )
-
-
 @pytest.fixture(scope="session")
 def claims_refresh():
     new_claims = tests.utils.default_claims()
@@ -141,20 +130,15 @@ class Mocker(object):
             "fence.resources.aws.boto_manager.BotoManager.get_bucket_region",
             mock_get_bucket_location,
         )
-        self.assume_role_patcher = patch(
-            "fence.resources.aws.boto_manager.BotoManager.assume_role", mock_assume_role
-        )
         self.patcher.start()
         self.auth_patcher.start()
         self.boto_patcher.start()
-        self.assume_role_patcher.start()
         self.additional_patchers = []
 
     def unmock_functions(self):
         self.patcher.stop()
         self.auth_patcher.stop()
         self.boto_patcher.stop()
-        self.assume_role_patcher.stop()
         for patcher in self.additional_patchers:
             patcher.stop()
 

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -1074,6 +1074,108 @@ def test_indexd_download_with_uploader_authorized(
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize("test_max_role_session_increase", [True, False])
+@pytest.mark.parametrize("preset_expires_in", [100, 1000])
+def test_assume_role_time_limit(
+    client,
+    user_client,
+    kid,
+    rsa_private_key,
+    test_max_role_session_increase,
+    preset_expires_in,
+):
+    """
+    Test ``GET /data/download/1`` with authorized user (user is the uploader).
+    """
+
+    fence.S3IndexedFileLocation._assume_role_cache.clear()
+
+    current_max_role_session_increase = config["MAX_ROLE_SESSION_INCREASE"]
+    config.update(MAX_ROLE_SESSION_INCREASE=test_max_role_session_increase)
+
+    # Mocking STS client assume role
+    duration_in_function = 0
+    mocked_sts_client = MagicMock()
+
+    def mock_sts_client_assume_role(RoleArn, DurationSeconds, RoleSessionName=None):
+        nonlocal duration_in_function
+        duration_in_function = DurationSeconds
+        return {
+            "Credentials": {
+                "AccessKeyId": "",
+                "SecretAccessKey": "",
+                "SessionToken": "",
+                "Expiration": datetime.now() + timedelta(seconds=DurationSeconds),
+            },
+            "AssumedRoleUser": {"AssumedRoleId": "", "Arn": RoleArn},
+        }
+
+    mocked_sts_client.assume_role = mock_sts_client_assume_role
+    mocked_sts_client.return_value = mocked_sts_client
+    assume_role_patcher = patch(
+        "fence.resources.aws.boto_manager.client", mocked_sts_client
+    )
+    assume_role_patcher.start()
+    # Mocking indexd document
+    did = str(uuid.uuid4())
+    index_document = {
+        "did": did,
+        "baseid": "",
+        "uploader": user_client.username,
+        "rev": "",
+        "size": 10,
+        "file_name": "file1",
+        "urls": ["s3://bucket5/key-{}".format(did[:8])],
+        "acl": ["phs000178"],
+        "hashes": {},
+        "metadata": {},
+        "form": "",
+        "created_date": "",
+        "updated_date": "",
+    }
+    mock_index_document = mock.patch(
+        "fence.blueprints.data.indexd.IndexedFile.index_document", index_document
+    )
+    mock_index_document.start()
+
+    indexed_file_location = "s3"
+    path = "/data/download/1"
+    query_string = {"protocol": indexed_file_location, "expires_in": preset_expires_in}
+    headers = {
+        "Authorization": "Bearer "
+        + jwt.encode(
+            utils.authorized_download_context_claims(
+                user_client.username, user_client.user_id
+            ),
+            key=rsa_private_key,
+            headers={"kid": kid},
+            algorithm="RS256",
+        ).decode("utf-8")
+    }
+    response = client.get(path, headers=headers, query_string=query_string)
+
+    if config["MAX_ROLE_SESSION_INCREASE"]:
+        buffered_expires_in = preset_expires_in + int(
+            config["ASSUME_ROLE_CACHE_SECONDS"]
+        )
+    else:
+        buffered_expires_in = max(
+            preset_expires_in, int(config["AWS_ASSUME_ROLE_MIN_LIMIT"])
+        )
+
+    assert response.status_code == 200
+    assert duration_in_function == buffered_expires_in  # assume role duration
+    assert (
+        "X-Amz-Expires=" + str(preset_expires_in) + "&" in response.json["url"]
+    )  # Signed url duration
+
+    assume_role_patcher.stop()
+    mock_index_document.stop()
+    config.update(
+        MAX_ROLE_SESSION_INCREASE=current_max_role_session_increase
+    )  # Resetting the config value to original
+
+
 def test_assume_role_cache(
     client,
     oauth_client,

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -597,3 +597,4 @@ GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS:
 # then we can increase the amount of time that a session is valid for
 MAX_ROLE_SESSION_INCREASE: true
 ASSUME_ROLE_CACHE_SECONDS: 1800
+AWS_ASSUME_ROLE_MIN_LIMIT: 900


### PR DESCRIPTION
- When an Assume role is requested for a duration less than 900 seconds(AWS min assume role limit), this code automatically sets it to 900 seconds. 

### Bug Fixes
-- Added logic to update the DurationSeconds field right before the STS api call. 
-- Manually tested the issue after the fix
-- Added unit tests to verify the fix
-- Made sure no other unit tests are breaking. 


### Improvements
-- Replaced flask.current_app.config with the modern FenceConfig singleton in a couple of places

### Dependency updates
-- Also removed some dead code (mock_assume_role function which was patching the actual assume_role function in boto_manager.py) 

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
