### PR TITLE
fix(google): pass storage creds into sync so Google Storage backend c…

### DIFF
--- a/fence/blueprints/login/ras.py
+++ b/fence/blueprints/login/ras.py
@@ -169,10 +169,11 @@ class RASCallback(DefaultOAuth2Callback):
             dbGaP = os.environ.get("dbGaP") or config.get("dbGaP")
             if not isinstance(dbGaP, list):
                 dbGaP = [dbGaP]
+            storage_creds = config["STORAGE_CREDENTIALS"]
 
             sync = fence.scripting.fence_create.init_syncer(
                 dbGaP,
-                None,
+                storage_creds,
                 DB,
                 arborist=arborist,
             )

--- a/fence/resources/ga4gh/passports.py
+++ b/fence/resources/ga4gh/passports.py
@@ -339,8 +339,9 @@ def sync_visa_authorization(gen3_user, ga4gh_visas, expiration):
             from fence.settings import DB
         except ImportError:
             pass
+    storage_creds = config["STORAGE_CREDENTIALS"]
     syncer = fence.scripting.fence_create.init_syncer(
-        dbgap_config, None, DB, arborist=arborist_client
+        dbgap_config, storage_creds, DB, arborist=arborist_client
     )
 
     with flask.current_app.db.session as db_session:


### PR DESCRIPTION
…an be updated


### New Features


### Breaking Changes


### Bug Fixes
- pass storage creds into sync so Google Storage backend can be updated

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
