### PR TITLE
Remove fallback to sub in RAS

### DIFF
--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -179,6 +179,9 @@ class RASOauth2Client(Oauth2ClientBase):
             if userinfo.get("UserID"):
                 username = userinfo["UserID"]
                 field_name = "UserID"
+            elif userinfo.get("userid"):
+                username = userinfo["userid"]
+                field_name = "userid"
             if not username:
                 self.logger.error(
                     "{}, received claims: {} and userinfo: {}".format(


### PR DESCRIPTION
RAS sometimes not sending the correct userinfo response causes access issues downstream. We should error out instead of falling back to avoid issues on the client-side since some depend on the UserID response to be consistent. 

### Improvements
- Remove fallback to other fields from RAS userinfo response when UserID is not provided and return an error instead.