### PR TITLE
Fix fence-create google-bucket-create

### DIFF
--- a/fence/scripting/fence_create.py
+++ b/fence/scripting/fence_create.py
@@ -1467,7 +1467,12 @@ def _create_or_update_google_bucket_and_db(
             project_db_entry = (
                 db_session.query(Project).filter_by(auth_id=project_auth_id).first()
             )
-            if project_db_entry:
+            if not project_db_entry:
+                logger.info(
+                    "No project with auth_id {} found. No linking "
+                    "occured.".format(project_auth_id)
+                )
+            else:
                 project_linkage = (
                     db_session.query(ProjectToBucket)
                     .filter_by(
@@ -1487,26 +1492,23 @@ def _create_or_update_google_bucket_and_db(
                     "Successfully linked project with auth_id {} "
                     "to the bucket.".format(project_auth_id)
                 )
-            else:
-                logger.info(
-                    "No project with auth_id {} found. No linking "
-                    "occured.".format(project_auth_id)
-                )
 
-            # Add StorageAccess if it doesn't exist for the project
-            storage_access = (
-                db_session.query(StorageAccess)
-                .filter_by(
-                    project_id=project_db_entry.id, provider_id=google_cloud_provider.id
+                # Add StorageAccess if it doesn't exist for the project
+                storage_access = (
+                    db_session.query(StorageAccess)
+                    .filter_by(
+                        project_id=project_db_entry.id,
+                        provider_id=google_cloud_provider.id,
+                    )
+                    .first()
                 )
-                .first()
-            )
-            if not storage_access:
-                storage_access = StorageAccess(
-                    project_id=project_db_entry.id, provider_id=google_cloud_provider.id
-                )
-                db_session.add(storage_access)
-                db_session.commit()
+                if not storage_access:
+                    storage_access = StorageAccess(
+                        project_id=project_db_entry.id,
+                        provider_id=google_cloud_provider.id,
+                    )
+                    db_session.add(storage_access)
+                    db_session.commit()
 
     return bucket_db_entry
 


### PR DESCRIPTION
```
[2023-03-08 22:20:53,211][fence.scripting.fence_create][   INFO] No project with auth_id QA found. No linking occured.
Traceback (most recent call last):
  File "/usr/local/bin/fence-create", line 6, in <module>
    sys.exit(main())
  File "/fence/bin/fence_create.py", line 536, in main
    create_or_update_google_bucket(
  File "/fence/fence/scripting/fence_create.py", line 1360, in create_or_update_google_bucket
    bucket_db_entry = _create_or_update_google_bucket_and_db(
  File "/fence/fence/scripting/fence_create.py", line 1505, in _create_or_update_google_bucket_and_db
    project_id=project_db_entry.id, provider_id=google_cloud_provider.id
AttributeError: 'NoneType' object has no attribute 'id'
```

### Bug Fixes
- Fix `fence-create google-bucket-create` when the project does not exist
