### PR TITLE
Added data use agreement to the download registration form

### DIFF
--- a/fence/blueprints/register.py
+++ b/fence/blueprints/register.py
@@ -5,9 +5,10 @@ in order to gain some predefined permissions.
 """
 
 import flask
+from flask.templating import render_template
 from flask_sqlalchemy_session import current_session
 from flask_wtf import FlaskForm
-from wtforms import StringField
+from wtforms import StringField, BooleanField
 from wtforms.validators import DataRequired, Email, StopValidation, ValidationError
 
 from fence import config
@@ -52,6 +53,9 @@ class RegistrationForm(FlaskForm):
     email = StringField(
         label="Email", validators=[xor_with_user_email, Email(), DataRequired()]
     )
+    datauseagreement = BooleanField(
+        validators=[DataRequired()], render_kw={"id": "checkbox"}
+    )
 
 
 @blueprint.route("/", methods=["GET", "POST"])
@@ -95,6 +99,7 @@ def register_user():
     lastname = flask.request.form["lastname"]
     org = flask.request.form["organization"]
     email = flask.g.user.email or flask.request.form["email"]
+    datauseagreement = flask.request.form["datauseagreement"]
 
     combined_info = {}
     if flask.g.user.additional_info is not None:
@@ -105,6 +110,7 @@ def register_user():
             "lastname": lastname,
             "org": org,
             "email": email,
+            "dataUseAgreement": datauseagreement,
         }
     }
     combined_info.update(registration_info)
@@ -124,3 +130,8 @@ def register_user():
     if flask.session.get("redirect"):
         return flask.redirect(flask.session.get("redirect"))
     return flask.jsonify(registration_info)
+
+
+@blueprint.route("/data_use_agreement/")
+def data_use_agreement():
+    return flask.render_template("data_use_agreement.html")

--- a/fence/templates/data_use_agreement.html
+++ b/fence/templates/data_use_agreement.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Data Use Agreement for Academic and Institutional Users</h1>
+
+<p>This Data Use Agreement for Academic and Institutional Users (this “Agreement”) is by and between you and the University of Chicago (the “University”) and governs your access to and use of the deidentified imaging and associated demographic and clinical data provided to you by the University (“MIDRC Data”). By accessing, using, or downloading any MIDRC Data, you are agreeing to be bound by the terms and conditions of this Agreement. <br>
+    1. The University grants you a limited, personal, worldwide, non-exclusive, non-transferable, royalty-free license to view and use the MIDRC Data solely for your personal, Non-Commercial Research Purposes. Any commercial use, sale, or other monetization is prohibited. “Non-Commercial Research Purposes” means academic research or other not-for-profit scholarly purposes which are undertaken at a non-profit or government institution and publishing in connection therewith. <br>
+    2. Other than the rights granted herein, the University retains all rights, title, and interest in the MIDRC Dataset. <br>
+    3. You will use the MIDRC Data only in compliance with all applicable laws and regulations.<br>
+    4. You may make a verbatim copy of the MIDRC Data for personal, non-commercial research use. If another user within your organization wishes to use the MIDRC Data, they must separately download the data set and enter into an Agreement directly with the University. <br>
+    5. You may not distribute, publish, or reproduce a copy of any portion or all of the MIDRC Data to others without specific prior written permission from the University. <br>
+    6. You will promptly report to the University in writing any unauthorized access or use of the MIDRC Data. <br>
+    7. You will register with and provide current contact information to the University. By accessing, using, or downloading the MIDRC Data, you consent to be contacted by the University. The University may use, and you hereby grant the University a non-exclusive, worldwide, perpetual, irrevocable license to use, any data you provide to the University, including any personally identifiable information. <br>
+    7. You will acknowledge your use of MIDRC Data in all oral or written presentations, disclosures, or publications arising from your use of the MIDRC Data. <br>
+    8. You may not modify, reverse engineer, decompile, or create derivative works from the MIDRC Data. You must not remove or alter any copyright or other proprietary notices in the MIDRC Data. For avoidance of doubt, the University will have no right, title, or interest in any research results that you create, including any data analyses, results of algorithm validations, annotations and overlays, and outcomes or evaluations you create using the MIDRC Data. <br>
+    9. The MIDRC Data has not been reviewed or approved by the Food and Drug Administration, and is for non-clinical, research use only. In no event shall data or images generated through the use of the MIDRC Data be used or relied upon in the diagnosis or provision of patient care. <br>
+    10. THE MIDRC DATA IS PROVIDED ON AN "AS IS", “WHERE IS” BASIS. THE UNIVERSITY MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON INFRINGEMENT. THE UNIVERSITY WILL HAVE NO LIABILITY WHATSOEVER ARISING FROM YOUR ACCESS OR USE OF THE MIDRC DATA. <br>
+    11. You will not make any attempt to re-identify any individual from the MIDRC Data. In the event that you identify any person whose data is included in the MIDRC Data, you will promptly notify the University in writing. <br>
+    12. The University may terminate this Agreement at any time upon notice to you. The University shall have no liability in the event of any such termination. Upon such termination, the University may direct that you immediately return or destroy all copies of any MIDRC Data and, upon the University’s request, you will certify the foregoing to the University in writing. <br>
+
+    </p>
+
+</body>
+</html>

--- a/fence/templates/register_user.html
+++ b/fence/templates/register_user.html
@@ -28,8 +28,25 @@
             {{ form.email.label }} {{ form.email }}
           {% endif %}
       </li>
+      <li>
+        {{ form.datauseagreement(disabled=True) }}
+        I have read and agree to the <a href="data_use_agreement" target="_blank" onclick=enableCheckbox()>Terms and Conditions.</a>
+          {% if not form.datauseagreement.checked %}
+            <p id="tempText">  Please click on <strong>Terms and Conditions</strong> to enable Checkbox</p>
+
+          {% endif %}
+          <script type="text/javascript">
+            function enableCheckbox()
+            {
+              document.getElementById("checkbox").disabled= false;
+              document.getElementById("tempText").remove();
+            }
+          </script>
+      </li>
+
     </ul>
     <button class="button-primary-orange" type="submit">Register</button>
+
   </form>
 {% endblock %}
 


### PR DESCRIPTION

This PR will add a data use agreement to the download registration form when "REGISTER_USERS_ON" is on. 

How to verify:

1. Set up a useryaml that has a GROUP with a policy (for example: "registered_users" with "data_upload" policy)
2. Your test user should not be in this group
3. Set up and run your Arborist
4. Run usersync
5. Put the name of the group in fence config's REGISTERED_USERS_GROUP; also set fence REGISTER_USERS_ON to true.
6. Look in the Fence db and confirm that your test user is not registered (he has no registration_info block in his additional_info column)
7. Look in Arborist db and confirm that your test user is not part of the group and does not have the group's policies
8. Set up and run your Fence, which is talking to your Arborist
9. Log in. You should be redirected to the registration form and registration form will have "Terms and Conditions" section.
10. When you enable checkbox and click on "Register" button the details will be stored in the fence db.

### New Features
Added data use agreement to the download registration form

<!-- This section should only contain important things devops should know when updating service versions. -->
