### PR TITLE
fix(audit): fix audit log to send Gen3 sub instead of idp sub

### DIFF
--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -128,7 +128,7 @@ class DefaultOAuth2Callback(Resource):
 def prepare_login_log(idp_name, id_from_idp=None):
     flask.g.audit_data = {
         "username": flask.g.user.username,
-        "sub": id_from_idp,
+        "sub": flask.g.user.id,
         "idp": idp_name,
         "fence_idp": flask.session.get("fence_idp"),
         "shib_idp": flask.session.get("shib_idp"),

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -121,11 +121,11 @@ class DefaultOAuth2Callback(Resource):
             return resp
         raise UserError(result)
 
-    def post_login(self, user=None, token_result=None, id_from_idp=None):
-        prepare_login_log(self.idp_name, id_from_idp=id_from_idp)
+    def post_login(self, user=None, token_result=None):
+        prepare_login_log(self.idp_name)
 
 
-def prepare_login_log(idp_name, id_from_idp=None):
+def prepare_login_log(idp_name):
     flask.g.audit_data = {
         "username": flask.g.user.username,
         "sub": flask.g.user.id,

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -121,7 +121,7 @@ class DefaultOAuth2Callback(Resource):
             return resp
         raise UserError(result)
 
-    def post_login(self, user=None, token_result=None):
+    def post_login(self, user=None, token_result=None, **kwargs):
         prepare_login_log(self.idp_name)
 
 


### PR DESCRIPTION
bug introduced in 5.5.2

### New Features


### Breaking Changes


### Bug Fixes
- Fix issue with IdP subject being sent to audit log on login instead of Gen3 subject

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
