### PR TITLE
Adds bucket parameter to upload_file

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -292,6 +292,21 @@ class BlankIndex(object):
                 raise InternalError(
                     "fence not configured with data upload bucket; can't create signed URL"
                 )
+            if 'bucket' in flask.request.json:
+                bucket = flask.request.json['bucket']
+                s3_buckets = get_value(
+                    flask.current_app.config,
+                    "S3_BUCKETS",
+                    InternalError("buckets not configured"),
+                )
+                if bucket not in s3_buckets:
+                    raise InternalError(
+                        "passed bucket {} not found in configuration {}".format(
+                            bucket, s3_buckets
+                        )
+                    )
+                self.logger.debug("Using bucket name passed in request {}".format(bucket))
+
             s3_url = "s3://{}/{}/{}".format(bucket, self.guid, file_name)
             url = S3IndexedFileLocation(s3_url).get_signed_url("upload", expires_in)
 


### PR DESCRIPTION
### New Features

* Adds  optional parameter `bucket`, to allow caller to specify destination bucket, a member of fence_config.S3_BUCKETS
* Defaults to DATA_UPLOAD_BUCKET


### Breaking Changes

`None`

### Bug Fixes

`None`

### Improvements

`None`

### Dependency updates

`None`

### Deployment changes

Paired with corresponding PR to gen3sdk https://github.com/uc-cdis/gen3sdk-python/pull/158