### PR TITLE
feat(oauth): make discovery url and scope configurable per client and…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -198,14 +198,14 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1357
+        "line_number": 1358
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/conftest.py",
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1380
+        "line_number": 1381
       }
     ],
     "tests/credentials/google/test_credentials.py": [
@@ -280,9 +280,9 @@
         "filename": "tests/test-fence-config.yaml",
         "hashed_secret": "1627df13b5cd8b3521d02bd8eb2ca31334b3aef2",
         "is_verified": false,
-        "line_number": 471
+        "line_number": 472
       }
     ]
   },
-  "generated_at": "2021-11-15T23:28:25Z"
+  "generated_at": "2021-12-07T17:55:07Z"
 }

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -100,10 +100,12 @@ OPENID_CONNECT:
   # in Google to be '{{BASE_URL}}/login/google/login', but expand BASE_URL to
   # whatever you set it to above.
   google:
+    discovery_url: 'https://accounts.google.com/.well-known/openid-configuration'
     client_id: ''
     client_secret: ''
     # this is be the allowed redirect back to fence, should not need to change
     redirect_url: '{{BASE_URL}}/login/google/login/'
+    scope: 'openid email'
     # if mock is true, will fake a successful login response from Google in /login/google
     #     NOTE: this will also modify the behavior of /link/google endpoints
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
@@ -149,6 +151,7 @@ OPENID_CONNECT:
     # ORCID.org. DO NOT include {{BASE_URL}} at ORCID.org, you need to actually put the
     # full url
     redirect_url: '{{BASE_URL}}/login/orcid/login/'
+    scope: 'openid'
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
@@ -158,6 +161,7 @@ OPENID_CONNECT:
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/ras/callback'
+    scope: 'openid email profile ga4gh_passport_v1'
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
@@ -168,6 +172,7 @@ OPENID_CONNECT:
   # Azure, make sure to select the `Accounts in any organizational directory` for
   # supported account types.
   microsoft:
+    discovery_url: 'https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration'
     # after registering a new appl, client_id can be found as
     # "APPLICATION (CLIENT) ID" in Microsoft Azure
     client_id: ''
@@ -178,6 +183,7 @@ OPENID_CONNECT:
     # your app in Azure. DO NOT include {{BASE_URL}} in Azure, you need to actually put the
     # full url
     redirect_url: '{{BASE_URL}}/login/microsoft/login/'
+    scope: 'openid email'
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
@@ -189,12 +195,14 @@ OPENID_CONNECT:
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/okta/login/'
+    scope: 'openid email'
   cognito:
     # You must create a user pool in order to have a discovery url
     discovery_url: 'https://cognito-idp.{REGION}.amazonaws.com/{USER-POOL-ID}/.well-known/openid-configuration'
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/cognito/login/'
+    scope: 'openid email'
     # In the case where Cognito is being used solely as an intermediary to a single IdP,
     # and that IdP is a SAML IdP with no 'email_verified' outgoing claim, but it is safe
     # to assume all emails from this SAML IdP are in fact verified, we may set this to True
@@ -202,20 +210,24 @@ OPENID_CONNECT:
   # CILogon subscribers can create and manage OIDC clients using COmanage Registry.
   # Free tier users may request OIDC clients at https://cilogon.org/oauth2/register
   cilogon:
+    discovery_url: 'https://cilogon.org/.well-known/openid-configuration'
     client_id: ''
     client_secret: ''
     # When registering the Callback URLs for your CILogon OIDC client be
     # sure to include the FULL url for this deployment, including the https:// scheme
     # and server FQDN.
     redirect_url: '{{BASE_URL}}/login/cilogon/login/'
+    scope: 'openid email profile'
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
     mock_default_user: 'http://cilogon.org/serverT/users/64703'
   synapse:
+    discovery_url: ''
     client_id: ''
     client_secret: ''
     redirect_url: ''
+    scope: 'openid'
   shibboleth:
     client_id: ''
     client_secret: ''
@@ -846,6 +858,7 @@ DREAM_CHALLENGE_TEAM: 'DREAM'
 DREAM_CHALLENGE_GROUP: 'DREAM'
 SYNAPSE_URI: 'https://repo-prod.prod.sagebase.org/auth/v1'
 SYNAPSE_JWKS_URI:
+# deprecated, use the discovery_url in the OPENID_CONNECT block for the synapse client
 SYNAPSE_DISCOVERY_URL:
 SYNAPSE_AUTHZ_TTL: 86400
 

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -1,6 +1,6 @@
 ---
 ############################### Fence Configuration ####################################
-# This file contains various configurations for the fence microservice.
+# This file contains various configurations for the Fence microservice.
 #
 # README:
 # - This is initially configured for minimal local development with reasonable defaults.

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -145,6 +145,7 @@ OPENID_CONNECT:
     shibboleth_discovery_url: 'https://login.bionimbus.org/Shibboleth.sso/DiscoFeed'
   # you can setup up an orcid client here: https://orcid.org/developer-tools
   orcid:
+    discovery_url: 'https://orcid.org/.well-known/openid-configuration'
     client_id: ''
     client_secret: ''
     # make sure you put the FULL url for this deployment in the allowed redirects in

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -6,14 +6,13 @@ class CilogonOauth2Client(Oauth2ClientBase):
     client for interacting with CILogon OIDC
     """
 
-    CILOGON_DISCOVERY_URL = "https://cilogon.org/.well-known/openid-configuration"
+    DISCOVERY_URL = "https://cilogon.org/.well-known/openid-configuration"
 
     def __init__(self, settings, logger, HTTP_PROXY=None):
         super(CilogonOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid email profile",
-            discovery_url=self.CILOGON_DISCOVERY_URL,
+            scope=settings.get("scope") or "openid email profile",
             idp="CILogon",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/cognito_oauth2.py
+++ b/fence/resources/openid/cognito_oauth2.py
@@ -18,8 +18,7 @@ class CognitoOauth2Client(Oauth2ClientBase):
         super(CognitoOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid email",
-            discovery_url=settings["discovery_url"],
+            scope=settings.get("scope") or "openid email",
             idp="Amazon Cognito",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/google_oauth2.py
+++ b/fence/resources/openid/google_oauth2.py
@@ -10,16 +10,13 @@ class GoogleOauth2Client(Oauth2ClientBase):
     https://developers.google.com/api-client-library/python/guide/aaa_oauth
     """
 
-    GOOGLE_DISCOVERY_URL = (
-        "https://accounts.google.com/.well-known/openid-configuration"
-    )
+    DISCOVERY_URL = "https://accounts.google.com/.well-known/openid-configuration"
 
     def __init__(self, settings, logger, HTTP_PROXY=None):
         super(GoogleOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid email",
-            discovery_url=self.GOOGLE_DISCOVERY_URL,
+            scope=settings.get("scope") or "openid email",
             idp="Google",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/microsoft_oauth2.py
+++ b/fence/resources/openid/microsoft_oauth2.py
@@ -10,14 +10,13 @@ class MicrosoftOauth2Client(Oauth2ClientBase):
 
     """
 
-    MICROSOFT_DISCOVERY_URL = "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
+    DISCOVERY_URL = "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
 
     def __init__(self, settings, logger, HTTP_PROXY=None):
         super(MicrosoftOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid email",
-            discovery_url=self.MICROSOFT_DISCOVERY_URL,
+            scope=settings.get("scope") or "openid email",
             idp="Microsoft",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/okta_oauth2.py
+++ b/fence/resources/openid/okta_oauth2.py
@@ -8,8 +8,7 @@ class OktaOauth2Client(Oauth2ClientBase):
         super(OktaOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid email",
-            discovery_url=settings["discovery_url"],
+            scope=settings.get("scope") or "openid email",
             idp="Okta",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/orcid_oauth2.py
+++ b/fence/resources/openid/orcid_oauth2.py
@@ -8,14 +8,13 @@ class OrcidOauth2Client(Oauth2ClientBase):
 
     """
 
-    ORCID_DISCOVERY_URL = "https://orcid.org/.well-known/openid-configuration"
+    DISCOVERY_URL = "https://orcid.org/.well-known/openid-configuration"
 
     def __init__(self, settings, logger, HTTP_PROXY=None):
         super(OrcidOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid",
-            discovery_url=self.ORCID_DISCOVERY_URL,
+            scope=settings.get("scope") or "openid",
             idp="Orcid",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -25,14 +25,13 @@ class RASOauth2Client(Oauth2ClientBase):
     as openid connect is supported under oauth2
     """
 
+    DISCOVERY_URL = "https://sts.nih.gov/.well-known/openid-configuration"
+
     def __init__(self, settings, logger, HTTP_PROXY=None):
         super(RASOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid ga4gh_passport_v1 email profile",
-            discovery_url=settings.get(
-                "discovery_url", "https://sts.nih.gov/.well-known/openid-configuration"
-            ),
+            scope=settings.get("scope") or "openid ga4gh_passport_v1 email profile",
             idp="ras",
             HTTP_PROXY=HTTP_PROXY,
         )

--- a/fence/resources/openid/synapse_oauth2.py
+++ b/fence/resources/openid/synapse_oauth2.py
@@ -36,10 +36,11 @@ class SynapseOauth2Client(Oauth2ClientBase):
         super(SynapseOauth2Client, self).__init__(
             settings,
             logger,
-            scope="openid",
+            scope=settings.get("scope") or "openid",
             # The default discovery URL on Synapse staging is not serving the correct
             # info. Providing a workaround here for overwriting.
-            discovery_url=config["SYNAPSE_DISCOVERY_URL"]
+            discovery_url=settings.get("discovery_url")
+            or config["SYNAPSE_DISCOVERY_URL"]
             or (config["SYNAPSE_URI"] + "/.well-known/openid-configuration"),
             idp="Synapse",
             HTTP_PROXY=HTTP_PROXY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1243,6 +1243,7 @@ def oauth_test_client_public(client, oauth_client_public):
 @pytest.fixture(scope="session")
 def microsoft_oauth2_client():
     settings = MagicMock()
+    settings.get.return_value = None
     logger = MagicMock()
     client = MicrosoftOauth2Client(settings=settings, logger=logger)
 

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -99,6 +99,7 @@ OPENID_CONNECT:
     redirect_url: '{{BASE_URL}}/login/ras/callback'
     discovery_url: 'https://sts.nih.gov/.well-known/openid-configuration'
   microsoft:
+    discovery_url: ''
     client_id: ''
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/cognito/login/'


### PR DESCRIPTION
… override defaults with configuration


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- scopes and discovery_url are overridable per oauth client in the configuration

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
