### PR TITLE
fix(multifence-validation): allow old AND new style id tokens

### DIFF
--- a/fence/blueprints/login/fence_login.py
+++ b/fence/blueprints/login/fence_login.py
@@ -6,6 +6,7 @@ from fence.blueprints.login.base import DefaultOAuth2Login, DefaultOAuth2Callbac
 from fence.blueprints.login.redirect import validate_redirect
 from fence.config import config
 from fence.errors import Unauthorized
+from fence.jwt.errors import JWTError
 from fence.jwt.validate import validate_jwt
 from fence.models import IdentityProvider
 
@@ -101,7 +102,7 @@ class FenceCallback(DefaultOAuth2Callback):
                 purpose="id",
                 attempt_refresh=True,
             )
-        except:
+        except JWTError:
             # Since fenceshib cannot be updated to issue "new-style" ID tokens
             # (where scopes are in the scope claim and aud is in the aud claim),
             # allow also "old-style" Fence ID tokens.

--- a/fence/blueprints/login/fence_login.py
+++ b/fence/blueprints/login/fence_login.py
@@ -91,21 +91,27 @@ class FenceCallback(DefaultOAuth2Callback):
         tokens = flask.current_app.fence_client.fetch_access_token(
             redirect_uri, **flask.request.args.to_dict()
         )
-        # After Fence 5.0.0 "remove scopes from aud claim" changes,
-        # this validate_jwt is supposed to look like this:
-        #     id_token_claims = validate_jwt(
-        #         tokens["id_token"], scope={"openid"}, purpose="id", attempt_refresh=True
-        #     )
-        # However, since fenceshib cannot be updated to issue "new-style" ID tokens
-        # (where scopes are in the scope claim and aud is in the aud claim),
-        # we will instead validate Fence ID tokens as "old-style" tokens.
-        id_token_claims = validate_jwt(
-            tokens["id_token"],
-            aud="openid",
-            scope=None,
-            purpose="id",
-            attempt_refresh=True,
-        )
+
+        try:
+            # For multi-Fence setup with two Fences >=5.0.0
+            id_token_claims = validate_jwt(
+                tokens["id_token"],
+                aud=self.client.client_id,
+                scope={"openid"},
+                purpose="id",
+                attempt_refresh=True,
+            )
+        except:
+            # Since fenceshib cannot be updated to issue "new-style" ID tokens
+            # (where scopes are in the scope claim and aud is in the aud claim),
+            # allow also "old-style" Fence ID tokens.
+            id_token_claims = validate_jwt(
+                tokens["id_token"],
+                aud="openid",
+                scope=None,
+                purpose="id",
+                attempt_refresh=True,
+            )
         username = id_token_claims["context"]["user"]["name"]
         email = id_token_claims["context"]["user"].get("email")
         login_user(


### PR DESCRIPTION
There exist people running multi Fence with two modern Fences!

Jira Ticket: n/a

### Bug Fixes
- Fix ID token validation for multi-tenant Fence setup: Allow both old and new style ID tokens
- Fix ID token validation for multi-tenant Fence setup: Client Fence should demand its client_id, not its BASE_URL, in the aud claim

