### PR TITLE
PXP-8318 Split public and private audit configs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2021-06-10T21:56:24Z",
+  "version": "1.1.0",
   "plugins_used": [
     {
-      "name": "AWSKeyDetector"
+      "name": "ArtifactoryDetector"
     },
     {
-      "name": "ArtifactoryDetector"
+      "name": "AWSKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -31,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -51,6 +51,52 @@
     },
     {
       "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "poetry.lock"
+      ]
     }
   ],
   "results": {
@@ -79,13 +125,6 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
         "line_number": 31
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "fence/config-default.yaml",
-        "hashed_secret": "5d07e1b80e448a213b392049888111e1779a52db",
-        "is_verified": false,
-        "line_number": 554
       }
     ],
     "fence/local_settings.example.py": [
@@ -221,47 +260,5 @@
       }
     ]
   },
-  "version": "1.1.0",
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "poetry.lock"
-      ]
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    }
-  ]
+  "generated_at": "2021-07-20T17:15:01Z"
 }

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -184,7 +184,7 @@ def app_register_blueprints(app):
         )
 
 
-def _check_s3_buckets(app):
+def _check_aws_creds_and_region(app):
     """
     Function to ensure that all s3_buckets have a valid credential.
     Additionally, if there is no region it will produce a warning then try to fetch and cache the region.
@@ -238,6 +238,14 @@ def _check_s3_buckets(app):
             region = app.boto.get_bucket_region(bucket_name, credential)
             config["S3_BUCKETS"][bucket_name]["region"] = region
 
+    cred = config["PUSH_AUDIT_LOGS_CONFIG"].get("aws_sqs_config", {}).get("aws_cred")
+    if cred and cred not in aws_creds:
+        raise ValueError(
+            "Credential {} for PUSH_AUDIT_LOGS_CONFIG.aws_sqs_config.aws_cred is not defined in AWS_CREDENTIALS".format(
+                cred
+            )
+        )
+
 
 def app_config(
     app, settings="fence.settings", root_dir=None, config_path=None, file_name=None
@@ -290,7 +298,7 @@ def app_config(
     _setup_oidc_clients(app)
 
     with app.app_context():
-        _check_s3_buckets(app)
+        _check_aws_creds_and_region(app)
 
 
 def _setup_data_endpoint_and_boto(app):

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -478,7 +478,10 @@ class IndexedFile(object):
 
     @cached_property
     def public(self):
-        return self.public_acl or self.public_authz
+        if self.index_document.get("authz", []):
+            return self.public_authz
+        else:
+            return self.public_acl
 
     @cached_property
     def public_acl(self):

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -570,6 +570,7 @@ AWS_CREDENTIALS: {}
 # NOTE: the region is optonal for s3_buckets, however it should be specified to avoid a
 # call to GetBucketLocation which you make lack the AWS ACLs for.
 # public buckets do not need the region field.
+# the cred values should be keys in section `AWS_CREDENTIALS`.
 S3_BUCKETS: {}
 # NOTE: Remove the {} and supply buckets if needed. Example in comments below
 #   bucket1:
@@ -627,15 +628,14 @@ ENABLE_AUDIT_LOGS:
 # `PUSH_AUDIT_LOGS_CONFIG.type` is one of: [api, aws_sqs].
 # - if type == api: logs are created by hitting the log creation endpoint.
 # - if type == aws_sqs: logs are pushed to an SQS and `aws_sqs_config` fields
-# `sqs_url` and `region` are required. Fields `aws_access_key_id` and
-# `aws_secret_access_key` are optional.
+# `sqs_url` and `region` are required. Field `aws_cred` is optional and it
+# should be a key in section `AWS_CREDENTIALS`.
 PUSH_AUDIT_LOGS_CONFIG:
   type: aws_sqs
   aws_sqs_config:
     sqs_url:
     region:
-    aws_access_key_id:
-    aws_secret_access_key:
+    aws_cred:
 
 # //////////////////////////////////////////////////////////////////////////////////////
 # CLOUD API LIBRARY (CIRRUS) AND GOOGLE CONFIGURATION
@@ -846,7 +846,7 @@ SERVICE_ACCOUNT_LIMIT: 6
 
 # Global sync visas during login
 # None(Default): Allow per client i.e. a fence client can pick whether or not to sync their visas during login with parse_visas param in /authorization endpoint
-# True: Parse for all clients i.e. a fence client will always sync their visas during login 
+# True: Parse for all clients i.e. a fence client will always sync their visas during login
 # False: Parse for no clients i.e. a fence client will not be able to sync visas during login even with parse_visas param
 GLOBAL_PARSE_VISAS_ON_LOGIN:
 # Settings for usersync with visas


### PR DESCRIPTION
Jira Ticket: [PXP-8318](https://ctds-planx.atlassian.net/browse/PXP-8318)

### New Features
- Split the private fields from the public fields in the audit logging configuration

### Improvements
- When deciding whether to sign a URL for download, do not rely on "acl" if the record has an "authz"
