### PR TITLE
Fix backwards compatibility for old refresh tokens without scopes

### DIFF
--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -127,11 +127,10 @@ class RefreshTokenGrant(AuthlibRefreshTokenGrant):
         if not user:
             raise InvalidRequestError('There is no "user" for this token.')
 
+        client = self.request.client
         scope = self.request.scope
         if not scope:
-            scope = credential["scope"]
-
-        client = self.request.client
+            scope = credential.get("scope", ["openid", "user", client.client_id])
         expires_in = credential["exp"]
         token = self.generate_token(
             client, self.GRANT_TYPE, user=user, expires_in=expires_in, scope=scope

--- a/fence/oidc/grants/refresh_token_grant.py
+++ b/fence/oidc/grants/refresh_token_grant.py
@@ -130,7 +130,15 @@ class RefreshTokenGrant(AuthlibRefreshTokenGrant):
         client = self.request.client
         scope = self.request.scope
         if not scope:
+            # scope = credential["scope"]
+
+            ##### begin refresh token patch block #####
+            # TODO: In the next release, remove this if block
+            # Old refresh tokens are not compatible with new validation, so to smooth
+            # the transition, allow old style refresh tokens with this patch;
+            # remove patch in next tag. Refresh tokens have default TTL of 30 days.
             scope = credential.get("scope", ["openid", "user", client.client_id])
+            ##### end refresh token patch block #####
         expires_in = credential["exp"]
         token = self.generate_token(
             client, self.GRANT_TYPE, user=user, expires_in=expires_in, scope=scope


### PR DESCRIPTION
Jira Ticket: n/a

If the token request with refresh token grant does not contain a "scope" query arg, then this part of the code will throw a KeyError when dealing with an old token with no scope claim. 

### Bug Fixes
- Fix backwards compatibility for old refresh tokens without scopes. (Note: 5.0.0 claimed to be backwards compatible with old refresh tokens, but was missing this patch)


