### PR TITLE
Pull resources from auth_mapping

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,14 +259,14 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 1556
+        "line_number": 1559
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/conftest.py",
         "hashed_secret": "227dea087477346785aefd575f91dd13ab86c108",
         "is_verified": false,
-        "line_number": 1579
+        "line_number": 1582
       }
     ],
     "tests/credentials/google/test_credentials.py": [
@@ -395,5 +395,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-20T20:37:17Z"
+  "generated_at": "2023-11-16T21:15:57Z"
 }

--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -114,10 +114,8 @@ def get_user_info(current_session, username):
 
     if hasattr(flask.current_app, "arborist"):
         try:
-            resources = flask.current_app.arborist.list_resources_for_user(
-                user.username
-            )
             auth_mapping = flask.current_app.arborist.auth_mapping(user.username)
+            resources = list(auth_mapping.keys())
         except ArboristError as exc:
             logger.error(
                 f"request to arborist for user's resources failed; going to list empty. Error: {exc}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,7 +391,10 @@ def mock_arborist_requests(request):
 
     def do_patch(urls_to_responses=None):
         urls_to_responses = urls_to_responses or {}
-        defaults = {"arborist/health": {"GET": ("", 200)}}
+        defaults = {
+            "arborist/health": {"GET": ("", 200)},
+            "arborist/auth/mapping": {"POST": ({}, "200")},
+        }
         defaults.update(urls_to_responses)
         urls_to_responses = defaults
 

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,9 +1,16 @@
 import mock
 import urllib.request, urllib.parse, urllib.error
 
+import pytest
+
 from fence.auth import build_redirect_url
 from fence.config import config
 from fence.resources.storage.cdis_jwt import create_session_token
+
+
+@pytest.fixture(autouse=True)
+def mock_arborist(mock_arborist_requests):
+    mock_arborist_requests()
 
 
 def test_redirect_url():


### PR DESCRIPTION
Link to JIRA Issue: [PXP-11181](https://ctds-planx.atlassian.net/browse/PXP-11181)
### New Features


### Breaking Changes


### Bug Fixes
- Fixes issue where users not present in arborist would have blank resources and authz fields when they should have values for open access data within the commons. 

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-11181]: https://ctds-planx.atlassian.net/browse/PXP-11181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ