### PR TITLE
chore(pybase3): Update pybase img de novo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # To run: docker run --rm -d -v /path/to/fence-config.yaml:/var/www/fence/fence-config.yaml --name=fence -p 80:80 fence
 # To check running container: docker exec -it fence /bin/bash
 
-FROM quay.io/cdis/python-nginx:pybase3-1.6.0
+FROM quay.io/cdis/python-nginx:pybase3-1.6.1
 
 ENV appname=fence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "5.2.0"
+version = "5.3.1"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Suppressing UWSGI & NGINX metrics in favour of DataDog’s telemetry / python APM / probing -- hoping we can achieve the same observability with it.

### Improvements
- Once we retire the k8s sidecar containers from fence's k8s YAML (here: https://github.com/uc-cdis/cloud-automation/pull/1643), old fence images will face a lot of log noise as the HTTP metrics endpoints will no longer exist.
