### PR TITLE
feat(google): only update Google IAM for Billing when there's no cach…

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -1100,12 +1100,12 @@ class GoogleStorageIndexedFileLocation(IndexedFileLocation):
                         db_entry,
                     )
 
-        if config["ENABLE_AUTOMATIC_BILLING_PERMISSION_SIGNED_URLS"]:
-            give_service_account_billing_access_if_necessary(
-                private_key,
-                r_pays_project,
-                default_billing_project=config["BILLING_PROJECT_FOR_SIGNED_URLS"],
-            )
+            if config["ENABLE_AUTOMATIC_BILLING_PERMISSION_SIGNED_URLS"]:
+                give_service_account_billing_access_if_necessary(
+                    private_key,
+                    r_pays_project,
+                    default_billing_project=config["BILLING_PROJECT_FOR_SIGNED_URLS"],
+                )
 
         # use configured project if it exists and no user project was given
         if config["BILLING_PROJECT_FOR_SIGNED_URLS"] and not r_pays_project:


### PR DESCRIPTION
…e of the SA creds


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Only try to update Google IAM with billing permissions for an SA if the SA creds are NOT cached, e.g. only do it once per cache of the creds to reduce unnecessary network calls to Google

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
