### PR TITLE
Switching the `and`  with `,` in user scope description

### DIFF
--- a/fence/blueprints/oauth2.py
+++ b/fence/blueprints/oauth2.py
@@ -269,7 +269,7 @@ def _get_auth_response_for_prompts(prompts, grant, user, client, scope):
             idp_names.append(idp_name)
 
         resource_description = [
-            SCOPE_DESCRIPTION[s].format(idp_names=" and ".join(idp_names))
+            SCOPE_DESCRIPTION[s].format(idp_names=", ".join(idp_names))
             for s in shown_scopes
         ]
 


### PR DESCRIPTION
Jira Ticket: [BRH-495](https://ctds-planx.atlassian.net/browse/BRH-495)

### Improvements
* Replacing the `and`  with `,` in user scope description to improve readability 

[BRH-495]: https://ctds-planx.atlassian.net/browse/BRH-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ