### PR TITLE
fix: visa_types in fence-config should be strings

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -894,5 +894,5 @@ USERSYNC:
   # fallback to dbgap sftp when there are no valid visas for a user i.e. if they're expired or if they're malformed
   fallback_to_dbgap_sftp: false
   visa_types:
-    ras: [https://ras.nih.gov/visas/v1, https://ras.nih.gov/visas/v1.1]
+    ras: ["https://ras.nih.gov/visas/v1", "https://ras.nih.gov/visas/v1.1"]
 RAS_USERINFO_ENDPOINT: '/openid/connect/v1.1/userinfo'


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* `visa_types` should be strings

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
