### PR TITLE
Fix ENABLED_IDENTITY_PROVIDERS errors

### DIFF
--- a/fence/auth.py
+++ b/fence/auth.py
@@ -194,8 +194,8 @@ def login_required(scope=None):
                 ]
             else:
                 # fall back on "providers"
-                enable_shib = "shibboleth" in config.get(
-                    "ENABLED_IDENTITY_PROVIDERS", {}
+                enable_shib = "shibboleth" in (
+                    config.get("ENABLED_IDENTITY_PROVIDERS") or {}
                 ).get("providers", {})
 
             if enable_shib and "SHIBBOLETH_HEADER" in config:

--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -178,7 +178,7 @@ def get_login_providers_info():
     # default login option
     if config.get("DEFAULT_LOGIN_IDP"):
         default_idp = config["DEFAULT_LOGIN_IDP"]
-    elif "default" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
+    elif "default" in (config.get("ENABLED_IDENTITY_PROVIDERS") or {}):
         # fall back on ENABLED_IDENTITY_PROVIDERS.default
         default_idp = config["ENABLED_IDENTITY_PROVIDERS"]["default"]
     else:
@@ -188,7 +188,7 @@ def get_login_providers_info():
     # other login options
     if config["LOGIN_OPTIONS"]:
         login_options = config["LOGIN_OPTIONS"]
-    elif "providers" in config.get("ENABLED_IDENTITY_PROVIDERS", {}):
+    elif "providers" in (config.get("ENABLED_IDENTITY_PROVIDERS") or {}):
         # fall back on "providers" and convert to "login_options" format
         enabled_providers = config["ENABLED_IDENTITY_PROVIDERS"]["providers"]
         login_options = [

--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -78,8 +78,8 @@ def authorize(*args, **kwargs):
 
     login_url = None
     if not idp:
-        if not config.get("DEFAULT_LOGIN_IDP") and "default" not in config.get(
-            "ENABLED_IDENTITY_PROVIDERS", {}
+        if not config.get("DEFAULT_LOGIN_IDP") and "default" not in (
+            config.get("ENABLED_IDENTITY_PROVIDERS") or {}
         ):
             # fall back on deprecated DEFAULT_LOGIN_URL
             login_url = config.get("DEFAULT_LOGIN_URL")

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -349,7 +349,7 @@ DEFAULT_LOGIN_URL: '{{BASE_URL}}/login/google'
 LOGIN_REDIRECT_WHITELIST: []
 
 ### DEPRECATED and replaced by OPENID_CONNECT + LOGIN_OPTIONS configs
-ENABLED_IDENTITY_PROVIDERS:
+ENABLED_IDENTITY_PROVIDERS: {}
 
 
 # //////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix errors caused by the value for `ENABLED_IDENTITY_PROVIDERS` being None in the default fence config and gen3 community members' fence configs

```
Details: {'message': "argument of type 'NoneType' is not iterable"}
[2022-02-01 17:49:50,479][fence.error_handler][  ERROR] Catch exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/fence/fence/auth.py", line 198, in wrapper
    "ENABLED_IDENTITY_PROVIDERS", {}
AttributeError: 'NoneType' object has no attribute 'get'
```

### Bug Fixes
- Fix ENABLED_IDENTITY_PROVIDERS errors caused by the default config
