### PR TITLE
fix(pkey-from-arg): Respect public_key arg

### DIFF
--- a/fence/jwt/validate.py
+++ b/fence/jwt/validate.py
@@ -105,7 +105,7 @@ def validate_jwt(
     except jwt.InvalidTokenError as e:
         raise JWTError(e)
     attempt_refresh = attempt_refresh and (token_iss != iss)
-    public_key = authutils.token.keys.get_public_key_for_token(
+    public_key = public_key or authutils.token.keys.get_public_key_for_token(
         encoded_token, attempt_refresh=attempt_refresh
     )
     try:


### PR DESCRIPTION
Jira Ticket: n/a

Here's a funny one :D It has been around for a minute! 

Uncovered when trying to run two Fences. The user_session code checks the incoming session token and calls the validation code with the app's own public key; this should _not_ use any other public key than the app's own. So the validate function needs to respect the arg. 

### Bug Fixes
Fix fence.jwt.validate so it uses the public_key argument


