### PR TITLE
PXP-10361 Allow specifying the upload bucket

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -239,7 +239,7 @@ def _check_azure_storage(app):
             logger.debug(err)
 
 
-def _check_aws_creds_and_region(app):
+def _check_buckets_aws_creds_and_region(app):
     """
     Function to ensure that all s3_buckets have a valid credential.
     Additionally, if there is no region it will produce a warning
@@ -248,6 +248,7 @@ def _check_aws_creds_and_region(app):
     buckets = config.get("S3_BUCKETS") or {}
     aws_creds = config.get("AWS_CREDENTIALS") or {}
 
+    # check that AWS creds and regions are configured
     for bucket_name, bucket_details in buckets.items():
         cred = bucket_details.get("cred")
         region = bucket_details.get("region")
@@ -301,6 +302,15 @@ def _check_aws_creds_and_region(app):
                 cred
             )
         )
+
+    # check that all the configured buckets are in `S3_BUCKETS`
+    bucket_names = config["ALLOWED_DATA_UPLOAD_BUCKETS"] or []
+    if config["DATA_UPLOAD_BUCKET"]:
+        bucket_names.append(config["DATA_UPLOAD_BUCKET"])
+    for bucket_name in bucket_names:
+        assert (
+            bucket_name in buckets
+        ), f"Data upload bucket '{bucket_name}' is not configured in 'S3_BUCKETS'"
 
 
 def app_config(
@@ -358,7 +368,7 @@ def app_config(
     _setup_oidc_clients(app)
 
     with app.app_context():
-        _check_aws_creds_and_region(app)
+        _check_buckets_aws_creds_and_region(app)
         _check_azure_storage(app)
 
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -308,9 +308,10 @@ def _check_buckets_aws_creds_and_region(app):
     if config["DATA_UPLOAD_BUCKET"]:
         bucket_names.append(config["DATA_UPLOAD_BUCKET"])
     for bucket_name in bucket_names:
-        assert (
-            bucket_name in buckets
-        ), f"Data upload bucket '{bucket_name}' is not configured in 'S3_BUCKETS'"
+        if bucket_name not in buckets:
+            logger.warning(
+                f"Data upload bucket '{bucket_name}' is not configured in 'S3_BUCKETS'"
+            )
 
 
 def app_config(

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -306,11 +306,11 @@ def upload_file(file_id):
         s3_buckets = get_value(
             flask.current_app.config,
             "S3_BUCKETS",
-            InternalError("buckets not configured"),
+            InternalError("S3_BUCKETS not configured"),
         )
         if bucket not in s3_buckets:
             logger.debug(f"Bucket '{bucket}' not found in S3_BUCKETS config")
-            raise Unauthorized("permission denied for bucket")
+            raise InternalError("permission denied for bucket")
 
     result = get_signed_url_for_file(
         "upload", file_id, file_name=file_name, bucket=bucket

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -10,8 +10,7 @@ from fence.blueprints.data.indexd import (
     IndexedFile,
     get_signed_url_for_file,
 )
-from fence.config import config
-from fence.errors import Forbidden, InternalError, UserError, Forbidden, Unauthorized
+from fence.errors import Forbidden, InternalError, UserError, Unauthorized
 from fence.resources.audit.utils import enable_audit_logging
 from fence.utils import get_valid_expiration
 
@@ -185,7 +184,7 @@ def upload_data_file():
         )
         if bucket not in s3_buckets:
             logger.debug(f"Bucket '{bucket}' not in ALLOWED_DATA_UPLOAD_BUCKETS config")
-            raise InternalError("permission denied for bucket")
+            raise Forbidden(f"Uploading to bucket '{bucket}' is not allowed")
 
     response = {
         "guid": blank_index.guid,
@@ -319,7 +318,7 @@ def upload_file(file_id):
         )
         if bucket not in s3_buckets:
             logger.debug(f"Bucket '{bucket}' not in ALLOWED_DATA_UPLOAD_BUCKETS config")
-            raise InternalError("permission denied for bucket")
+            raise Forbidden(f"Uploading to bucket '{bucket}' is not allowed")
 
     result = get_signed_url_for_file(
         "upload", file_id, file_name=file_name, bucket=bucket

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -177,6 +177,15 @@ def upload_data_file():
 
     protocol = params["protocol"] if "protocol" in params else None
     bucket = params.get("bucket")
+    if bucket:
+        s3_buckets = get_value(
+            flask.current_app.config,
+            "ALLOWED_DATA_UPLOAD_BUCKETS",
+            InternalError("ALLOWED_DATA_UPLOAD_BUCKETS not configured"),
+        )
+        if bucket not in s3_buckets:
+            logger.debug(f"Bucket '{bucket}' not in ALLOWED_DATA_UPLOAD_BUCKETS config")
+            raise InternalError("permission denied for bucket")
 
     response = {
         "guid": blank_index.guid,
@@ -305,11 +314,11 @@ def upload_file(file_id):
     if bucket:
         s3_buckets = get_value(
             flask.current_app.config,
-            "S3_BUCKETS",
-            InternalError("S3_BUCKETS not configured"),
+            "ALLOWED_DATA_UPLOAD_BUCKETS",
+            InternalError("ALLOWED_DATA_UPLOAD_BUCKETS not configured"),
         )
         if bucket not in s3_buckets:
-            logger.debug(f"Bucket '{bucket}' not found in S3_BUCKETS config")
+            logger.debug(f"Bucket '{bucket}' not in ALLOWED_DATA_UPLOAD_BUCKETS config")
             raise InternalError("permission denied for bucket")
 
     result = get_signed_url_for_file(

--- a/fence/blueprints/data/blueprint.py
+++ b/fence/blueprints/data/blueprint.py
@@ -198,6 +198,9 @@ def upload_data_file():
 def init_multipart_upload():
     """
     Initialize a multipart upload request
+
+    NOTE This endpoint does not currently accept a `bucket` parameter like
+    `POST /upload` and `GET /upload/<GUID>` do.
     """
     params = flask.request.get_json()
     if not params:

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -292,6 +292,21 @@ class BlankIndex(object):
                 raise InternalError(
                     "fence not configured with data upload bucket; can't create signed URL"
                 )
+            if 'bucket' in flask.request.json:
+                bucket = flask.request.json['bucket']
+                s3_buckets = get_value(
+                    flask.current_app.config,
+                    "S3_BUCKETS",
+                    InternalError("buckets not configured"),
+                )
+                if bucket not in s3_buckets:
+                    raise InternalError(
+                        "passed bucket {} not found in configuration {}".format(
+                            bucket, s3_buckets
+                        )
+                    )
+                self.logger.debug("Using bucket name passed in request {}".format(bucket))
+
             s3_url = "s3://{}/{}/{}".format(bucket, self.guid, file_name)
             url = S3IndexedFileLocation(s3_url).get_signed_url("upload", expires_in)
 

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -887,7 +887,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
         s3_buckets = get_value(
             flask.current_app.config,
             "S3_BUCKETS",
-            InternalError("buckets not configured"),
+            InternalError("S3_BUCKETS not configured"),
         )
         for bucket in s3_buckets:
             if re.match("^" + bucket + "$", self.parsed_url.netloc):
@@ -903,7 +903,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
         cls, bucket_name, aws_creds, expires_in, boto=None
     ):
         s3_buckets = get_value(
-            config, "S3_BUCKETS", InternalError("buckets not configured")
+            config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
         )
         if len(aws_creds) == 0 and len(s3_buckets) == 0:
             raise InternalError("no bucket is configured")
@@ -913,7 +913,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
         bucket_cred = s3_buckets.get(bucket_name)
         if bucket_cred is None:
             logger.debug(f"Bucket '{bucket_name}' not found in S3_BUCKETS config")
-            raise Unauthorized("permission denied for bucket")
+            raise InternalError("permission denied for bucket")
 
         cred_key = get_value(
             bucket_cred, "cred", InternalError("credential of that bucket is missing")
@@ -942,7 +942,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
 
     def get_bucket_region(self):
         s3_buckets = get_value(
-            config, "S3_BUCKETS", InternalError("buckets not configured")
+            config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
         )
         if len(s3_buckets) == 0:
             return None
@@ -969,7 +969,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
             config, "AWS_CREDENTIALS", InternalError("credentials not configured")
         )
         s3_buckets = get_value(
-            config, "S3_BUCKETS", InternalError("buckets not configured")
+            config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
         )
 
         bucket_name = self.bucket_name()

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -633,10 +633,13 @@ S3_BUCKETS: {}
 #     region: 'us-east-1'
 #     role-arn: 'arn:aws:iam::role1'
 
-# `DATA_UPLOAD_BUCKET` specifies an S3 bucket to which data files are uploaded,
-# using the `/data/upload` endpoint. This must be one of the first keys under
-# `S3_BUCKETS` (since these are the buckets fence has credentials for).
-DATA_UPLOAD_BUCKET: 'bucket1'
+# Names of the S3 buckets to which data files can be uploaded. They should be
+# configured in `S3_BUCKETS`.
+ALLOWED_DATA_UPLOAD_BUCKETS: []
+
+# Default S3 bucket to which data files are uploaded, when the bucket is not specified
+# by the uploader. It should be configured in `S3_BUCKETS`.
+DATA_UPLOAD_BUCKET: ''
 
 # //////////////////////////////////////////////////////////////////////////////////////
 # PROXY

--- a/fence/resources/audit/client.py
+++ b/fence/resources/audit/client.py
@@ -38,7 +38,7 @@ class AuditServiceClient:
 
         if self.push_type == "aws_sqs":
             aws_sqs_config = config["PUSH_AUDIT_LOGS_CONFIG"]["aws_sqs_config"]
-            # we know the cred is in AWS_CREDENTIALS (see `_check_aws_creds_and_region`)
+            # we know the cred is in AWS_CREDENTIALS (see `_check_buckets_aws_creds_and_region`)
             aws_creds = (
                 config.get("AWS_CREDENTIALS", {})[aws_sqs_config["aws_cred"]]
                 if "aws_cred" in aws_sqs_config

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -633,7 +633,15 @@ paths:
           in: query
           description: >-
             the requested file name in the cloud bucket you will upload to.
-            if not provided, will use the GUID/file_id
+            If not provided, will use the GUID/file_id
+          schema:
+            type: string
+        - name: bucket
+          required: false
+          in: query
+          description: >-
+            the requested bucket to upload to.
+            If not provided, defaults to the configured DATA_UPLOAD_BUCKET.
           schema:
             type: string
       responses:
@@ -668,7 +676,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestUploadBlank'
+              $ref: '#/components/schemas/InitMultipartUpload'
       responses:
         201:
           description: successful operation; created new blank record in indexd and uploadId for multipart upload
@@ -1649,6 +1657,33 @@ components:
             user: generic user access
   schemas:
     RequestUploadBlank:
+      type: object
+      required:
+      properties:
+        file_name:
+          type: string
+          required: true
+          description: the file name to use for this upload
+        bucket:
+          type: string
+          required: true
+          description: the requested bucket to upload to. If not provided,
+          defaults to the configured DATA_UPLOAD_BUCKET.
+        expires_in:
+          type: integer
+          description: optional integer specifying the presigned URL lifetime
+        authz:
+          type: array
+          items:
+            type: string
+          description: requested authorization resources to be set on the
+            resulting indexed record. You must have proper authorization to set this
+      example:
+        file_name: "my_file.bam"
+        bucket: "bucket1"
+        expires_in: 1200
+        authz: ["/programs/A"]
+    InitMultipartUpload:
       type: object
       required:
       properties:

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1667,8 +1667,9 @@ components:
         bucket:
           type: string
           required: true
-          description: the requested bucket to upload to. If not provided,
-          defaults to the configured DATA_UPLOAD_BUCKET.
+          description: >-
+            the requested bucket to upload to. If not provided,
+            defaults to the configured DATA_UPLOAD_BUCKET.
         expires_in:
           type: integer
           description: optional integer specifying the presigned URL lifetime

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -1668,8 +1668,8 @@ components:
           type: string
           required: true
           description: >-
-            the requested bucket to upload to. If not provided,
-            defaults to the configured DATA_UPLOAD_BUCKET.
+            the requested bucket to upload to.
+            If not provided, defaults to the configured DATA_UPLOAD_BUCKET.
         expires_in:
           type: integer
           description: optional integer specifying the presigned URL lifetime

--- a/tests/data/test_blank_index.py
+++ b/tests/data/test_blank_index.py
@@ -16,30 +16,36 @@ from fence.blueprints.data.indexd import BlankIndex, flask
 from fence.errors import InternalError
 
 
+class MockResponse:
+    """
+    Mock response for requests lib
+    """
+
+    def __init__(self, data, status_code=200):
+        """
+        Set up mock response
+        """
+        self.data = data
+        self.status_code = status_code
+
+    def json(self):
+        """
+        Mock json() call
+        """
+        return self.data
+
+    def text(self):
+        """
+        Mock text() call
+        """
+        return self.data
+
+
 def test_blank_index_upload(app, client, auth_client, encoded_creds_jwt, user_client):
     """
     test BlankIndex upload
     POST /data/upload
     """
-
-    class MockResponse:
-        """
-        Mock response for requests lib
-        """
-
-        def __init__(self, data, status_code=200):
-            """
-            Set up mock response
-            """
-            self.data = data
-            self.status_code = status_code
-
-        def json(self):
-            """
-            Mock json() call
-            """
-            return self.data
-
     data_requests_mocker = mock.patch(
         "fence.blueprints.data.indexd.requests", new_callable=mock.Mock
     )
@@ -84,25 +90,6 @@ def test_blank_index_upload_authz(
     """
     Same test as above, except request a specific "authz" for the new record
     """
-
-    class MockResponse:
-        """
-        Mock response for requests lib
-        """
-
-        def __init__(self, data, status_code=200):
-            """
-            Set up mock response
-            """
-            self.data = data
-            self.status_code = status_code
-
-        def json(self):
-            """
-            Mock json() call
-            """
-            return self.data
-
     data_requests_mocker = mock.patch(
         "fence.blueprints.data.indexd.requests", new_callable=mock.Mock
     )
@@ -130,10 +117,6 @@ def test_blank_index_upload_authz(
         response = client.post("/data/upload", headers=headers, data=data)
         indexd_url = app.config.get("INDEXD") or app.config.get("BASE_URL") + "/index"
         endpoint = indexd_url + "/index/blank/"
-        indexd_auth = (
-            config["INDEXD_USERNAME"],
-            config["INDEXD_PASSWORD"],
-        )
         data_requests.post.assert_called_once_with(
             endpoint,
             auth=None,
@@ -145,31 +128,69 @@ def test_blank_index_upload_authz(
         assert "url" in response.json
 
 
+@pytest.mark.parametrize(
+    "bucket,expect_success",
+    [[None, True], ["bucket1", True], ["not-a-configured-bucket", False]],
+)
+def test_blank_index_upload_bucket(
+    app, client, auth_client, encoded_creds_jwt, user_client, bucket, expect_success
+):
+    """
+    Same test as above, except request a specific bucket to upload the file to
+    """
+    data_requests_mocker = mock.patch(
+        "fence.blueprints.data.indexd.requests", new_callable=mock.Mock
+    )
+    arborist_requests_mocker = mock.patch(
+        "gen3authz.client.arborist.client.httpx.Client.request", new_callable=mock.Mock
+    )
+    with data_requests_mocker as data_requests, arborist_requests_mocker as arborist_requests:
+        data_requests.post.return_value = MockResponse(
+            {
+                "did": str(uuid.uuid4()),
+                "rev": str(uuid.uuid4())[:8],
+                "baseid": str(uuid.uuid4()),
+            }
+        )
+        data_requests.post.return_value.status_code = 200
+        arborist_requests.return_value = MockResponse({"auth": True})
+        arborist_requests.return_value.status_code = 200
+        headers = {
+            "Authorization": "Bearer " + encoded_creds_jwt.jwt,
+            "Content-Type": "application/json",
+        }
+        file_name = "asdf"
+        data = json.dumps({"file_name": file_name, "bucket": bucket})
+        response = client.post("/data/upload", headers=headers, data=data)
+        indexd_url = app.config.get("INDEXD") or app.config.get("BASE_URL") + "/index"
+        endpoint = indexd_url + "/index/blank/"
+        indexd_auth = (
+            config["INDEXD_USERNAME"],
+            config["INDEXD_PASSWORD"],
+        )
+        data_requests.post.assert_called_once_with(
+            endpoint,
+            auth=indexd_auth,
+            json={"file_name": file_name, "uploader": user_client.username},
+            headers={},
+        )
+        if expect_success:
+            assert response.status_code == 201, response
+            assert "guid" in response.json
+            assert "url" in response.json
+            bucket_in_url = bucket if bucket else config["DATA_UPLOAD_BUCKET"]
+            assert bucket_in_url in response.json["url"]
+        else:
+            # "permission denied for bucket"
+            assert response.status_code == 401, response
+
+
 def test_blank_index_upload_missing_indexd_credentials(
     app, client, auth_client, encoded_creds_jwt, user_client
 ):
     """
     test BlankIndex upload with missing indexd credentials
     """
-
-    class MockResponse:
-        """
-        Mock response for requests lib
-        """
-
-        def __init__(self, data, status_code=200):
-            """
-            Set up mock response
-            """
-            self.data = data
-            self.status_code = status_code
-
-        def json(self):
-            """
-            Mock json() call
-            """
-            return self.data
-
     data_requests_mocker = mock.patch(
         "fence.blueprints.data.indexd.requests", new_callable=mock.Mock
     )
@@ -229,30 +250,6 @@ def test_blank_index_upload_missing_indexd_credentials_unable_to_load_json(
         def json(self):
             """
             Mock json() call
-            """
-            return self.data
-
-    class MockResponse:
-        """
-        Mock response for requests lib
-        """
-
-        def __init__(self, data, status_code=200):
-            """
-            Set up mock response
-            """
-            self.data = data
-            self.status_code = status_code
-
-        def json(self):
-            """
-            Mock json() call
-            """
-            raise ValueError("unable to get json")
-
-        def text(self):
-            """
-            Mock text() call
             """
             return self.data
 

--- a/tests/data/test_blank_index.py
+++ b/tests/data/test_blank_index.py
@@ -79,7 +79,7 @@ def test_blank_index_upload(app, client, auth_client, encoded_creds_jwt, user_cl
             json={"file_name": file_name, "uploader": user_client.username},
             headers={},
         )
-        assert response.status_code == 201, response
+        assert response.status_code == 201, response.json
         assert "guid" in response.json
         assert "url" in response.json
 
@@ -123,14 +123,20 @@ def test_blank_index_upload_authz(
             json={"file_name": file_name, "uploader": None, "authz": authz},
             headers={"Authorization": "bearer " + encoded_creds_jwt.jwt},
         )
-        assert response.status_code == 201, response
+        assert response.status_code == 201, response.json
         assert "guid" in response.json
         assert "url" in response.json
 
 
 @pytest.mark.parametrize(
     "bucket,expect_success",
-    [[None, True], ["bucket1", True], ["not-a-configured-bucket", False]],
+    [
+        [None, True],
+        ["bucket2", True],
+        # bucket3 is in S3_BUCKETS but not in ALLOWED_DATA_UPLOAD_BUCKETS
+        ["bucket3", False],
+        ["not-a-configured-bucket", False],
+    ],
 )
 def test_blank_index_upload_bucket(
     app, client, auth_client, encoded_creds_jwt, user_client, bucket, expect_success
@@ -175,7 +181,7 @@ def test_blank_index_upload_bucket(
             headers={},
         )
         if expect_success:
-            assert response.status_code == 201, response
+            assert response.status_code == 201, response.json
             assert "guid" in response.json
             assert "url" in response.json
             bucket_in_url = bucket if bucket else config["DATA_UPLOAD_BUCKET"]

--- a/tests/data/test_blank_index.py
+++ b/tests/data/test_blank_index.py
@@ -182,7 +182,7 @@ def test_blank_index_upload_bucket(
             assert bucket_in_url in response.json["url"]
         else:
             # "permission denied for bucket"
-            assert response.status_code == 401, response
+            assert response.status_code == 500, response
 
 
 def test_blank_index_upload_missing_indexd_credentials(

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -390,7 +390,7 @@ def test_indexd_upload_file_bucket(
         assert bucket_in_url in response.json.get("url")
     else:
         # "permission denied for bucket"
-        assert response.status_code == 401, response
+        assert response.status_code == 500, response
 
 
 @pytest.mark.parametrize("indexd_client", ["nonexistent_guid"], indirect=True)

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -347,7 +347,13 @@ def test_indexd_upload_file_filename_key_error(
 @pytest.mark.parametrize("indexd_client", ["s3"], indirect=True)
 @pytest.mark.parametrize(
     "bucket,expect_success",
-    [[None, True], ["bucket1", True], ["not-a-configured-bucket", False]],
+    [
+        [None, True],
+        ["bucket2", True],
+        # bucket3 is in S3_BUCKETS but not in ALLOWED_DATA_UPLOAD_BUCKETS
+        ["bucket3", False],
+        ["not-a-configured-bucket", False],
+    ],
 )
 def test_indexd_upload_file_bucket(
     client,

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -480,6 +480,10 @@ S3_BUCKETS:
     region: 'us-east-1'
     role-arn: 'arn:aws:iam::707767160287:role/bucket_reader_writer_to_cdistest-presigned-url_role'
 
+ALLOWED_DATA_UPLOAD_BUCKETS: ['bucket2']
+
+DATA_UPLOAD_BUCKET: 'bucket1'
+
 # //////////////////////////////////////////////////////////////////////////////////////
 # PROXY
 #   - Optional: If the api is behind firewall that needs to set http proxy

--- a/tests/test-fence-config.yaml
+++ b/tests/test-fence-config.yaml
@@ -480,7 +480,7 @@ S3_BUCKETS:
     region: 'us-east-1'
     role-arn: 'arn:aws:iam::707767160287:role/bucket_reader_writer_to_cdistest-presigned-url_role'
 
-ALLOWED_DATA_UPLOAD_BUCKETS: ['bucket2']
+ALLOWED_DATA_UPLOAD_BUCKETS: ['bucket3']
 
 DATA_UPLOAD_BUCKET: 'bucket1'
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -85,7 +85,7 @@ def test_app_config():
             "patch_name": "fence.resources.storage.StorageManager.__init__",
             "return_value": None,
         },
-        {"patch_name": "fence._check_aws_creds_and_region"},
+        {"patch_name": "fence._check_buckets_aws_creds_and_region"},
         {
             "patch_name": "fence.BlobServiceClient.from_connection_string",
             "return_value": fake_blob_service_client,


### PR DESCRIPTION
Fixes and closes #1048

### New Features
- Allow specifying the bucket to upload to (endpoints `/data/upload` and `/data/upload/<GUID>`)

### Deployment changes
- Configure the `ALLOWED_DATA_UPLOAD_BUCKETS` setting to allow users to upload to buckets other than `DATA_UPLOAD_BUCKET`

### Improvements
- Return a 500 error instead of a 401 error when an S3 bucket is not configured properly