### PR TITLE
PXP-10920 Support deleting data without GUID prefix

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -425,6 +425,11 @@ class IndexedFile(object):
                         "indexd: {}".format(url + self.file_id)
                     )
                     raise InternalError("URLs and metadata not found")
+
+                # indexd can resolve GUIDs without prefix, but cannot perform other operations
+                # (such as delete) without the prefix, so make sure `file_id` is the whole GUID
+                self.file_id = json_response["did"]
+
                 return res.json()
             except Exception as e:
                 logger.error(

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -428,7 +428,9 @@ class IndexedFile(object):
 
                 # indexd can resolve GUIDs without prefix, but cannot perform other operations
                 # (such as delete) without the prefix, so make sure `file_id` is the whole GUID
-                self.file_id = json_response["did"]
+                real_guid = json_response.get("did")
+                if real_guid and real_guid != self.file_id:
+                    self.file_id = real_guid
 
                 return res.json()
             except Exception as e:
@@ -719,6 +721,9 @@ class IndexedFile(object):
         # it's possible that for some reason (something else modified the record in the
         # meantime) that the revision doesn't match, which would lead to error here
         if response.status_code != 200:
+            logger.error(
+                f"Unable to delete indexd record '{self.file_id}': {response.status_code} - {response.text}"
+            )
             return (flask.jsonify(response.json()), 500)
         return ("", 204)
 

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -721,9 +721,7 @@ class IndexedFile(object):
         # it's possible that for some reason (something else modified the record in the
         # meantime) that the revision doesn't match, which would lead to error here
         if response.status_code != 200:
-            logger.error(
-                f"Unable to delete indexd record '{self.file_id}': {response.status_code} - {response.text}"
-            )
+            logger.error(f"Unable to delete indexd record '{self.file_id}': {response}")
             return (flask.jsonify(response.json()), 500)
         return ("", 204)
 

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1976,6 +1976,11 @@ class UserSyncer(object):
                         )
                     )
                     continue
+                self.logger.debug(
+                    "updating client `{}` (found {} client IDs)".format(
+                        client_name, len(clients)
+                    )
+                )
                 # there may be more than 1 client with this name if credentials are being rotated,
                 # so we grant access to each client ID
                 for client in clients:


### PR DESCRIPTION
Jira Ticket: [PXP-10920](https://ctds-planx.atlassian.net/browse/PXP-10920)

If we hit the Fence `DELETE /data/<GUID>` endpoint with a GUID without prefix, the indexd record is fetched successfully (GUID resolution without prefix) and the file is deleted from the bucket, but fence fails to delete the indexd record itself (the deletion endpoint does not accept a GUID without prefix).

### Improvements
- The `DELETE /data/<GUID>` endpoint now supports resolving and deleting a GUID without its prefix


[PXP-10920]: https://ctds-planx.atlassian.net/browse/PXP-10920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ