### PR TITLE
PXP-9099 Fix redirection to default IDP in oauth2 flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -280,9 +280,9 @@
         "filename": "tests/test-fence-config.yaml",
         "hashed_secret": "1627df13b5cd8b3521d02bd8eb2ca31334b3aef2",
         "is_verified": false,
-        "line_number": 472
+        "line_number": 471
       }
     ]
   },
-  "generated_at": "2021-11-15T20:50:20Z"
+  "generated_at": "2021-11-15T23:28:25Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -242,7 +246,7 @@
         "filename": "tests/login/test_fence_login.py",
         "hashed_secret": "d300421e208bfd0d432294de15169fd9b8975def",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 48
       }
     ],
     "tests/ras/test_ras.py": [
@@ -280,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-18T02:36:18Z"
+  "generated_at": "2021-11-15T20:50:20Z"
 }

--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -44,6 +44,188 @@ IDP_URL_MAP = {
 }
 
 
+def absolute_login_url(provider_id, fence_idp=None, shib_idp=None):
+    """
+    Args:
+        provider_id (str): provider to log in with; an IDP_URL_MAP key.
+        fence_idp (str, optional): if provider_id is "fence"
+            (multi-tenant Fence setup), fence_idp can be any of the
+            providers supported by the other Fence. If not specified,
+            will default to NIH login.
+        shib_idp (str, optional): if provider_id is "fence" and
+            fence_idp is "shibboleth", shib_idp can be any Shibboleth/
+            InCommon provider. If not specified, will default to NIH
+            login.
+
+    Returns:
+        str: login URL for this provider, including extra query
+            parameters if fence_idp and/or shib_idp are specified.
+    """
+    try:
+        base_url = config["BASE_URL"].rstrip("/")
+        login_url = base_url + "/login/{}".format(IDP_URL_MAP[provider_id])
+    except KeyError as e:
+        raise InternalError("identity provider misconfigured: {}".format(str(e)))
+
+    params = {}
+    if fence_idp:
+        params["idp"] = fence_idp
+    if shib_idp:
+        params["shib_idp"] = shib_idp
+    login_url = add_params_to_uri(login_url, params)
+
+    return login_url
+
+
+def provider_info(login_details):
+    """
+    Args:
+        login_details (dict):
+        { name, desc, idp, fence_idp, shib_idps, secondary }
+        - "idp": a configured provider.
+        Multiple options can be configured with the same idp.
+        - if provider_id is "fence", "fence_idp" can be any of the
+        providers supported by the other Fence. If not specified, will
+        default to NIH login.
+        - if provider_id is "fence" and fence_idp is "shibboleth", a
+        list of "shib_idps" can be configured for InCommon login. If
+        not specified, will default to NIH login.
+        - Optional parameters: "desc" (description) and "secondary"
+        (boolean - can be used by the frontend to display secondary
+        buttons differently).
+
+    Returns:
+        dict: { name, desc, idp, urls, secondary }
+        - urls: list of { name, url } dictionaries
+    """
+    info = {
+        # "id" deprecated, replaced by "idp"
+        "id": login_details["idp"],
+        "idp": login_details["idp"],
+        "name": login_details["name"],
+        # "url" deprecated, replaced by "urls"
+        "url": absolute_login_url(login_details["idp"]),
+        "desc": login_details.get("desc", None),
+        "secondary": login_details.get("secondary", False),
+    }
+
+    # for Fence multi-tenant login
+    fence_idp = None
+    if login_details["idp"] == "fence":
+        fence_idp = login_details.get("fence_idp")
+
+    # handle Shibboleth IDPs: InCommon login can either be configured
+    # directly in this Fence, or through multi-tenant Fence
+    if (
+        login_details["idp"] == "shibboleth" or fence_idp == "shibboleth"
+    ) and "shib_idps" in login_details:
+        # get list of all available shib IDPs
+        if not hasattr(flask.current_app, "all_shib_idps"):
+            flask.current_app.all_shib_idps = get_all_shib_idps()
+
+        requested_shib_idps = login_details["shib_idps"]
+        if requested_shib_idps == "*":
+            shib_idps = flask.current_app.all_shib_idps
+        elif isinstance(requested_shib_idps, list):
+            # get the display names for each requested shib IDP
+            shib_idps = []
+            for requested_shib_idp in requested_shib_idps:
+                shib_idp = next(
+                    (
+                        available_shib_idp
+                        for available_shib_idp in flask.current_app.all_shib_idps
+                        if available_shib_idp["idp"] == requested_shib_idp
+                    ),
+                    None,
+                )
+                if not shib_idp:
+                    raise InternalError(
+                        'Requested shib_idp "{}" does not exist'.format(
+                            requested_shib_idp
+                        )
+                    )
+                shib_idps.append(shib_idp)
+        else:
+            raise InternalError(
+                'fence provider misconfigured: "shib_idps" must be a list or "*", got {}'.format(
+                    requested_shib_idps
+                )
+            )
+
+        info["urls"] = [
+            {
+                "name": shib_idp["name"],
+                "url": absolute_login_url(
+                    login_details["idp"], fence_idp, shib_idp["idp"]
+                ),
+            }
+            for shib_idp in shib_idps
+        ]
+
+    # non-Shibboleth provider
+    else:
+        info["urls"] = [
+            {
+                "name": login_details["name"],
+                "url": absolute_login_url(login_details["idp"], fence_idp),
+            }
+        ]
+
+    return info
+
+
+def get_login_providers_info():
+    # default login option
+    if config.get("DEFAULT_LOGIN_IDP"):
+        default_idp = config["DEFAULT_LOGIN_IDP"]
+    elif "default" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
+        # fall back on ENABLED_IDENTITY_PROVIDERS.default
+        default_idp = config["ENABLED_IDENTITY_PROVIDERS"]["default"]
+    else:
+        logger.warning("DEFAULT_LOGIN_IDP not configured")
+        default_idp = None
+
+    # other login options
+    if config["LOGIN_OPTIONS"]:
+        login_options = config["LOGIN_OPTIONS"]
+    elif "providers" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
+        # fall back on "providers" and convert to "login_options" format
+        enabled_providers = config["ENABLED_IDENTITY_PROVIDERS"]["providers"]
+        login_options = [
+            {
+                "name": details.get("name"),
+                "idp": idp,
+                "desc": details.get("desc"),
+                "secondary": details.get("secondary"),
+            }
+            for idp, details in enabled_providers.items()
+        ]
+    else:
+        logger.warning("LOGIN_OPTIONS not configured or empty")
+        login_options = []
+
+    try:
+        all_provider_info = [
+            provider_info(login_details) for login_details in login_options
+        ]
+    except KeyError as e:
+        raise InternalError("LOGIN_OPTIONS misconfigured: cannot find key {}".format(e))
+
+    # if several login_options are defined for this default IDP, will
+    # default to the first one:
+    default_provider_info = next(
+        (info for info in all_provider_info if info["idp"] == default_idp), None
+    )
+    if not default_provider_info:
+        raise InternalError(
+            "default provider misconfigured: DEFAULT_LOGIN_IDP is set to {}, which is not configured in LOGIN_OPTIONS".format(
+                default_idp
+            )
+        )
+
+    return default_provider_info, all_provider_info
+
+
 def make_login_blueprint(app):
     """
     Args:
@@ -64,184 +246,7 @@ def make_login_blueprint(app):
         """
         The default root login route.
         """
-        # default login option
-        if config.get("DEFAULT_LOGIN_IDP"):
-            default_idp = config["DEFAULT_LOGIN_IDP"]
-        elif "default" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
-            # fall back on ENABLED_IDENTITY_PROVIDERS.default
-            default_idp = config["ENABLED_IDENTITY_PROVIDERS"]["default"]
-        else:
-            logger.warning("DEFAULT_LOGIN_IDP not configured")
-            default_idp = None
-
-        # other login options
-        if config["LOGIN_OPTIONS"]:
-            login_options = config["LOGIN_OPTIONS"]
-        elif "providers" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
-            # fall back on "providers" and convert to "login_options" format
-            enabled_providers = config["ENABLED_IDENTITY_PROVIDERS"]["providers"]
-            login_options = [
-                {
-                    "name": details.get("name"),
-                    "idp": idp,
-                    "desc": details.get("desc"),
-                    "secondary": details.get("secondary"),
-                }
-                for idp, details in enabled_providers.items()
-            ]
-        else:
-            logger.warning("LOGIN_OPTIONS not configured or empty")
-            login_options = []
-
-        def absolute_login_url(provider_id, fence_idp=None, shib_idp=None):
-            """
-            Args:
-                provider_id (str): provider to log in with; an IDP_URL_MAP key.
-                fence_idp (str, optional): if provider_id is "fence"
-                    (multi-tenant Fence setup), fence_idp can be any of the
-                    providers supported by the other Fence. If not specified,
-                    will default to NIH login.
-                shib_idp (str, optional): if provider_id is "fence" and
-                    fence_idp is "shibboleth", shib_idp can be any Shibboleth/
-                    InCommon provider. If not specified, will default to NIH
-                    login.
-
-            Returns:
-                str: login URL for this provider, including extra query
-                    parameters if fence_idp and/or shib_idp are specified.
-            """
-            try:
-                base_url = config["BASE_URL"].rstrip("/")
-                login_url = base_url + "/login/{}".format(IDP_URL_MAP[provider_id])
-            except KeyError as e:
-                raise InternalError(
-                    "identity provider misconfigured: {}".format(str(e))
-                )
-
-            params = {}
-            if fence_idp:
-                params["idp"] = fence_idp
-            if shib_idp:
-                params["shib_idp"] = shib_idp
-            login_url = add_params_to_uri(login_url, params)
-
-            return login_url
-
-        def provider_info(login_details):
-            """
-            Args:
-                login_details (dict):
-                { name, desc, idp, fence_idp, shib_idps, secondary }
-                - "idp": a configured provider.
-                Multiple options can be configured with the same idp.
-                - if provider_id is "fence", "fence_idp" can be any of the
-                providers supported by the other Fence. If not specified, will
-                default to NIH login.
-                - if provider_id is "fence" and fence_idp is "shibboleth", a
-                list of "shib_idps" can be configured for InCommon login. If
-                not specified, will default to NIH login.
-                - Optional parameters: "desc" (description) and "secondary"
-                (boolean - can be used by the frontend to display secondary
-                buttons differently).
-
-            Returns:
-                dict: { name, desc, idp, urls, secondary }
-                - urls: list of { name, url } dictionaries
-            """
-            info = {
-                # "id" deprecated, replaced by "idp"
-                "id": login_details["idp"],
-                "idp": login_details["idp"],
-                "name": login_details["name"],
-                # "url" deprecated, replaced by "urls"
-                "url": absolute_login_url(login_details["idp"]),
-                "desc": login_details.get("desc", None),
-                "secondary": login_details.get("secondary", False),
-            }
-
-            # for Fence multi-tenant login
-            fence_idp = None
-            if login_details["idp"] == "fence":
-                fence_idp = login_details.get("fence_idp")
-
-            # handle Shibboleth IDPs: InCommon login can either be configured
-            # directly in this Fence, or through multi-tenant Fence
-            if (
-                login_details["idp"] == "shibboleth" or fence_idp == "shibboleth"
-            ) and "shib_idps" in login_details:
-                # get list of all available shib IDPs
-                if not hasattr(app, "all_shib_idps"):
-                    app.all_shib_idps = get_all_shib_idps()
-
-                requested_shib_idps = login_details["shib_idps"]
-                if requested_shib_idps == "*":
-                    shib_idps = app.all_shib_idps
-                elif isinstance(requested_shib_idps, list):
-                    # get the display names for each requested shib IDP
-                    shib_idps = []
-                    for requested_shib_idp in requested_shib_idps:
-                        shib_idp = next(
-                            (
-                                available_shib_idp
-                                for available_shib_idp in app.all_shib_idps
-                                if available_shib_idp["idp"] == requested_shib_idp
-                            ),
-                            None,
-                        )
-                        if not shib_idp:
-                            raise InternalError(
-                                'Requested shib_idp "{}" does not exist'.format(
-                                    requested_shib_idp
-                                )
-                            )
-                        shib_idps.append(shib_idp)
-                else:
-                    raise InternalError(
-                        'fence provider misconfigured: "shib_idps" must be a list or "*", got {}'.format(
-                            requested_shib_idps
-                        )
-                    )
-
-                info["urls"] = [
-                    {
-                        "name": shib_idp["name"],
-                        "url": absolute_login_url(
-                            login_details["idp"], fence_idp, shib_idp["idp"]
-                        ),
-                    }
-                    for shib_idp in shib_idps
-                ]
-
-            # non-Shibboleth provider
-            else:
-                info["urls"] = [
-                    {
-                        "name": login_details["name"],
-                        "url": absolute_login_url(login_details["idp"], fence_idp),
-                    }
-                ]
-
-            return info
-
-        try:
-            all_provider_info = [
-                provider_info(login_details) for login_details in login_options
-            ]
-        except KeyError as e:
-            raise InternalError("LOGIN_OPTIONS misconfigured: {}".format(e))
-
-        # if several login_options are defined for this default IDP, will
-        # default to the first one:
-        default_provider_info = next(
-            (info for info in all_provider_info if info["idp"] == default_idp), None
-        )
-        if not default_provider_info:
-            raise InternalError(
-                "default provider misconfigured: DEFAULT_LOGIN_IDP is set to {}, which is not configured in LOGIN_OPTIONS".format(
-                    default_idp
-                )
-            )
-
+        default_provider_info, all_provider_info = get_login_providers_info()
         return flask.jsonify(
             {"default_provider": default_provider_info, "providers": all_provider_info}
         )

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -22,7 +22,7 @@ import json
 
 from authutils.errors import JWTExpiredError
 
-from fence.blueprints.login import IDP_URL_MAP
+from fence.blueprints.login import IDP_URL_MAP, get_login_providers_info
 from fence.errors import Unauthorized, UserError
 from fence.jwt.errors import JWTError
 from fence.jwt.token import SCOPE_DESCRIPTION
@@ -77,15 +77,17 @@ def authorize(*args, **kwargs):
     shib_idp = flask.request.args.get("shib_idp")
 
     login_url = None
-    if not idp:  # use default login IDP
-        idp = config.get("DEFAULT_LOGIN_IDP")
-        if not idp:
-            if "default" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
-                # fall back on ENABLED_IDENTITY_PROVIDERS.default
-                idp = config["ENABLED_IDENTITY_PROVIDERS"]["default"]
-            else:
-                # fall back on deprecated DEFAULT_LOGIN_URL
-                login_url = config.get("DEFAULT_LOGIN_URL")
+    if not idp:
+        if not config.get("DEFAULT_LOGIN_IDP") and "default" not in config.get(
+            "ENABLED_IDENTITY_PROVIDERS", {}
+        ):
+            # fall back on deprecated DEFAULT_LOGIN_URL
+            login_url = config.get("DEFAULT_LOGIN_URL")
+        else:
+            default_provider_info, _ = get_login_providers_info()
+            idp = default_provider_info["idp"]
+            # if more than 1 URL is configured, default to the 1st one
+            login_url = default_provider_info["urls"][0]["url"]
 
     if need_authentication or not user:
         redirect_url = config.get("BASE_URL") + flask.request.full_path
@@ -94,8 +96,8 @@ def authorize(*args, **kwargs):
         if not login_url:
             if idp not in IDP_URL_MAP or idp not in config["OPENID_CONNECT"]:
                 raise UserError("idp {} is not supported".format(idp))
-            idp_url = IDP_URL_MAP[idp]
-            login_url = "{}/login/{}".format(config.get("BASE_URL"), idp_url)
+            idp_endpoint = IDP_URL_MAP[idp]
+            login_url = "{}/login/{}".format(config.get("BASE_URL"), idp_endpoint)
 
         # handle valid extra params for fence multi-tenant and shib login
         if idp == "fence" and fence_idp:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1137,7 +1137,7 @@ def patch_app_db_session(app, monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def oauth_client(app, db_session, oauth_user):
+def oauth_client(app, db_session, oauth_user, get_all_shib_idps_patcher):
     """
     Create a confidential OAuth2 client and add it to the database along with a
     test user for the client.
@@ -1497,3 +1497,29 @@ def restore_config():
 
     # restore old configs
     config.update(saved_config)
+
+
+@pytest.fixture(scope="function")
+def get_all_shib_idps_patcher():
+    """
+    Don't make real requests to the list of InCommon IDPs exposed
+    by login.bionimbus
+    """
+    mock = MagicMock()
+    mock.return_value = [
+        {"idp": "some-incommon-entity-id", "name": "Some InCommon Provider"},
+        {
+            "idp": "urn:mace:incommon:nih.gov",
+            "name": "National Institutes of Health (NIH)",
+        },
+        {"idp": "urn:mace:incommon:uchicago.edu", "name": "University of Chicago"},
+    ]
+    get_all_shib_idps_patch = patch(
+        "fence.blueprints.login.get_all_shib_idps",
+        mock,
+    )
+    get_all_shib_idps_patch.start()
+
+    yield mock
+
+    get_all_shib_idps_patch.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1507,12 +1507,18 @@ def get_all_shib_idps_patcher():
     """
     mock = MagicMock()
     mock.return_value = [
-        {"idp": "some-incommon-entity-id", "name": "Some InCommon Provider"},
+        {
+            "idp": "some-incommon-entity-id",
+            "name": "Some InCommon Provider",
+        },
         {
             "idp": "urn:mace:incommon:nih.gov",
             "name": "National Institutes of Health (NIH)",
         },
-        {"idp": "urn:mace:incommon:uchicago.edu", "name": "University of Chicago"},
+        {
+            "idp": "urn:mace:incommon:uchicago.edu",
+            "name": "University of Chicago",
+        },
     ]
     get_all_shib_idps_patch = patch(
         "fence.blueprints.login.get_all_shib_idps",

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -122,7 +122,6 @@ OPENID_CONNECT:
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/fence/login'
-    shibboleth_discovery_url: 'https://login.bionimbus.org/Shibboleth.sso/DiscoFeed'
   shibboleth:
     client_id: ''
     client_secret: ''
@@ -483,7 +482,7 @@ ARBORIST: '/arborist'
 AZ_BLOB_CREDENTIALS: 'fake connection string'
 
 # AZ_BLOB_CONTAINER_URL: 'https://storageaccount.blob.core.windows.net/container/'
-# this is the container used for uploading, and should match the storage account 
+# this is the container used for uploading, and should match the storage account
 # used in the connection string for AZ_BLOB_CREDENTIALS
 AZ_BLOB_CONTAINER_URL: 'https://myfakeblob.blob.core.windows.net/my-fake-container/'
 


### PR DESCRIPTION
Jira Ticket: [PXP-9099](https://ctds-planx.atlassian.net/browse/PXP-9099)

Fix bug causing a redirection to the default NIH entity ID instead of the custom entity ID when users login through the oauth2 flow WITHOUT SPECIFYING AN IDP.

The config below should redirect to the "X" provider when users log into Gen3 via a client portal which does not specify the IDP, but it redirects to "urn:mace:incommon:nih.gov" instead (default "shib_idp") because the "shib_idp" param is not passed to centralized fence.

```
DEFAULT_LOGIN_IDP: fence
LOGIN_OPTIONS:
  - name: 'NIH Login'
    idp: fence
    fence_idp: shibboleth
    shib_idps:
      - X
```

### Bug Fixes
- Fix the redirection to the default IDP in the `/oauth2/authorize` endpoint: when the default IDP is "fence", include `idp` and `shib_idp` query parameters

### Improvements
- Update the unit tests so we don't make real requests to get the list of InCommon IDPs
