### PR TITLE
PXP-10250 PXP-10268 OIDC clients expliration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -321,7 +321,7 @@
         "filename": "tests/scripting/test_fence-create.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 221
+        "line_number": 265
       }
     ],
     "tests/test-fence-config.yaml": [
@@ -334,5 +334,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T16:56:51Z"
+  "generated_at": "2022-11-10T20:09:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -321,7 +321,7 @@
         "filename": "tests/scripting/test_fence-create.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 263
+        "line_number": 264
       }
     ],
     "tests/test-fence-config.yaml": [
@@ -334,5 +334,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T21:32:37Z"
+  "generated_at": "2022-11-10T22:37:01Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -321,7 +321,7 @@
         "filename": "tests/scripting/test_fence-create.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 265
+        "line_number": 263
       }
     ],
     "tests/test-fence-config.yaml": [
@@ -334,5 +334,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-10T20:09:05Z"
+  "generated_at": "2022-11-10T21:32:37Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "fence/utils.py",
         "hashed_secret": "8318df9ecda039deac9868adf1944a29a95c7114",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 112
       }
     ],
     "migrations/versions/e4c7b0ab68d3_create_tables.py": [
@@ -334,5 +334,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-12T15:25:33Z"
+  "generated_at": "2022-11-10T16:56:51Z"
 }

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The OAuth2 Client Credentials flow is used for machine-to-machine communication 
 As a Gen3 commons administrator, if you want to create an OAuth client for a client credentials flow:
 
 ```bash
-fence-create client-create --client CLIENT_NAME --grant-types client_credentials
+fence-create client-create --client CLIENT_NAME --grant-types client_credentials (--expires-in 30)
 ```
 
 This command will return a client ID and client secret, which you can then use to obtain an access token:
@@ -530,11 +530,11 @@ This command will return a client ID and client secret, which you can then use t
 curl --request POST https://FENCE_URL/oauth2/token?grant_type=client_credentials -d scope="openid user" --user CLIENT_ID:CLIENT_SECRET
 ```
 
+The optional `--expires-in` parameter allows specifying the number of days until this client expires. The recommendation is to rotate these credentials at least once a year.
+
 NOTE: In Gen3, you can grant specific access to a client the same way you would to a user. See the [user.yaml guide](https://github.com/uc-cdis/fence/blob/master/docs/user.yaml_guide.md) for more details.
 
 NOTE: Client credentials tokens are not linked to a user. They are not supported by all Gen3 endpoints.
-
-NOTE: The recommendation is to rotate these credentials at least once a year. Credentials expiration is not enforced at the moment but may be in the future.
 
 #### Modify OAuth Client
 

--- a/README.md
+++ b/README.md
@@ -491,8 +491,10 @@ WARNING: fence-create directly modifies the database in some cases and may circu
 As a Gen3 commons administrator, if you want to create an oauth client that skips user consent step, use the following command:
 
 ```bash
-fence-create client-create --client CLIENT_NAME --urls OAUTH_REDIRECT_URL --username USERNAME --auto-approve
+fence-create client-create --client CLIENT_NAME --urls OAUTH_REDIRECT_URL --username USERNAME --auto-approve (--expires-in 30)
 ```
+
+The optional `--expires-in` parameter allows specifying the number of days until this client expires.
 
 #### Register an Implicit Oauth Client
 
@@ -530,7 +532,7 @@ This command will return a client ID and client secret, which you can then use t
 curl --request POST https://FENCE_URL/oauth2/token?grant_type=client_credentials -d scope="openid user" --user CLIENT_ID:CLIENT_SECRET
 ```
 
-The optional `--expires-in` parameter allows specifying the number of days until this client expires. The recommendation is to rotate these credentials at least once a year.
+The optional `--expires-in` parameter allows specifying the number of *days* until this client expires. The recommendation is to rotate credentials with the `client_credentials` grant at least once a year.
 
 NOTE: In Gen3, you can grant specific access to a client the same way you would to a user. See the [user.yaml guide](https://github.com/uc-cdis/fence/blob/master/docs/user.yaml_guide.md) for more details.
 
@@ -547,7 +549,7 @@ allowed here too.
 
 Add `--append` argument to add new callback urls or allowed scopes to existing client (instead of replacing them) using `--append --urls` or `--append --allowed-scopes`
 ```bash
-fence-create client-modify --client CLIENT_NAME --urls http://localhost/api/v0/new/oauth2/authorize --append
+fence-create client-modify --client CLIENT_NAME --urls http://localhost/api/v0/new/oauth2/authorize --append (--expires-in 30)
 ```
 
 #### Delete OAuth Client
@@ -556,6 +558,19 @@ fence-create client-modify --client CLIENT_NAME --urls http://localhost/api/v0/n
 fence-create client-delete --client CLIENT_NAME
 ```
 That command should output the result of the deletion attempt.
+
+#### Delete Expired OAuth Clients
+
+```bash
+fence-create client-delete-expired
+```
+
+To post a warning in Slack about any clients that are about to expire:
+
+```bash
+fence-create client-delete-expired --slack-webhook <url> --warning-days <default 7: only post about clients expiring in under 7 days>
+```
+
 
 #### List OAuth Clients
 

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ That command should output the result of the deletion attempt.
 fence-create client-delete-expired
 ```
 
-To post a warning in Slack about any clients that are about to expire:
+To post a warning in Slack about any clients that expired or are about to expire:
 
 ```bash
 fence-create client-delete-expired --slack-webhook <url> --warning-days <default 7: only post about clients expiring in under 7 days>

--- a/bin/fence_create.py
+++ b/bin/fence_create.py
@@ -153,7 +153,7 @@ def parse_arguments():
     client_delete_expired = subparsers.add_parser("client-delete-expired")
     client_delete_expired.add_argument(
         "--slack-webhook",
-        help="Slack webhook to post warnings when clients are about to expire",
+        help="Slack webhook to post warnings when clients expired or are about to expire",
         required=False,
     )
     client_delete_expired.add_argument(

--- a/bin/fence_create.py
+++ b/bin/fence_create.py
@@ -16,6 +16,7 @@ from fence.scripting.fence_create import (
     create_google_logging_bucket,
     create_sample_data,
     delete_client_action,
+    delete_expired_clients_action,
     delete_users,
     delete_expired_google_access,
     cleanup_expired_ga4gh_information,
@@ -148,6 +149,8 @@ def parse_arguments():
 
     client_delete = subparsers.add_parser("client-delete")
     client_delete.add_argument("--client", required=True)
+
+    client_delete_expired = subparsers.add_parser("client-delete-expired")
 
     user_delete = subparsers.add_parser("user-delete")
     user_delete.add_argument("--users", required=True, nargs="+")
@@ -461,6 +464,8 @@ def main():
         delete_client_action(DB, args.client)
     elif args.action == "client-list":
         list_client_action(DB)
+    elif args.action == "client-delete-expired":
+        delete_expired_clients_action(DB)
     elif args.action == "user-delete":
         delete_users(DB, args.users)
     elif args.action == "expired-service-account-delete":

--- a/bin/fence_create.py
+++ b/bin/fence_create.py
@@ -151,6 +151,17 @@ def parse_arguments():
     client_delete.add_argument("--client", required=True)
 
     client_delete_expired = subparsers.add_parser("client-delete-expired")
+    client_delete_expired.add_argument(
+        "--slack-webhook",
+        help="Slack webhook to post warnings when clients are about to expire",
+        required=False,
+    )
+    client_delete_expired.add_argument(
+        "--warning-days",
+        help="how many days before a client expires should we post a warning on Slack",
+        required=False,
+        default=7,
+    )
 
     user_delete = subparsers.add_parser("user-delete")
     user_delete.add_argument("--users", required=True, nargs="+")
@@ -465,7 +476,7 @@ def main():
     elif args.action == "client-list":
         list_client_action(DB)
     elif args.action == "client-delete-expired":
-        delete_expired_clients_action(DB)
+        delete_expired_clients_action(DB, args.slack_webhook, args.warning_days)
     elif args.action == "user-delete":
         delete_users(DB, args.users)
     elif args.action == "expired-service-account-delete":

--- a/bin/fence_create.py
+++ b/bin/fence_create.py
@@ -103,6 +103,9 @@ def parse_arguments():
     client_create.add_argument(
         "--allowed-scopes", help="which scopes are allowed for this client", nargs="+"
     )
+    client_create.add_argument(
+        "--expires-in", help="days until this client expires", required=False
+    )
 
     client_modify = subparsers.add_parser("client-modify")
     client_modify.add_argument("--client", required=True)
@@ -136,6 +139,9 @@ def parse_arguments():
         help="which ABAC policies are granted to this client; if given, "
         "previous policies will be revoked",
         nargs="*",
+    )
+    client_modify.add_argument(
+        "--expires-in", help="days until this client expires", required=False
     )
 
     client_list = subparsers.add_parser("client-list")
@@ -433,6 +439,7 @@ def main():
             arborist=arborist,
             policies=args.policies,
             allowed_scopes=args.allowed_scopes,
+            expires_in=args.expires_in,
         )
     elif args.action == "client-modify":
         modify_client_action(
@@ -448,6 +455,7 @@ def main():
             policies=args.policies,
             allowed_scopes=args.allowed_scopes,
             append=args.append,
+            expires_in=args.expires_in,
         )
     elif args.action == "client-delete":
         delete_client_action(DB, args.client)

--- a/fence/models.py
+++ b/fence/models.py
@@ -146,10 +146,7 @@ def get_client_expires_at(expires_in, grant_types):
 
         # for backwards compatibility, 0 means no expiration
         if expires_in != 0:
-            expires_in_secs = expires_in * 24 * 60 * 60  # days to seconds
-            expires_at = (
-                datetime.utcnow() + timedelta(seconds=expires_in_secs)
-            ).timestamp()
+            expires_at = (datetime.utcnow() + timedelta(days=expires_in)).timestamp()
 
     if "client_credentials" in grant_types.split("\n"):
         if not expires_in or expires_in <= 0 or expires_in > 366:

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -84,6 +84,7 @@ def modify_client_action(
     policies=None,
     allowed_scopes=None,
     append=False,
+    expires_in=None,  # TODO
 ):
     driver = SQLAlchemyDriver(DB)
     with driver.session as s:
@@ -126,7 +127,13 @@ def modify_client_action(
 
 
 def create_client_action(
-    DB, username=None, client=None, urls=None, auto_approve=False, **kwargs
+    DB,
+    username=None,
+    client=None,
+    urls=None,
+    auto_approve=False,
+    expires_in=None,
+    **kwargs,
 ):
     print("\nSave these credentials! Fence will not save the unhashed client secret.")
     res = create_client(
@@ -135,6 +142,7 @@ def create_client_action(
         urls=urls,
         name=client,
         auto_approve=auto_approve,
+        expires_in=expires_in,  # todo check if this is read as an int. and check if we use half a day
         **kwargs,
     )
     print("client id, client secret:")

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -142,7 +142,7 @@ def create_client_action(
         urls=urls,
         name=client,
         auto_approve=auto_approve,
-        expires_in=expires_in,  # todo check if this is read as an int. and check if we use half a day
+        expires_in=expires_in,
         **kwargs,
     )
     print("client id, client secret:")
@@ -178,7 +178,7 @@ def delete_client_action(DB, client_name):
                 current_session.delete(client)
             current_session.commit()
 
-        logger.info("Client {} deleted".format(client_name))
+        logger.info("Client '{}' deleted".format(client_name))
     except Exception as e:
         logger.error(str(e))
 

--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -259,6 +259,7 @@ def delete_expired_clients_action(DB, slack_webhook=None, warning_days=None):
             for e in post_msgs:
                 logger.info(e)
             if slack_webhook:  # post a warning on Slack
+                logger.info("Posting to Slack...")
                 payload = {
                     "attachments": [
                         {

--- a/fence/utils.py
+++ b/fence/utils.py
@@ -47,6 +47,7 @@ def create_client(
     arborist=None,
     policies=None,
     allowed_scopes=None,
+    expires_in=None,
 ):
     client_id = random_str(40)
     if arborist is not None:
@@ -97,6 +98,7 @@ def create_client(
             grant_types=grant_types,
             is_confidential=confidential,
             token_endpoint_auth_method=auth_method,
+            expires_in=expires_in,
         )
         s.add(client)
         s.commit()

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 import mock
 
@@ -223,7 +223,7 @@ def test_create_client_with_expiration(db_session, grant_type, expires_in):
     """
     client_name = "client_with_expiration"
     grant_types = [grant_type]
-    now = datetime.utcnow().timestamp()
+    now = datetime.utcnow()
 
     def to_test():
         saved_client = db_session.query(Client).filter_by(name=client_name).first()
@@ -231,10 +231,10 @@ def test_create_client_with_expiration(db_session, grant_type, expires_in):
         if not expires_in:
             assert saved_client.expires_at == 0
         else:
-            expected_expires_at = now + expires_in * 24 * 60 * 60
-            # allow up to 4 seconds variation to account for test execution
-            assert saved_client.expires_at <= expected_expires_at + 4000
-            assert saved_client.expires_at >= expected_expires_at - 4000
+            expected_expires_at = (now + timedelta(days=expires_in)).timestamp()
+            # allow up to 1 second variation to account for test execution
+            assert saved_client.expires_at <= expected_expires_at + 1
+            assert saved_client.expires_at >= expected_expires_at - 1
 
     if expires_in in [-10, "not-valid"]:
         with pytest.raises(UserError):
@@ -1688,7 +1688,7 @@ def test_modify_client_expiration(db_session, expires_in, existing_expiration):
     original_expires_at = client.expires_at
 
     # modify the client's expiration
-    now = datetime.utcnow().timestamp()
+    now = datetime.utcnow()
     if expires_in in [-10, "not-valid"]:
         with pytest.raises(UserError):
             modify_client_action(
@@ -1701,7 +1701,7 @@ def test_modify_client_expiration(db_session, expires_in, existing_expiration):
         if not expires_in:
             assert client.expires_at == original_expires_at
         else:
-            expected_expires_at = now + expires_in * 24 * 60 * 60
-            # allow up to 4 seconds variation to account for test execution
-            assert client.expires_at <= expected_expires_at + 4000
-            assert client.expires_at >= expected_expires_at - 4000
+            expected_expires_at = (now + timedelta(days=expires_in)).timestamp()
+            # allow up to 1 second variation to account for test execution
+            assert client.expires_at <= expected_expires_at + 1
+            assert client.expires_at >= expected_expires_at - 1


### PR DESCRIPTION
Jira Tickets: [PXP-10250](https://ctds-planx.atlassian.net/browse/PXP-10250) and [PXP-10268](https://ctds-planx.atlassian.net/browse/PXP-10268)

Goes with https://github.com/uc-cdis/cloud-automation/pull/2075

### New Features
- Add `--expires-in` parameter to the `fence-create` `client-create` and `client-modify` commands to specify the number of days in which in a client expires
- Add the `fence-create client-delete-expired` command to remove expired OIDC clients and optionally post warnings in Slack
