### PR TITLE
allow setting INDEXD_PASSWORD via env var

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -675,6 +675,7 @@ INDEXD: null
 # this is the username which fence uses to make authenticated requests to indexd
 INDEXD_USERNAME: 'fence'
 # this is the password which fence uses to make authenticated requests to indexd
+# can also be set via env var INDEXD_PASSWORD
 INDEXD_PASSWORD: ''
 
 # //////////////////////////////////////////////////////////////////////////////////////

--- a/fence/config.py
+++ b/fence/config.py
@@ -67,7 +67,7 @@ class FenceConfig(Config):
             )
             self["INDEXD_PASSWORD"] = os.environ["INDEXD_PASSWORD"]
         else:
-            logger.info(
+            logger.debug(
                 "Environment variable 'INDEXD_PASSWORD' empty or not set: using 'INDEXD_PASSWORD' field from config file"
             )
 

--- a/fence/config.py
+++ b/fence/config.py
@@ -60,6 +60,17 @@ class FenceConfig(Config):
                 "Environment variable 'DB' empty or not set: using 'DB' field from config file"
             )
 
+        # allow setting INDEXD_PASSWORD via env var
+        if os.environ.get("INDEXD_PASSWORD"):
+            logger.info(
+                "Found environment variable 'INDEXD_PASSWORD': overriding 'INDEXD_PASSWORD' field from config file"
+            )
+            self["INDEXD_PASSWORD"] = os.environ["INDEXD_PASSWORD"]
+        else:
+            logger.info(
+                "Environment variable 'INDEXD_PASSWORD' empty or not set: using 'INDEXD_PASSWORD' field from config file"
+            )
+
         if "ROOT_URL" not in self._configs and "BASE_URL" in self._configs:
             url = urllib.parse.urlparse(self._configs["BASE_URL"])
             self._configs["ROOT_URL"] = "{}://{}".format(url.scheme, url.netloc)


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- Allow setting `INDEXD_PASSWORD` via environment variable. 

<!-- This section should only contain important things devops should know when updating service versions. -->
