### PR TITLE
feat(cfg): global cfg to disable allowing Passports->DRS as a method …

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -76,6 +76,12 @@ def get_signed_url_for_file(
     if no_force_sign_param and no_force_sign_param.lower() == "true":
         force_signed_url = False
 
+    if ga4gh_passports and not config["GA4GH_PASSPORTS_TO_DRS_ENABLED"]:
+        raise NotSupported(
+            "Using GA4GH Passports as a means of authentication and authorization "
+            "is not supported by this instance of Gen3."
+        )
+
     user_ids_from_passports = None
     if ga4gh_passports:
         # TODO change this to usernames

--- a/fence/blueprints/ga4gh.py
+++ b/fence/blueprints/ga4gh.py
@@ -30,6 +30,12 @@ def get_ga4gh_signed_url(object_id, access_id):
             config["GA4GH_DRS_POSTED_PASSPORT_FIELD"]
         )
 
+        if ga4gh_passports and flask.request.headers.get("Authorization"):
+            raise UserError(
+                "You cannot supply both GA4GH passports and a token "
+                "in the Authorization header of a request."
+            )
+
     result = get_signed_url_for_file(
         "download",
         object_id,

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -871,6 +871,8 @@ SERVICE_ACCOUNT_LIMIT: 6
 # //////////////////////////////////////////////////////////////////////////////////////
 # GA4GH SUPPORT: DATA ACCESS AND AUTHORIZATION SYNCING
 # //////////////////////////////////////////////////////////////////////////////////////
+# whether or not to accept GA4GH Passports as a means of AuthN/Z to the DRS data access endpoint
+GA4GH_PASSPORTS_TO_DRS_ENABLED: false
 
 # RAS refresh_tokens expire in 15 days
 RAS_REFRESH_EXPIRATION: 1296000


### PR DESCRIPTION
…of authN/Z, also don't allow passport & Auth header


### New Features
- lobal cfg to disable allowing Passports->DRS as a method of AuthN/Z

### Breaking Changes


### Bug Fixes


### Improvements
- don't allow both POST-ing a passport & sending Auth header in the same request to the GA4GH DRS Data Access Endpoint

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
