### PR TITLE
Fix SQLAlchemyDriver warning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -189,7 +189,7 @@
         "filename": "fence/resources/google/utils.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 133
       }
     ],
     "fence/utils.py": [
@@ -198,7 +198,7 @@
         "filename": "fence/utils.py",
         "hashed_secret": "8318df9ecda039deac9868adf1944a29a95c7114",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 128
       }
     ],
     "migrations/versions/a04a70296688_non_unique_client_name.py": [
@@ -216,7 +216,7 @@
         "filename": "migrations/versions/e4c7b0ab68d3_create_tables.py",
         "hashed_secret": "adb1fcd33b07abf9b6a064745759accea5cb341f",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 21
       }
     ],
     "migrations/versions/ea7e1b843f82_optional_client_redirect_uri.py": [
@@ -355,7 +355,7 @@
         "filename": "tests/scripting/test_fence-create.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 301
+        "line_number": 300
       }
     ],
     "tests/test-fence-config.yaml": [
@@ -368,5 +368,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-22T17:22:09Z"
+  "generated_at": "2023-05-10T22:20:13Z"
 }

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -12,7 +12,6 @@ from authutils.oauth2.client import OAuthClient
 from cdislogging import get_logger
 from gen3authz.client.arborist.client import ArboristClient
 from flask_wtf.csrf import validate_csrf
-from userdatamodel.driver import SQLAlchemyDriver
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from azure.storage.blob import BlobServiceClient
 from azure.core.exceptions import ResourceNotFoundError
@@ -52,7 +51,7 @@ from fence.resources.openid.ras_oauth2 import RASOauth2Client
 from fence.resources.storage import StorageManager
 from fence.resources.user.user_session import UserSessionInterface
 from fence.error_handler import get_error_response
-from fence.utils import random_str
+from fence.utils import get_SQLAlchemyDriver
 import fence.blueprints.admin
 import fence.blueprints.data
 import fence.blueprints.login
@@ -107,12 +106,7 @@ def app_init(
 
 def app_sessions(app):
     app.url_map.strict_slashes = False
-
-    # override userdatamodel's `setup_db` function which creates tables
-    # and runs database migrations, because Alembic handles that now.
-    # TODO move userdatamodel code to Fence and remove dependencies to it
-    SQLAlchemyDriver.setup_db = lambda _: None
-    app.db = SQLAlchemyDriver(config["DB"])
+    app.db = get_SQLAlchemyDriver(config["DB"])
 
     # app.db.Session is from SQLAlchemyDriver and uses
     # SQLAlchemy's sessionmaker. Using scoped_session here ensures

--- a/fence/resources/google/utils.py
+++ b/fence/resources/google/utils.py
@@ -14,7 +14,6 @@ from cirrus.google_cloud.utils import (
     get_valid_service_account_id_for_user,
 )
 
-from userdatamodel.driver import SQLAlchemyDriver
 from userdatamodel.user import GoogleProxyGroup, User, AccessPrivilege
 
 from fence.auth import current_token
@@ -33,6 +32,7 @@ from fence.models import (
 )
 from fence.resources.google import STORAGE_ACCESS_PROVIDER_NAME
 from fence.errors import NotSupported, NotFound
+from fence.utils import get_SQLAlchemyDriver
 
 from cdislogging import get_logger
 
@@ -967,6 +967,6 @@ def is_google_managed_service_account(service_account_email):
 
 def get_db_session(db=None):
     if db:
-        return SQLAlchemyDriver(db).Session()
+        return get_SQLAlchemyDriver(db).Session()
     else:
         return current_app.scoped_session()

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -24,7 +24,6 @@ from gen3users.validation import validate_user_yaml
 from paramiko.proxy import ProxyCommand
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func
-from userdatamodel.driver import SQLAlchemyDriver
 
 from fence.config import config
 from fence.models import (
@@ -42,6 +41,7 @@ from fence.resources.storage import StorageManager
 from fence.resources.google.access_utils import bulk_update_google_groups
 from fence.sync import utils
 from fence.sync.passport_sync.ras_sync import RASVisa
+from fence.utils import get_SQLAlchemyDriver
 
 
 def _format_policy_id(path, privilege):
@@ -336,7 +336,7 @@ class UserSyncer(object):
         self.dbGaP = dbGaP
         self.parse_consent_code = dbGaP[0].get("parse_consent_code", True)
         self.session = db_session
-        self.driver = SQLAlchemyDriver(DB)
+        self.driver = get_SQLAlchemyDriver(DB)
         self.project_mapping = project_mapping or {}
         self._projects = dict()
         self._created_roles = set()

--- a/migrations/versions/e4c7b0ab68d3_create_tables.py
+++ b/migrations/versions/e4c7b0ab68d3_create_tables.py
@@ -14,9 +14,8 @@ import logging
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-from userdatamodel.driver import SQLAlchemyDriver
-
 from bin.old_migration_script import migrate
+from fence.utils import get_SQLAlchemyDriver
 
 # revision identifiers, used by Alembic.
 revision = "e4c7b0ab68d3"
@@ -45,7 +44,7 @@ def upgrade():
         logger.info(
             "Found existing tables: this is not a new instance of Fence. Running the old migration script... Note that future migrations will be run using Alembic."
         )
-        driver = SQLAlchemyDriver(context.config.get_main_option("sqlalchemy.url"))
+        driver = get_SQLAlchemyDriver(context.config.get_main_option("sqlalchemy.url"))
         migrate(driver)
         return
     else:

--- a/tests/dbgap_sync/conftest.py
+++ b/tests/dbgap_sync/conftest.py
@@ -12,7 +12,6 @@ from cdisutilstest.code.storage_client_mock import get_client, StorageClientMock
 import pytest
 from userdatamodel import Base
 from userdatamodel.models import *
-from userdatamodel.driver import SQLAlchemyDriver
 from gen3authz.client.arborist.client import ArboristClient
 
 from fence.config import config

--- a/tests/scripting/conftest.py
+++ b/tests/scripting/conftest.py
@@ -22,7 +22,9 @@ def patch_driver(db, monkeypatch):
     Change the database driver in ``fence.scripting.fence_create`` to use the
     one from the test fixtures.
     """
-    monkeypatch.setattr("fence.scripting.fence_create.SQLAlchemyDriver", lambda _: db)
+    monkeypatch.setattr(
+        "fence.scripting.fence_create.get_SQLAlchemyDriver", lambda _: db
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/scripting/test_fence-create.py
+++ b/tests/scripting/test_fence-create.py
@@ -8,12 +8,11 @@ import pytest
 import cirrus
 from cirrus.google_cloud.errors import GoogleAuthError
 from userdatamodel.models import Group
-from userdatamodel.driver import SQLAlchemyDriver
 
 from fence.config import config
 from fence.errors import UserError
 from fence.jwt.validate import validate_jwt
-from fence.utils import create_client
+from fence.utils import create_client, get_SQLAlchemyDriver
 from fence.models import (
     AccessPrivilege,
     Project,
@@ -64,7 +63,7 @@ def mock_arborist(mock_arborist_requests):
 
 
 def delete_client_if_exists(db, client_name, username=None):
-    driver = SQLAlchemyDriver(db)
+    driver = get_SQLAlchemyDriver(db)
     with driver.session as session:
         clients = session.query(Client).filter_by(name=client_name).all()
         if clients:


### PR DESCRIPTION
```
ERROR:SQLAlchemyDriver:Fail to setup database tables, continue anyways
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/userdatamodel/driver.py", line 28, in __init__
    self.setup_db()
  File "/usr/local/lib/python3.9/site-packages/userdatamodel/driver.py", line 36, in setup_db
    self.pre_migrate()
  File "/usr/local/lib/python3.9/site-packages/userdatamodel/driver.py", line 88, in pre_migrate
    if not self.engine.dialect.has_table(
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/dialects/postgresql/base.py", line 3593, in has_table
    self._ensure_has_table_connection(connection)
  File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 342, in _ensure_has_table_connection
    raise exc.ArgumentError(
sqlalchemy.exc.ArgumentError: The argument passed to Dialect.has_table() should be a <class 'sqlalchemy.engine.base.Connection'>, got <class 'sqlalchemy.engine.base.Engine'>. Additionally, the Dialect.has_table() method is for internal dialect use only; please use ``inspect(some_engine).has_table(<tablename>>)`` for public API use.
```

### Improvements
- Fix `SQLAlchemyDriver` warning when running `fence-create` commands
