### PR TITLE
(PXP-10115): fix test_user_sync_with_visa_sync_job flakiness

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -200,14 +200,14 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1482
+        "line_number": 1513
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/conftest.py",
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1505
+        "line_number": 1536
       }
     ],
     "tests/credentials/google/test_credentials.py": [
@@ -282,5 +282,5 @@
       }
     ]
   },
-  "generated_at": "2022-04-07T17:08:49Z"
+  "generated_at": "2022-06-27T19:35:11Z"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ import time
 import flask
 from datetime import datetime
 import mock
+import uuid
+import random
+import string
 
 from addict import Dict
 from authutils.testing.fixtures import (
@@ -262,6 +265,13 @@ def kid_2():
     return "test-keypair-2"
 
 
+def random_txn():
+    """Return a random txn to use for mocking passports and visas"""
+    random_chars = random.choices(string.ascii_lowercase + string.digits, k=33)
+    random_chars[16] = "."
+    return "".join(random_chars)
+
+
 def get_subjects_to_passports(
     subject_to_encoded_visas=None, passport_exp=None, kid=None, rsa_private_key=None
 ):
@@ -281,8 +291,8 @@ def get_subjects_to_passports(
                     "iat": int(time.time()),
                     "exp": int(time.time()) + 1000,
                     "scope": "openid ga4gh_passport_v1 email profile",
-                    "jti": "jtiajoidasndokmasdl",
-                    "txn": "sapidjspa.asipidja",
+                    "jti": str(uuid.uuid4()),
+                    "txn": random_txn(),
                     "name": "",
                     "ga4gh_visa_v1": {
                         "type": "https://ras.nih.gov/visas/v1",
@@ -308,6 +318,8 @@ def get_subjects_to_passports(
             "kid": kid,
         }
         new_passport = {
+            "jti": str(uuid.uuid4()),
+            "txn": random_txn(),
             "iss": "https://stsstg.nih.gov",
             "sub": subject,
             "iat": int(time.time()),

--- a/tests/dbgap_sync/conftest.py
+++ b/tests/dbgap_sync/conftest.py
@@ -1,6 +1,7 @@
 import os
 import time
 import jwt
+import uuid
 
 from unittest.mock import MagicMock, patch
 from yaml import safe_load as yaml_load
@@ -27,6 +28,8 @@ from fence.models import (
     create_user,
     User,
 )
+
+from tests.conftest import random_txn
 
 logger = get_logger(__name__)
 
@@ -259,9 +262,8 @@ def get_test_encoded_decoded_visa_and_exp(
         "iat": int(time.time()),
         "exp": expires,
         "scope": "openid ga4gh_passport_v1 email profile",
-        "jti": "jtiajoidasndokmasdl"
-        + str(expires),  # expires to make unique from others
-        "txn": "sapidjspa.asipidja" + str(expires),
+        "jti": str(uuid.uuid4()),
+        "txn": random_txn(),
         "name": "",
         "ga4gh_visa_v1": {
             "type": "https://ras.nih.gov/visas/v1",


### PR DESCRIPTION
Jira Ticket: [PXP-10115](https://ctds-planx.atlassian.net/browse/PXP-10115)

Please see ticket comment for more background on what is causing flakiness.

### Bug Fixes
- Fix `test_user_sync_with_visa_sync_job` flakiness by generating unique `jti`, `txn` fields for every mocked passport
