### PR TITLE
feat(DCF-1446): Assign MFA policy on login

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -315,6 +315,15 @@
         "line_number": 48
       }
     ],
+    "tests/login/test_idp_oauth2.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/login/test_idp_oauth2.py",
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "tests/migrations/test_a04a70296688.py": [
       {
         "type": "Hex High Entropy String",
@@ -368,5 +377,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-15T16:30:09Z"
+  "generated_at": "2023-07-26T23:47:35Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,6 +133,15 @@
         "line_number": 7
       }
     ],
+    "docs/fence_multifactor_authentication_guide.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/fence_multifactor_authentication_guide.md",
+        "hashed_secret": "0f674908b6342fcf2a9842d04699cb008d57d399",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
     "fence/blueprints/storage_creds/google.py": [
       {
         "type": "Private Key",
@@ -377,5 +386,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-26T23:47:35Z"
+  "generated_at": "2023-08-08T00:23:28Z"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ services:
 addons:
   postgresql: "13"
   apt:
-      packages:
-        - postgresql-13
+    sources:
+      - sourceline: deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main
+          13
+        key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    packages:
+      - postgresql-13
 install:
   - pip install --upgrade pip
   - pip install poetry

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ sudo: false
 
 cache: pip
 
-addons:
-  postgresql: "9.6"
+services:
+    - postgresql
 
 install:
   - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: jammy
 python:
   - "3.9"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ cache: pip
 services:
     - postgresql
 
+addons:
+  postgresql: "13"
+  apt:
+      packages:
+        - postgresql-13
 install:
   - pip install --upgrade pip
   - pip install poetry

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,15 @@ addons:
         key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     packages:
       - postgresql-13
+
+before_install:
+  # Copy custom configs from the repo because PG-13 isn't set up to run like
+  # it normally does on Travis out of the box.
+  # Source: https://github.com/NCI-GDC/psqlgraph/blob/94f315db2c039217752cba85d9c63988f2059317/.travis.yml
+  - sudo cp travis/postgresql.conf /etc/postgresql/13/main/postgresql.conf
+  - sudo cp travis/pg_hba.conf /etc/postgresql/13/main/pg_hba.conf
+  - sudo pg_ctlcluster 13 main restart
+
 install:
   - pip install --upgrade pip
   - pip install poetry

--- a/docs/fence_multifactor_authentication_guide.md
+++ b/docs/fence_multifactor_authentication_guide.md
@@ -3,7 +3,7 @@
 Fence is capable of using token claims from IdPs to identify when multifactor authentication (MFA) was used during the authentication process.
 
 ## File Level Enforcement
-To restrict access to files to user who've authenticated with MFA, the following resource *MUST* be present for indexd record:
+To restrict access to files to user who've authenticated with MFA, the following resource *MUST* be present in the indexd record's `authz`:
 `/multifactor_auth`
 
 And the following configs must be updated:

--- a/docs/fence_multifactor_authentication_guide.md
+++ b/docs/fence_multifactor_authentication_guide.md
@@ -1,0 +1,64 @@
+# Fence Multifactor Authentication Guide
+
+Fence is capable of using token claims from IdPs to identify when multifactor authentication (MFA) was used during the authentication process.
+
+## File Level Enforcement
+To restrict access to files to user who've authenticated with MFA, the following resource *MUST* be present for indexd record:
+`/multifactor_auth`
+
+And the following configs must be updated:
+- fence-config.yaml
+- user.yaml
+
+### fence-config.yaml changes
+
+MFA claim checking is configured on a per-IdP basis. For a given IdP, define the name of the claim in the id_token and is possible values that indicate MFA. If the id_token claim value matches at least one value in the configured multifactor_auth_claim_info.values, then "/multifactor_auth" resource will be assigned to the user.
+
+For example, Okta may issue the following id_token when MFA is used:
+```
+{
+  "amr": ["otp", "pwd"],
+  "aud": "6joRGIzNCaJfdCPzRjlh",
+  "auth_time": 1311280970,
+  "exp": 1311280970,
+  "iat": 1311280970,
+  "idp": "00ok1u7AsAkrwdZL3z0g3",
+  "iss": "https://$"
+  "jti": "Tlenfse93dgkaksginv",
+  "sub": "00uk1u7AsAk6dZL3z0g3",
+  "ver": 1
+}
+```
+
+And fence-config.yaml is configured as follows:
+```
+OPENID_CONNECT:
+  okta:
+    client_id: 'redacted'
+    client_secret: 'redacted'
+    multifactor_auth_claim_info:
+      claim: 'amr'
+      values: [  "mfa", "otp", "sms" ]
+```
+
+Then fence will assign the "/multifactor_auth" resource to the user in Arborist.
+
+### user.yaml changes
+The `mfa_policy` policy and `multifactor_auth` resource must be added to user.yaml so the appropriate policy and resource are created in arborist when usersync runs.
+
+NOTE: The role_ids provided here are an example and should be changed to the appropriate arborist roles for the commons.
+
+Add the following to the `resources` section:
+```yaml
+  - name: multifactor_auth
+```
+
+Add the following the `policies` section:
+```yaml
+- id: mfa_policy
+  role_ids:
+   - read-storage
+   - read
+   resource_paths:
+   - /multifactor_auth
+```

--- a/fence/blueprints/link.py
+++ b/fence/blueprints/link.py
@@ -274,7 +274,7 @@ class GoogleCallback(Resource):
         code = flask.request.args.get("code")
 
         if not config.get("MOCK_GOOGLE_AUTH", False):
-            google_response = flask.current_app.google_client.get_user_id(code)
+            google_response = flask.current_app.google_client.get_auth_info(code)
             email = google_response.get("email")
         else:
             # if we're mocking google auth, mock response to include the email

--- a/fence/blueprints/login/base.py
+++ b/fence/blueprints/login/base.py
@@ -1,4 +1,5 @@
 import flask
+from cdislogging import get_logger
 from flask_restful import Resource
 from urllib.parse import urlparse, urlencode, parse_qsl
 
@@ -6,6 +7,8 @@ from fence.auth import login_user
 from fence.blueprints.login.redirect import validate_redirect
 from fence.config import config
 from fence.errors import UserError
+
+logger = get_logger(__name__)
 
 
 class DefaultOAuth2Login(Resource):
@@ -63,6 +66,7 @@ class DefaultOAuth2Callback(Resource):
         username_field="email",
         email_field="email",
         id_from_idp_field="sub",
+        app=flask.current_app,
     ):
         """
         Construct a resource for a login callback endpoint
@@ -84,6 +88,10 @@ class DefaultOAuth2Callback(Resource):
         self.username_field = username_field
         self.email_field = email_field
         self.id_from_idp_field = id_from_idp_field
+        self.is_mfa_enabled = "multifactor_auth_claim_info" in config[
+            "OPENID_CONNECT"
+        ].get(self.idp_name, {})
+        self.app = app
 
     def get(self):
         # Check if user granted access
@@ -109,7 +117,7 @@ class DefaultOAuth2Callback(Resource):
             return flask.redirect(location=final_redirect_url)
 
         code = flask.request.args.get("code")
-        result = self.client.get_user_id(code)
+        result = self.client.get_auth_info(code)
         username = result.get(self.username_field)
         if not username:
             raise UserError(
@@ -125,6 +133,22 @@ class DefaultOAuth2Callback(Resource):
 
     def post_login(self, user=None, token_result=None, **kwargs):
         prepare_login_log(self.idp_name)
+        if token_result:
+            username = token_result.get(self.username_field)
+            if self.is_mfa_enabled:
+                if token_result.get("mfa"):
+                    logger.info(f"Adding mfa_policy for {username}")
+                    self.app.arborist.grant_user_policy(
+                        username=username,
+                        policy_id="mfa_policy",
+                    )
+                    return
+                else:
+                    logger.info(f"Revoking mfa_policy for {username}")
+                    self.app.arborist.revoke_user_policy(
+                        username=username,
+                        policy_id="mfa_policy",
+                    )
 
 
 def prepare_login_log(idp_name):

--- a/fence/blueprints/login/ras.py
+++ b/fence/blueprints/login/ras.py
@@ -114,4 +114,4 @@ class RASCallback(DefaultOAuth2Callback):
             user=user, refresh_token=refresh_token, expires=expires + issued_time
         )
 
-        super(RASCallback, self).post_login(id_from_idp=id_from_idp)
+        super(RASCallback, self).post_login(token_result=token_result)

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -112,7 +112,7 @@ OPENID_CONNECT:
     email_field: ''  # optional (default "email"); claims field to get the user email from
     scope: ''  # optional (default "openid")
     multifactor_auth_claim_info: # optional, include if you're using arborist to enforce mfa on a per-file level
-      claim: '' # claims field that indicates mfa, usually the acr or acm claim.
+      claim: '' # claims field that indicates mfa, either the acr or acm claim.
       values: [ "" ] # possible values that indicate mfa was used. At least one value configured here is required to be in the token
   # These Google values must be obtained from Google's Cloud Console
   # Follow: https://developers.google.com/identity/protocols/OpenIDConnect

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -186,7 +186,7 @@ OPENID_CONNECT:
     scope: 'openid email profile ga4gh_passport_v1'
 #    multifactor_auth_claim_info:
 #      claim: 'acr'
-#      values: [ "https://sts.nih.gov/assurance/aal/2", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo" ]
+#      values: [ 'https://stsstg.nih.gov/assurance/aal/2', 'https://stsstg.nih.gov/assurance/ial/1' ]
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -111,6 +111,9 @@ OPENID_CONNECT:
     user_id_field: ''  # optional (default "sub"); claims field to get the user_id from
     email_field: ''  # optional (default "email"); claims field to get the user email from
     scope: ''  # optional (default "openid")
+    multifactor_auth_claim_info: # optional, include if you're using arborist to enforce mfa on a per-file level
+      claim: '' # claims field that indicates mfa, usually the acr or acm claim.
+      values: [ "" ] # possible values that indicate mfa was used. Not all values configured here are required to be in the token
   # These Google values must be obtained from Google's Cloud Console
   # Follow: https://developers.google.com/identity/protocols/OpenIDConnect
   #
@@ -181,6 +184,9 @@ OPENID_CONNECT:
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/ras/callback'
     scope: 'openid email profile ga4gh_passport_v1'
+#    multifactor_auth_claim_info:
+#      claim: 'acr'
+#      values: [ "https://sts.nih.gov/assurance/aal/2", "urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo" ]
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
@@ -207,6 +213,9 @@ OPENID_CONNECT:
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
     mock_default_user: 'test@example.com'
+    #    multifactor_auth_claim_info:
+    #      claim: 'amr'
+    #      values: [ "mfa", "otp", "rsa", "ngcmfa", "wiaormfa" ]
   # For information on configuring an Okta tenant as an OIDC IdP refer to Okta documentation at:
   # https://developer.okta.com/docs/reference/api/oidc/#2-okta-as-the-identity-platform-for-your-app-or-api
   okta:
@@ -215,6 +224,9 @@ OPENID_CONNECT:
     client_secret: ''
     redirect_url: '{{BASE_URL}}/login/okta/login/'
     scope: 'openid email'
+    #    multifactor_auth_claim_info:
+    #      claim: 'amr'
+    #      values: [ "mfa", "otp", "sms" ]
   cognito:
     # You must create a user pool in order to have a discovery url
     discovery_url: 'https://cognito-idp.{REGION}.amazonaws.com/{USER-POOL-ID}/.well-known/openid-configuration'
@@ -241,6 +253,9 @@ OPENID_CONNECT:
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false
     mock_default_user: 'http://cilogon.org/serverT/users/64703'
+    #    multifactor_auth_claim_info:
+    #      claim: 'acr'
+    #      values: [ "https://refeds.org/profile/mfa" ]
   synapse:
     discovery_url: ''
     client_id: ''

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -113,7 +113,7 @@ OPENID_CONNECT:
     scope: ''  # optional (default "openid")
     multifactor_auth_claim_info: # optional, include if you're using arborist to enforce mfa on a per-file level
       claim: '' # claims field that indicates mfa, usually the acr or acm claim.
-      values: [ "" ] # possible values that indicate mfa was used. Not all values configured here are required to be in the token
+      values: [ "" ] # possible values that indicate mfa was used. At least one value configured here is required to be in the token
   # These Google values must be obtained from Google's Cloud Console
   # Follow: https://developers.google.com/identity/protocols/OpenIDConnect
   #

--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -186,7 +186,7 @@ OPENID_CONNECT:
     scope: 'openid email profile ga4gh_passport_v1'
 #    multifactor_auth_claim_info:
 #      claim: 'acr'
-#      values: [ 'https://stsstg.nih.gov/assurance/aal/2', 'https://stsstg.nih.gov/assurance/ial/1' ]
+#      values: [ 'https://stsstg.nih.gov/assurance/aal/2' ]
     # if mock is true, will fake a successful login response for login
     # WARNING: DO NOT ENABLE IN PRODUCTION (for testing purposes only)
     mock: false

--- a/fence/config.py
+++ b/fence/config.py
@@ -143,6 +143,13 @@ class FenceConfig(Config):
                 "Visa parsing on login is enabled but `ENABLE_VISA_UPDATE_CRON` is disabled!"
             )
 
+        for idp in self._configs.get("OPENID_CONNECT", {}).values():
+            mfa_info = idp.get("multifactor_auth_claim_info")
+            if mfa_info and mfa_info["claim"] not in ["amr", "acr"]:
+                logger.warning(
+                    f"multifactor_auth_claim_info is using {mfa_info['claim']}, which is neither AMR or ACR. Unable to determine if a user used MFA. Fence will continue and assume they have not used MFA."
+                )
+
         self._validate_parent_child_studies(self._configs["dbGaP"])
 
     @staticmethod

--- a/fence/config.py
+++ b/fence/config.py
@@ -143,11 +143,11 @@ class FenceConfig(Config):
                 "Visa parsing on login is enabled but `ENABLE_VISA_UPDATE_CRON` is disabled!"
             )
 
-        for idp in self._configs.get("OPENID_CONNECT", {}).values():
+        for idp_id, idp in self._configs.get("OPENID_CONNECT", {}).items():
             mfa_info = idp.get("multifactor_auth_claim_info")
             if mfa_info and mfa_info["claim"] not in ["amr", "acr"]:
                 logger.warning(
-                    f"multifactor_auth_claim_info is using {mfa_info['claim']}, which is neither AMR or ACR. Unable to determine if a user used MFA. Fence will continue and assume they have not used MFA."
+                    f"IdP '{idp_id}' is using multifactor_auth_claim_info '{mfa_info['claim']}', which is neither AMR or ACR. Unable to determine if a user used MFA. Fence will continue and assume they have not used MFA."
                 )
 
         self._validate_parent_child_studies(self._configs["dbGaP"])

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -31,7 +31,7 @@ class CilogonOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         try:
             token_endpoint = self.get_value_from_discovery_doc(
                 "token_endpoint", "https://cilogon.org/oauth2/token"
@@ -42,7 +42,7 @@ class CilogonOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("sub"):
-                return {"sub": claims["sub"]}
+                return {"sub": claims["sub"], "mfa": self.has_mfa_claim(claims)}
             else:
                 return {"error": "Can't get user's CILogon sub"}
         except Exception as e:

--- a/fence/resources/openid/cilogon_oauth2.py
+++ b/fence/resources/openid/cilogon_oauth2.py
@@ -42,7 +42,7 @@ class CilogonOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("sub"):
-                return {"sub": claims["sub"], "mfa": self.has_mfa_claim(claims)}
+                return {"sub": claims["sub"]}
             else:
                 return {"error": "Can't get user's CILogon sub"}
         except Exception as e:

--- a/fence/resources/openid/cognito_oauth2.py
+++ b/fence/resources/openid/cognito_oauth2.py
@@ -37,7 +37,7 @@ class CognitoOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         """
         Exchange code for tokens, get email from id token claims.
         Return dict with "email" field on success OR "error" field on error.
@@ -53,7 +53,11 @@ class CognitoOauth2Client(Oauth2ClientBase):
                 claims.get("email_verified")
                 or self.settings.get("assume_emails_verified")
             ):
-                return {"email": claims["email"], "sub": claims.get("sub")}
+                return {
+                    "email": claims["email"],
+                    "sub": claims.get("sub"),
+                    "mfa": self.has_mfa_claim(claims),
+                }
             elif claims.get("email"):
                 return {"error": "Email is not verified"}
             else:

--- a/fence/resources/openid/cognito_oauth2.py
+++ b/fence/resources/openid/cognito_oauth2.py
@@ -53,11 +53,7 @@ class CognitoOauth2Client(Oauth2ClientBase):
                 claims.get("email_verified")
                 or self.settings.get("assume_emails_verified")
             ):
-                return {
-                    "email": claims["email"],
-                    "sub": claims.get("sub"),
-                    "mfa": self.has_mfa_claim(claims),
-                }
+                return {"email": claims["email"], "sub": claims.get("sub")}
             elif claims.get("email"):
                 return {"error": "Email is not verified"}
             else:

--- a/fence/resources/openid/google_oauth2.py
+++ b/fence/resources/openid/google_oauth2.py
@@ -50,11 +50,7 @@ class GoogleOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email") and claims.get("email_verified"):
-                return {
-                    "email": claims["email"],
-                    "sub": claims.get("sub"),
-                    "mfa": self.has_mfa_claim(claims),
-                }
+                return {"email": claims["email"], "sub": claims.get("sub")}
             elif claims.get("email"):
                 return {"error": "Email is not verified"}
             else:

--- a/fence/resources/openid/google_oauth2.py
+++ b/fence/resources/openid/google_oauth2.py
@@ -34,7 +34,7 @@ class GoogleOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         """
         Get user id
         """
@@ -50,7 +50,11 @@ class GoogleOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email") and claims.get("email_verified"):
-                return {"email": claims["email"], "sub": claims.get("sub")}
+                return {
+                    "email": claims["email"],
+                    "sub": claims.get("sub"),
+                    "mfa": self.has_mfa_claim(claims),
+                }
             elif claims.get("email"):
                 return {"error": "Email is not verified"}
             else:

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -154,7 +154,7 @@ class Oauth2ClientBase(object):
         )
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         """
         Exchange code for tokens, get user_id from id token claims.
         Return dictionary with necessary field(s) for successfully logged in
@@ -169,7 +169,10 @@ class Oauth2ClientBase(object):
             if claims.get(user_id_field):
                 if user_id_field == "email" and not claims.get("email_verified"):
                     return {"error": "Email is not verified"}
-                return {user_id_field: claims[user_id_field]}
+                return {
+                    user_id_field: claims[user_id_field],
+                    "mfa": self.has_mfa_claim(claims),
+                }
             else:
                 self.logger.exception(
                     f"Can't get {user_id_field} from claims: {claims}"
@@ -219,6 +222,33 @@ class Oauth2ClientBase(object):
         )
 
         return token_response
+
+    def has_mfa_claim(self, decoded_id_token):
+        """
+        Determines if the claim denoting whether multifactor authentication was used is contained within the claims
+        of the provided id_token.
+
+        Parameters:
+        - decoded_id_token (dict): The decoded id_token, a dict of claims -> claim values.
+
+        """
+        mfa_claim_info = self.settings.get("multifactor_auth_claim_info")
+        if not mfa_claim_info:
+            return False
+        claim_name = mfa_claim_info.get("claim")
+        mfa_values = mfa_claim_info.get("values")
+        if not claim_name or not mfa_values:
+            self.logger.warning(
+                f"{self.idp} has a configured multifactor_auth_claim_info with a missing claim name "
+                f"and values. Please check the OPENID_CONNECT settings for {self.idp} in the fence "
+                f"config yaml."
+            )
+            return False
+        mfa_claims = decoded_id_token.get(claim_name).split(" ")
+        self.logger.info(
+            f"Comparing token's {claim_name} claims: {mfa_claims} to mfa values {mfa_values}"
+        )
+        return len(set(mfa_claims) & set(mfa_values)) > 0
 
     def store_refresh_token(self, user, refresh_token, expires, db_session=None):
         """

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -244,7 +244,17 @@ class Oauth2ClientBase(object):
                 f"config yaml."
             )
             return False
-        mfa_claims = decoded_id_token.get(claim_name, "").split(" ")
+        mfa_claims = []
+        if claim_name == "amr":
+            mfa_claims = decoded_id_token.get(claim_name, [])
+        elif claim_name == "acr":
+            mfa_claims = decoded_id_token.get(claim_name, "").split(" ")
+        else:
+            self.logger.error(
+                f"{claim_name} is neither AMR or ACR - cannot determine if MFA was used"
+            )
+            return False
+
         self.logger.info(
             f"Comparing token's {claim_name} claims: {mfa_claims} to mfa values {mfa_values}"
         )

--- a/fence/resources/openid/idp_oauth2.py
+++ b/fence/resources/openid/idp_oauth2.py
@@ -244,7 +244,7 @@ class Oauth2ClientBase(object):
                 f"config yaml."
             )
             return False
-        mfa_claims = decoded_id_token.get(claim_name).split(" ")
+        mfa_claims = decoded_id_token.get(claim_name, "").split(" ")
         self.logger.info(
             f"Comparing token's {claim_name} claims: {mfa_claims} to mfa values {mfa_values}"
         )

--- a/fence/resources/openid/microsoft_oauth2.py
+++ b/fence/resources/openid/microsoft_oauth2.py
@@ -51,11 +51,7 @@ class MicrosoftOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email"):
-                return {
-                    "email": claims["email"],
-                    "sub": claims.get("sub"),
-                    "mfa": self.has_mfa_claim(claims),
-                }
+                return {"email": claims["email"], "sub": claims.get("sub")}
             return {"error": "Can't get user's Microsoft email!"}
         except Exception as exception:
             self.logger.exception("Can't get user info")

--- a/fence/resources/openid/microsoft_oauth2.py
+++ b/fence/resources/openid/microsoft_oauth2.py
@@ -35,7 +35,7 @@ class MicrosoftOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         """
         Get user id given an authorization code
         """
@@ -51,7 +51,11 @@ class MicrosoftOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email"):
-                return {"email": claims["email"], "sub": claims.get("sub")}
+                return {
+                    "email": claims["email"],
+                    "sub": claims.get("sub"),
+                    "mfa": self.has_mfa_claim(claims),
+                }
             return {"error": "Can't get user's Microsoft email!"}
         except Exception as exception:
             self.logger.exception("Can't get user info")

--- a/fence/resources/openid/okta_oauth2.py
+++ b/fence/resources/openid/okta_oauth2.py
@@ -27,7 +27,7 @@ class OktaOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         try:
             token_endpoint = self.get_value_from_discovery_doc(
                 "token_endpoint",
@@ -40,7 +40,11 @@ class OktaOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email"):
-                return {"email": claims["email"], "sub": claims.get("sub")}
+                return {
+                    "email": claims["email"],
+                    "sub": claims.get("sub"),
+                    "mfa": self.has_mfa_claim(claims),
+                }
             else:
                 return {"error": "Can't get user's email!"}
         except Exception as e:

--- a/fence/resources/openid/okta_oauth2.py
+++ b/fence/resources/openid/okta_oauth2.py
@@ -40,11 +40,7 @@ class OktaOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("email"):
-                return {
-                    "email": claims["email"],
-                    "sub": claims.get("sub"),
-                    "mfa": self.has_mfa_claim(claims),
-                }
+                return {"email": claims["email"], "sub": claims.get("sub")}
             else:
                 return {"error": "Can't get user's email!"}
         except Exception as e:

--- a/fence/resources/openid/orcid_oauth2.py
+++ b/fence/resources/openid/orcid_oauth2.py
@@ -33,7 +33,7 @@ class OrcidOauth2Client(Oauth2ClientBase):
 
         return uri
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         try:
             token_endpoint = self.get_value_from_discovery_doc(
                 "token_endpoint", "https://orcid.org/oauth/token"
@@ -44,7 +44,11 @@ class OrcidOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("sub"):
-                return {"orcid": claims["sub"], "sub": claims["sub"]}
+                return {
+                    "orcid": claims["sub"],
+                    "sub": claims["sub"],
+                    "mfa": self.has_mfa_claim(claims),
+                }
             else:
                 return {"error": "Can't get user's orcid"}
         except Exception as e:

--- a/fence/resources/openid/orcid_oauth2.py
+++ b/fence/resources/openid/orcid_oauth2.py
@@ -44,11 +44,7 @@ class OrcidOauth2Client(Oauth2ClientBase):
             claims = self.get_jwt_claims_identity(token_endpoint, jwks_endpoint, code)
 
             if claims.get("sub"):
-                return {
-                    "orcid": claims["sub"],
-                    "sub": claims["sub"],
-                    "mfa": self.has_mfa_claim(claims),
-                }
+                return {"orcid": claims["sub"], "sub": claims["sub"]}
             else:
                 return {"error": "Can't get user's orcid"}
         except Exception as e:

--- a/fence/resources/openid/ras_oauth2.py
+++ b/fence/resources/openid/ras_oauth2.py
@@ -117,7 +117,7 @@ class RASOauth2Client(Oauth2ClientBase):
             )
         )
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         err_msg = "Unable to parse UserID from RAS userinfo response"
 
         try:
@@ -189,6 +189,7 @@ class RASOauth2Client(Oauth2ClientBase):
             "username": username,
             "email": userinfo.get("email"),
             "sub": userinfo.get("sub"),
+            "mfa": self.has_mfa_claim(claims),
         }
 
     def map_iss_sub_pair_to_user(

--- a/fence/resources/openid/synapse_oauth2.py
+++ b/fence/resources/openid/synapse_oauth2.py
@@ -98,7 +98,7 @@ class SynapseOauth2Client(Oauth2ClientBase):
 
         return None, None
 
-    def get_user_id(self, code):
+    def get_auth_info(self, code):
         try:
             token_endpoint = self.get_value_from_discovery_doc(
                 "token_endpoint", config["SYNAPSE_URI"] + "/oauth2/token"

--- a/fence/resources/user/user_session.py
+++ b/fence/resources/user/user_session.py
@@ -204,7 +204,7 @@ class UserSessionInterface(SessionInterface):
             except Unauthorized:
                 user = None
 
-            user_sess_id = _get_user_id_from_session(session)
+            user_sess_id = _get_auth_info_from_session(session)
 
             # user_id == '' in session means no login has occured, which is
             # okay if user is hitting with just an access_token
@@ -288,8 +288,8 @@ def _get_valid_access_token(app, session, request):
         return None
 
     # check that the current user is the one from the session and access_token
-    user_sess_id = _get_user_id_from_session(session)
-    token_user_id = _get_user_id_from_access_token(valid_access_token)
+    user_sess_id = _get_auth_info_from_session(session)
+    token_user_id = _get_auth_info_from_access_token(valid_access_token)
 
     if user.id != user_sess_id and user.username != user_sess_id:
         return None
@@ -349,7 +349,7 @@ def _create_access_token_cookie(app, session, response, user):
     return response
 
 
-def _get_user_id_from_session(session):
+def _get_auth_info_from_session(session):
     """
     Get user's identifier from the session. It could be their id or username
     since both are unique.
@@ -365,7 +365,7 @@ def _get_user_id_from_session(session):
     return user_sess_id
 
 
-def _get_user_id_from_access_token(access_token):
+def _get_auth_info_from_access_token(access_token):
     """
     Get user's identifier from the access token claims
     """

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1880,21 +1880,22 @@ class UserSyncer(object):
             idp, {}
         )
         if not is_mfa_enabled:
+            # TODO This should be a diff, not a revocation of all policies.
             self.arborist_client.revoke_all_policies_for_user(username)
             return
 
-        resources = []
+        policies = []
         try:
-            resources = self.arborist_client.list_resources_for_user(username)
+            policies = self.arborist_client.get_user()["policies"]
         except Exception as e:
             self.logger.error(
-                f"Could not retrieve user's resources, revoking all policies anyway. {e}"
+                f"Could not retrieve user's policies, revoking all policies anyway. {e}"
             )
         finally:
             # TODO This should be a diff, not a revocation of all policies.
             self.arborist_client.revoke_all_policies_for_user(username)
 
-        if "/multifactor_auth" in resources:
+        if "mfa_policy" in policies:
             status_code = self.arborist_client.grant_user_policy(username, "mfa_policy")
 
     def _update_authz_in_arborist(

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -2002,8 +2002,7 @@ class UserSyncer(object):
 
             self.arborist_client.create_user_if_not_exist(username)
             if not single_user_sync:
-                # TODO make this smarter - it should do a diff, not revoke all and add
-                self.arborist_client.revoke_all_policies_for_user(username)
+                self._revoke_all_policies_preserve_mfa(user)
 
             # as of 2/11/2022, for single_user_sync, as RAS visa parsing has
             # previously mapped each project to the same set of privileges

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -1868,6 +1868,35 @@ class UserSyncer(object):
 
         return True
 
+    def _revoke_all_policies_preserve_mfa(self, user):
+        """
+        If MFA is enabled for the user's idp, check if they have the /multifactor_auth resource and restore the
+        mfa_policy after revoking all policies.
+        """
+        has_revoked_policies = False
+        try:
+            username = user.username
+            idp = user.identity_provider.name if user.identity_provider else None
+
+            is_mfa_enabled = "multifactor_auth_claim_info" in config[
+                "OPENID_CONNECT"
+            ].get(idp, {})
+            if not is_mfa_enabled:
+                self.arborist_client.revoke_all_policies_for_user(username)
+                return
+
+            resources = self.arborist_client.list_resources_for_user(username)
+            # TODO This should be a diff, not a revocation of all policies.
+            self.arborist_client.revoke_all_policies_for_user(username)
+            has_revoked_policies = True
+            if "/multifactor_auth" in resources:
+                self.arborist_client.grant_user_policy(username, "mfa_policy")
+        except Exception as e:
+            self.logger.error(f"Error attempting to preserve MFA policy. {e}")
+            if not has_revoked_policies:
+                self.logger.error(f"Revoking all policies for user {user.username}")
+                self.arborist_client.revoke_all_policies_for_user(username)
+
     def _update_authz_in_arborist(
         self,
         session,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,7 @@ def no_app_context_no_public_keys():
 @pytest.fixture(scope="function")
 def mock_arborist_requests(request):
     """
-    This fixture returns a function which you call to mock out arborist endopints.
+    This fixture returns a function which you call to mock out arborist endpoints.
     Give it an argument in this format:
         {
             "arborist/health": {

--- a/tests/dbgap_sync/conftest.py
+++ b/tests/dbgap_sync/conftest.py
@@ -99,51 +99,6 @@ def syncer(db_session, request, rsa_private_key, kid):
     storage_credentials = {str(backend_name): {"backend": backend}}
     provider = [{"name": backend_name, "backend": backend}]
 
-    users = [
-        {
-            "username": "TESTUSERB",
-            "is_admin": True,
-            "email": "userA@gmail.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "USER_1",
-            "is_admin": True,
-            "email": "user1@gmail.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "test_user1@gmail.com",
-            "is_admin": False,
-            "email": "test_user1@gmail.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "deleted_user@gmail.com",
-            "is_admin": True,
-            "email": "deleted_user@gmail.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "TESTUSERD",
-            "is_admin": True,
-            "email": "userD@gmail.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "expired_visa_user",
-            "is_admin": False,
-            "email": "expired@expired.com",
-            "idp_name": "ras",
-        },
-        {
-            "username": "invalid_visa_user",
-            "is_admin": False,
-            "email": "invalid@invalid.com",
-            "idp_name": "ras",
-        },
-    ]
-
     projects = [
         {
             "auth_id": "TCGA-PCAWG",
@@ -220,6 +175,8 @@ def syncer(db_session, request, rsa_private_key, kid):
     syncer_obj.arborist_client._user_url = "/user"
 
     syncer_obj._create_arborist_resources = MagicMock()
+
+    syncer_obj.arborist_client.revoke_all_policies_for_user = MagicMock()
 
     for element in provider:
         udm.create_provider(db_session, element["name"], backend=element["backend"])

--- a/tests/dbgap_sync/test_user_sync.py
+++ b/tests/dbgap_sync/test_user_sync.py
@@ -1050,7 +1050,7 @@ def test_revoke_all_policies_preserve_mfa(monkeypatch, db_session, syncer):
     user = User(
         username="mockuser", identity_provider=IdentityProvider(name="mock_idp")
     )
-    syncer.arborist_client.list_resources_for_user.return_value = ["/multifactor_auth"]
+    syncer.arborist_client.get_user.return_value = {"policies": ["mfa_policy"]}
     syncer._revoke_all_policies_preserve_mfa(user)
     syncer.arborist_client.revoke_all_policies_for_user.assert_called_with(
         user.username

--- a/tests/dbgap_sync/test_user_sync.py
+++ b/tests/dbgap_sync/test_user_sync.py
@@ -1,30 +1,23 @@
 import os
 import pytest
-import yaml
 import collections
 
 import asyncio
-import flask
 from unittest.mock import MagicMock, patch
 import mock
+from userdatamodel.user import IdentityProvider
 
 from fence import models
-from fence.resources.google import access_utils
-from fence.resources.google.access_utils import (
-    GoogleUpdateException,
-    bulk_update_google_groups,
-)
-from fence.sync.sync_users import _format_policy_id
+from fence.resources.google.access_utils import GoogleUpdateException
 from fence.config import config
 from fence.job.visa_update_cronjob import Visa_Token_Update
-from tests.dbgap_sync.conftest import LOCAL_YAML_DIR
 
-from tests.utils import TEST_RAS_USERNAME, TEST_RAS_SUB
 from tests.dbgap_sync.conftest import (
     get_test_encoded_decoded_visa_and_exp,
     fake_ras_login,
 )
 from tests.conftest import get_subjects_to_passports
+from fence.models import User
 
 
 def equal_project_access(d1, d2):
@@ -1037,4 +1030,109 @@ def test_user_sync_with_visa_sync_job(
         in setup_info["subjects_to_encoded_visas"][
             setup_info["usernames_to_ras_subjects"][valid_user.username]
         ]
+    )
+
+
+@pytest.mark.parametrize("syncer", ["cleversafe", "google"], indirect=True)
+def test_revoke_all_policies_preserve_mfa(monkeypatch, db_session, syncer):
+    """
+    Test that the mfa_policy is re-granted to the user after revoking all their policies.
+    """
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {
+            "mock_idp": {
+                "multifactor_auth_claim_info": {"claim": "acr", "values": ["mfa"]}
+            }
+        },
+    )
+    user = User(
+        username="mockuser", identity_provider=IdentityProvider(name="mock_idp")
+    )
+    syncer.arborist_client.list_resources_for_user.return_value = ["/multifactor_auth"]
+    syncer._revoke_all_policies_preserve_mfa(user)
+    syncer.arborist_client.revoke_all_policies_for_user.assert_called_with(
+        user.username
+    )
+    syncer.arborist_client.grant_user_policy.assert_called_with(
+        user.username, "mfa_policy"
+    )
+
+
+@pytest.mark.parametrize("syncer", ["cleversafe", "google"], indirect=True)
+def test_revoke_all_policies_preserve_mfa_no_mfa(monkeypatch, db_session, syncer):
+    """
+    Test to ensure the mfa_policy preservation does not occur if the user does not have the mfa resource granted.
+    """
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {
+            "mock_idp": {
+                "multifactor_auth_claim_info": {"claim": "acr", "values": ["mfa"]}
+            }
+        },
+    )
+    user = User(
+        username="mockuser", identity_provider=IdentityProvider(name="mock_idp")
+    )
+    syncer.arborist_client.list_resources_for_user.return_value = [
+        "/programs/phs0001111"
+    ]
+    syncer._revoke_all_policies_preserve_mfa(user)
+    syncer.arborist_client.revoke_all_policies_for_user.assert_called_with(
+        user.username
+    )
+    syncer.arborist_client.grant_user_policy.assert_not_called()
+
+
+@pytest.mark.parametrize("syncer", ["cleversafe", "google"], indirect=True)
+def test_revoke_all_policies_preserve_mfa_no_idp(monkeypatch, db_session, syncer):
+    """
+    Tests for when no IDP is associated with the user
+    """
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {
+            "mock_idp": {
+                "multifactor_auth_claim_info": {"claim": "acr", "values": ["mfa"]}
+            }
+        },
+    )
+    user = User(username="mockuser")
+    syncer._revoke_all_policies_preserve_mfa(user)
+    syncer.arborist_client.revoke_all_policies_for_user.assert_called_with(
+        user.username
+    )
+    syncer.arborist_client.grant_user_policy.assert_not_called()
+    syncer.arborist_client.list_resources_for_user.assert_not_called()
+
+
+@pytest.mark.parametrize("syncer", ["cleversafe", "google"], indirect=True)
+def test_revoke_all_policies_preserve_mfa_ensure_revoke_on_error(
+    monkeypatch, db_session, syncer
+):
+    """
+    Tests that arborist_client.revoke_all_policies is still called when an error occurs
+    """
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {
+            "mock_idp": {
+                "multifactor_auth_claim_info": {"claim": "acr", "values": ["mfa"]}
+            }
+        },
+    )
+    user = User(
+        username="mockuser", identity_provider=IdentityProvider(name="mock_idp")
+    )
+    syncer.arborist_client.list_resources_for_user.side_effect = Exception(
+        "Unknown error"
+    )
+    syncer._revoke_all_policies_preserve_mfa(user)
+    syncer.arborist_client.revoke_all_policies_for_user.assert_called_with(
+        user.username
     )

--- a/tests/link/conftest.py
+++ b/tests/link/conftest.py
@@ -21,7 +21,7 @@ def add_new_g_acnt_mock(db_session):
 @pytest.fixture(scope="function")
 def google_auth_get_user_info_mock():
     mock = MagicMock()
-    patcher = patch("flask.current_app.google_client.get_user_id", mock)
+    patcher = patch("flask.current_app.google_client.get_auth_info", mock)
     patcher.start()
 
     yield mock

--- a/tests/login/test_base.py
+++ b/tests/login/test_base.py
@@ -1,0 +1,56 @@
+from fence.blueprints.login import DefaultOAuth2Callback
+from fence.config import config
+from unittest.mock import MagicMock, patch
+
+
+@patch("fence.blueprints.login.base.prepare_login_log")
+def test_post_login_set_mfa(app, monkeypatch):
+    """
+    Verifies the arborist is called with the mfa_policy if a given token contains the claims found in the
+    configured multifactor_auth_claim_info
+    """
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {
+            "mock_idp": {
+                "multifactor_auth_claim_info": {"claim": "acr", "values": ["mfa"]}
+            }
+        },
+    )
+    callback = DefaultOAuth2Callback(
+        "mock_idp", MagicMock(), username_field="username", app=app
+    )
+
+    app.arborist = MagicMock()
+    token_result = {"username": "lisasimpson", "mfa": True}
+    callback.post_login(token_result=token_result)
+    app.arborist.grant_user_policy.assert_called_with(
+        username=token_result["username"], policy_id="mfa_policy"
+    )
+
+    token_result = {"username": "homersimpson", "mfa": False}
+    callback.post_login(token_result=token_result)
+    app.arborist.revoke_user_policy.assert_called_with(
+        username=token_result["username"], policy_id="mfa_policy"
+    )
+
+
+@patch("fence.blueprints.login.base.prepare_login_log")
+def test_post_login_no_mfa_enabled(app, monkeypatch):
+    """
+    Verifies arborist is not called when there is no multifactor_auth_claim_info defined for the given IDP.
+    """
+    app.arborist = MagicMock()
+    monkeypatch.setitem(
+        config,
+        "OPENID_CONNECT",
+        {"mock_idp": {}},
+    )
+    with app.app_context():
+        callback = DefaultOAuth2Callback(
+            "mock_idp", MagicMock(), username_field="username"
+        )
+        token_result = {"username": "lisasimpson"}
+        callback.post_login(token_result=token_result)
+        app.arborist.revoke_user_policy.assert_not_called()

--- a/tests/login/test_idp_oauth2.py
+++ b/tests/login/test_idp_oauth2.py
@@ -1,0 +1,40 @@
+import pytest
+from cdislogging import get_logger
+
+from fence import Oauth2ClientBase
+
+MOCK_SETTINGS = {
+    "client_id": "client",
+    "client_secret": "hunter2",
+    "redirect_url": "localhost",
+    "multifactor_auth_claim_info": {
+        "claim": "acr",
+        "values": ["mfa", "otp", "duo", "sms", "phonecall"],
+    },
+}
+logger = get_logger(__name__, log_level="debug")
+
+
+@pytest.fixture()
+def oauth_client():
+    return Oauth2ClientBase(settings=MOCK_SETTINGS, idp="mock", logger=logger)
+
+
+def test_has_mfa_claim(oauth_client):
+    has_mfa = oauth_client.has_mfa_claim({"acr": "mfa"})
+    assert has_mfa
+
+
+def test_has_mfa_claim_multiple_acr(oauth_client):
+    has_mfa = oauth_client.has_mfa_claim({"acr": "mfa otp duo"})
+    assert has_mfa
+
+
+def test_does_not_has_mfa_claim(oauth_client):
+    has_mfa = oauth_client.has_mfa_claim({"acr": "pwd"})
+    assert not has_mfa
+
+
+def test_does_not_has_mfa_claim_multiple(oauth_client):
+    has_mfa = oauth_client.has_mfa_claim({"acr": "pwd trustme"})
+    assert not has_mfa

--- a/tests/login/test_idp_oauth2.py
+++ b/tests/login/test_idp_oauth2.py
@@ -34,6 +34,9 @@ def test_does_not_has_mfa_claim(oauth_client):
     has_mfa = oauth_client.has_mfa_claim({"acr": "pwd"})
     assert not has_mfa
 
+    has_mfa = oauth_client.has_mfa_claim({"something": "mfa"})
+    assert not has_mfa
+
 
 def test_does_not_has_mfa_claim_multiple(oauth_client):
     has_mfa = oauth_client.has_mfa_claim({"acr": "pwd trustme"})

--- a/tests/login/test_idp_oauth2.py
+++ b/tests/login/test_idp_oauth2.py
@@ -3,7 +3,7 @@ from cdislogging import get_logger
 
 from fence import Oauth2ClientBase
 
-MOCK_SETTINGS = {
+MOCK_SETTINGS_ACR = {
     "client_id": "client",
     "client_secret": "hunter2",
     "redirect_url": "localhost",
@@ -12,32 +12,74 @@ MOCK_SETTINGS = {
         "values": ["mfa", "otp", "duo", "sms", "phonecall"],
     },
 }
+MOCK_SETTINGS_AMR = {
+    "client_id": "client",
+    "client_secret": "hunter2",
+    "redirect_url": "localhost",
+    "multifactor_auth_claim_info": {
+        "claim": "amr",
+        "values": ["mfa", "otp", "duo", "sms", "phonecall"],
+    },
+}
 logger = get_logger(__name__, log_level="debug")
 
 
 @pytest.fixture()
-def oauth_client():
-    return Oauth2ClientBase(settings=MOCK_SETTINGS, idp="mock", logger=logger)
+def oauth_client_acr():
+    return Oauth2ClientBase(settings=MOCK_SETTINGS_ACR, idp="mock", logger=logger)
 
 
-def test_has_mfa_claim(oauth_client):
-    has_mfa = oauth_client.has_mfa_claim({"acr": "mfa"})
+@pytest.fixture()
+def oauth_client_amr():
+    return Oauth2ClientBase(settings=MOCK_SETTINGS_AMR, idp="mock", logger=logger)
+
+
+def test_has_mfa_claim_acr(oauth_client_acr):
+    has_mfa = oauth_client_acr.has_mfa_claim({"acr": "mfa"})
     assert has_mfa
 
 
-def test_has_mfa_claim_multiple_acr(oauth_client):
-    has_mfa = oauth_client.has_mfa_claim({"acr": "mfa otp duo"})
+def test_has_mfa_claim_acr(oauth_client_acr):
+    has_mfa = oauth_client_acr.has_mfa_claim({"acr": "mfa"})
     assert has_mfa
 
 
-def test_does_not_has_mfa_claim(oauth_client):
-    has_mfa = oauth_client.has_mfa_claim({"acr": "pwd"})
+def test_has_mfa_claim_multiple_acr(oauth_client_acr):
+    has_mfa = oauth_client_acr.has_mfa_claim({"acr": "mfa otp duo"})
+    assert has_mfa
+
+
+def test_does_not_has_mfa_claim(oauth_client_acr):
+    has_mfa = oauth_client_acr.has_mfa_claim({"acr": "pwd"})
     assert not has_mfa
 
-    has_mfa = oauth_client.has_mfa_claim({"something": "mfa"})
+    has_mfa = oauth_client_acr.has_mfa_claim({"something": "mfa"})
     assert not has_mfa
 
 
-def test_does_not_has_mfa_claim_multiple(oauth_client):
-    has_mfa = oauth_client.has_mfa_claim({"acr": "pwd trustme"})
+def test_does_not_has_mfa_claim_multiple(oauth_client_acr):
+    has_mfa = oauth_client_acr.has_mfa_claim({"acr": "pwd trustme"})
+    assert not has_mfa
+
+
+def test_has_mfa_claim_amr(oauth_client_amr):
+    has_mfa = oauth_client_amr.has_mfa_claim({"amr": ["mfa"]})
+    assert has_mfa
+
+
+def test_has_mfa_claim_multiple_amr(oauth_client_amr):
+    has_mfa = oauth_client_amr.has_mfa_claim({"amr": ["mfa", "otp", "duo"]})
+    assert has_mfa
+
+
+def test_does_not_has_mfa_claim_amr(oauth_client_amr):
+    has_mfa = oauth_client_amr.has_mfa_claim({"amr": ["pwd"]})
+    assert not has_mfa
+
+    has_mfa = oauth_client_amr.has_mfa_claim({"something": ["mfa"]})
+    assert not has_mfa
+
+
+def test_does_not_has_mfa_claim_multiple_amr(oauth_client_amr):
+    has_mfa = oauth_client_amr.has_mfa_claim({"amr": ["pwd, trustme"]})
     assert not has_mfa

--- a/tests/login/test_microsoft_login.py
+++ b/tests/login/test_microsoft_login.py
@@ -13,7 +13,7 @@ def test_get_auth_url(microsoft_oauth2_client):
     assert url  # nosec
 
 
-def test_get_user_id(microsoft_oauth2_client):
+def test_get_auth_info(microsoft_oauth2_client):
     """
     Test getting a user id and check for email claim
     """
@@ -23,12 +23,12 @@ def test_get_user_id(microsoft_oauth2_client):
         "fence.resources.openid.idp_oauth2.Oauth2ClientBase.get_jwt_claims_identity",
         return_value=return_value,
     ):
-        user_id = microsoft_oauth2_client.get_user_id(code="123")
+        user_id = microsoft_oauth2_client.get_auth_info(code="123")
         for key, value in expected_value.items():
             assert return_value[key] == value
 
 
-def test_get_user_id_missing_claim(microsoft_oauth2_client):
+def test_get_auth_info_missing_claim(microsoft_oauth2_client):
     """
     Test getting a user id but missing the email claim
     """
@@ -38,15 +38,15 @@ def test_get_user_id_missing_claim(microsoft_oauth2_client):
         "fence.resources.openid.idp_oauth2.Oauth2ClientBase.get_jwt_claims_identity",
         return_value=return_value,
     ):
-        user_id = microsoft_oauth2_client.get_user_id(code="123")
+        user_id = microsoft_oauth2_client.get_auth_info(code="123")
         assert user_id == expected_value  # nosec
 
 
-def test_get_user_id_invalid_code(microsoft_oauth2_client):
+def test_get_auth_info_invalid_code(microsoft_oauth2_client):
     """
     Test getting a user id but with an invalid code
     """
     expected_value = "Can't get your Microsoft email:"
 
-    user_id = microsoft_oauth2_client.get_user_id(code="123")
+    user_id = microsoft_oauth2_client.get_auth_info(code="123")
     assert expected_value in user_id["error"]  # nosec

--- a/travis/pg_hba.conf
+++ b/travis/pg_hba.conf
@@ -1,0 +1,10 @@
+# This config file will be used for the Travis test run.
+#
+# The new PostgreSQL 13 changes some settings from what they originally were
+# in Travis, so we'll set them back. In particular we want to enable
+# passwordless authentication for connections to PostgreSQL.
+# Source: https://github.com/NCI-GDC/psqlgraph/blob/94f315db2c039217752cba85d9c63988f2059317/travis/pg_hba.conf
+local   all             postgres                                trust
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust

--- a/travis/postgresql.conf
+++ b/travis/postgresql.conf
@@ -1,0 +1,32 @@
+# This config file will be used for PostgreSQL 13 because Travis doesn't
+# have configurations set up for it yet. The most important part will be the
+# ramfs storage location change. It also defaults to port 5433 so we need to
+# change that back, too.
+# Copied from https://github.com/NCI-GDC/psqlgraph/blob/94f315db2c039217752cba85d9c63988f2059317/travis/postgresql.conf
+data_directory = '/var/ramfs/postgresql/13/main'
+hba_file = '/etc/postgresql/13/main/pg_hba.conf'
+ident_file = '/etc/postgresql/13/main/pg_ident.conf'
+external_pid_file = '/var/run/postgresql/13-main.pid'
+port = 5432
+max_connections = 255
+unix_socket_directories = '/var/run/postgresql'
+ssl = on
+ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'
+shared_buffers = 128MB
+dynamic_shared_memory_type = posix
+max_wal_size = 256MB
+min_wal_size = 80MB
+log_line_prefix = '%t '
+log_timezone = 'UTC'
+cluster_name = '13/main'
+stats_temp_directory = '/var/run/postgresql/13-main.pg_stat_tmp'
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+lc_messages = 'en_US.UTF-8'
+lc_monetary = 'en_US.UTF-8'
+lc_numeric = 'en_US.UTF-8'
+lc_time = 'en_US.UTF-8'
+default_text_search_config = 'pg_catalog.english'
+include_dir = 'conf.d'
+fsync = false


### PR DESCRIPTION
Adds the mfa_policy on login when the configured claim and value are present in the user's id_token.


### New Features
- Enables support for identifying when users have authenticated with MFA.  

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- Deployment changes to enable this feature for commons are described here https://github.com/uc-cdis/fence/blob/e36f6574ade17bb8c9c0c9df8801f9a59de423b1/docs/fence_multifactor_authentication_guide.md
<!-- This section should only contain important things devops should know when updating service versions. -->
