### PR TITLE
Feat/s3 delete files

### DIFF
--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -388,9 +388,9 @@ def app_config(
 
 def _setup_data_endpoint_and_boto(app):
     if "AWS_CREDENTIALS" in config and len(config["AWS_CREDENTIALS"]) > 0:
-        value = list(config["AWS_CREDENTIALS"].values())[0]
+        creds = config["AWS_CREDENTIALS"]
         buckets = config.get("S3_BUCKETS", {})
-        app.boto = BotoManager(value, buckets, logger=logger)
+        app.boto = BotoManager(creds, buckets, logger=logger)
         app.register_blueprint(fence.blueprints.data.blueprint, url_prefix="/data")
 
 

--- a/fence/__init__.py
+++ b/fence/__init__.py
@@ -389,7 +389,8 @@ def app_config(
 def _setup_data_endpoint_and_boto(app):
     if "AWS_CREDENTIALS" in config and len(config["AWS_CREDENTIALS"]) > 0:
         value = list(config["AWS_CREDENTIALS"].values())[0]
-        app.boto = BotoManager(value, logger=logger)
+        buckets = config.get("S3_BUCKETS", {})
+        app.boto = BotoManager(value, buckets, logger=logger)
         app.register_blueprint(fence.blueprints.data.blueprint, url_prefix="/data")
 
 

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -1150,6 +1150,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
 
     def delete(self, bucket, file_id):
         try:
+            print(f"DEBUG boto: {flask.current_app.boto}")
             return flask.current_app.boto.delete_data_file(bucket, file_id)
         except Exception as e:
             logger.error(e)

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -349,12 +349,13 @@ class BlankIndex(object):
         Returns:
             uploadId(str)
         """
-        bucket = bucket or flask.current_app.config["DATA_UPLOAD_BUCKET"]
         if not bucket:
-            raise InternalError(
-                "fence not configured with data upload bucket; can't create signed URL"
-            )
-
+            try:
+                bucket = flask.current_app.config["DATA_UPLOAD_BUCKET"]
+            except KeyError:
+                raise InternalError(
+                    "fence not configured with data upload bucket; can't create signed URL"
+                )
         s3_url = "s3://{}/{}".format(bucket, key)
         return S3IndexedFileLocation(s3_url).init_multipart_upload(expires_in)
 

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -1150,7 +1150,6 @@ class S3IndexedFileLocation(IndexedFileLocation):
 
     def delete(self, bucket, file_id):
         try:
-            print(f"DEBUG boto: {flask.current_app.boto}")
             return flask.current_app.boto.delete_data_file(bucket, file_id)
         except Exception as e:
             logger.error(e)

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -349,8 +349,9 @@ class BlankIndex(object):
         Returns:
             uploadId(str)
         """
-        bucket = bucket or flask.current_app.config["DATA_UPLOAD_BUCKET"]
-        if not bucket:
+        try:
+            bucket = bucket or flask.current_app.config["DATA_UPLOAD_BUCKET"]
+        except KeyError:
             raise InternalError(
                 "fence not configured with data upload bucket; can't create signed URL"
             )

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -349,13 +349,12 @@ class BlankIndex(object):
         Returns:
             uploadId(str)
         """
+        bucket = bucket or flask.current_app.config["DATA_UPLOAD_BUCKET"]
         if not bucket:
-            try:
-                bucket = flask.current_app.config["DATA_UPLOAD_BUCKET"]
-            except KeyError:
-                raise InternalError(
-                    "fence not configured with data upload bucket; can't create signed URL"
-                )
+            raise InternalError(
+                "fence not configured with data upload bucket; can't create signed URL"
+            )
+
         s3_url = "s3://{}/{}".format(bucket, key)
         return S3IndexedFileLocation(s3_url).init_multipart_upload(expires_in)
 

--- a/fence/blueprints/data/multipart_upload.py
+++ b/fence/blueprints/data/multipart_upload.py
@@ -159,10 +159,9 @@ def generate_presigned_url_for_uploading_part(
     additional_signed_qs = {"partNumber": str(partNumber), "uploadId": uploadId}
 
     try:
-        presigned_url = generate_aws_presigned_url(
+        return generate_aws_presigned_url(
             url, "PUT", credentials, "s3", region, expires, additional_signed_qs
         )
-        return presigned_url
     except Exception as e:
         raise InternalError(
             "Can not generate presigned url for part number {} of key {}. Detail {}".format(

--- a/fence/blueprints/data/multipart_upload.py
+++ b/fence/blueprints/data/multipart_upload.py
@@ -39,6 +39,7 @@ def initialize_multipart_upload(bucket_name, key, credentials):
         aws_secret_access_key=credentials["aws_secret_access_key"],
         aws_session_token=credentials.get("aws_session_token"),
     )
+
     s3client = None
     if url:
         s3client = session.client("s3", endpoint_url=url)
@@ -93,6 +94,7 @@ def complete_multipart_upload(bucket_name, key, credentials, uploadId, parts):
         aws_secret_access_key=credentials["aws_secret_access_key"],
         aws_session_token=credentials.get("aws_session_token"),
     )
+
     s3client = None
     if url:
         s3client = session.client("s3", endpoint_url=url)
@@ -145,12 +147,7 @@ def generate_presigned_url_for_uploading_part(
     )
     bucket = s3_buckets.get(bucket_name)
 
-    s3_buckets = get_value(
-        config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
-    )
-    bucket = s3_buckets.get(bucket_name)
-
-    if bucket.get("endpoint_url"):
+    if s3_buckets.get("endpoint_url"):
         url = bucket["endpoint_url"].strip("/") + "/{}/{}".format(
             bucket_name, key.strip("/")
         )

--- a/fence/blueprints/data/multipart_upload.py
+++ b/fence/blueprints/data/multipart_upload.py
@@ -39,7 +39,6 @@ def initialize_multipart_upload(bucket_name, key, credentials):
         aws_secret_access_key=credentials["aws_secret_access_key"],
         aws_session_token=credentials.get("aws_session_token"),
     )
-
     s3client = None
     if url:
         s3client = session.client("s3", endpoint_url=url)
@@ -94,7 +93,6 @@ def complete_multipart_upload(bucket_name, key, credentials, uploadId, parts):
         aws_secret_access_key=credentials["aws_secret_access_key"],
         aws_session_token=credentials.get("aws_session_token"),
     )
-
     s3client = None
     if url:
         s3client = session.client("s3", endpoint_url=url)
@@ -147,7 +145,12 @@ def generate_presigned_url_for_uploading_part(
     )
     bucket = s3_buckets.get(bucket_name)
 
-    if s3_buckets.get("endpoint_url"):
+    s3_buckets = get_value(
+        config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
+    )
+    bucket = s3_buckets.get(bucket_name)
+
+    if bucket.get("endpoint_url"):
         url = bucket["endpoint_url"].strip("/") + "/{}/{}".format(
             bucket_name, key.strip("/")
         )
@@ -156,9 +159,10 @@ def generate_presigned_url_for_uploading_part(
     additional_signed_qs = {"partNumber": str(partNumber), "uploadId": uploadId}
 
     try:
-        return generate_aws_presigned_url(
+        presigned_url = generate_aws_presigned_url(
             url, "PUT", credentials, "s3", region, expires, additional_signed_qs
         )
+        return presigned_url
     except Exception as e:
         raise InternalError(
             "Can not generate presigned url for part number {} of key {}. Detail {}".format(

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -70,7 +70,7 @@ class BotoManager(object):
                 self.logger.error("multiple files found with prefix {}".format(prefix))
                 return ("Multiple files found matching this prefix. Backing off.", 400)
             key = s3_objects["Contents"][0]["Key"]
-            s3_client.delete_object(Bucket=bucket, Key=key)
+            self.s3_client.delete_object(Bucket=bucket, Key=key)
             self.logger.info(
                 "deleted file for prefix {} in bucket {}".format(prefix, bucket)
             )

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -18,30 +18,28 @@ class BotoManager(object):
     )
 
     def __init__(self, config, buckets, logger):
-        self.sts_client = client("sts", **config)
-        self.s3_client = client("s3", **config)
+        default = list(config.values())[0]
+        self.sts_client = client("sts", **default)
+        self.s3_client = client("s3", **default)
         self.s3_clients = self.create_s3_clients(config, buckets)
         self.logger = logger
         self.ec2 = None
         self.iam = None
 
     def create_s3_clients(self, config, buckets):
-        s3_clients = {}
-        for creds in config:
-            if config[creds]['aws'] == 'true':
-                s3_clients = {'default': self.s3_client}
+        s3_clients = {'default': self.s3_client}
 
         for bucket in buckets:
             cred_name = buckets[bucket]['cred']
-            keys = config[cred_name]
-            if 'aws' in keys:
-                keys.pop('aws')
+            creds = {}
+            if cred_name != '*':
+                creds = config[cred_name]
 
             if 'endpoint_url' in buckets[bucket]:
                 endpoint_url = buckets[bucket]['endpoint_url']
-                s3_clients[bucket] = client('s3', **keys, endpoint_url=endpoint_url)
+                s3_clients[bucket] = client('s3', **creds, endpoint_url=endpoint_url)
             else:
-                s3_clients[bucket] = client('s3', **keys)
+                s3_clients[bucket] = client('s3', **creds)
         return s3_clients
 
     def get_s3_client(self, bucket):

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -26,14 +26,22 @@ class BotoManager(object):
         self.iam = None
 
     def create_s3_clients(self, config, buckets):
-        s3_clients = {
-            'default': client('s3', **config)
-        }
+        s3_clients = {}
+        for creds in config:
+            if config[creds]['aws'] == 'true':
+                s3_clients = {'default': self.s3_client}
+
         for bucket in buckets:
+            cred_name = buckets[bucket]['cred']
+            keys = config[cred_name]
+            if 'aws' in keys:
+                keys.pop('aws')
+
             if 'endpoint_url' in buckets[bucket]:
                 endpoint_url = buckets[bucket]['endpoint_url']
-                endpoint_url = buckets[bucket]['endpoint_url']
-                s3_clients[bucket] = client('s3', **config, endpoint_url=endpoint_url)
+                s3_clients[bucket] = client('s3', **keys, endpoint_url=endpoint_url)
+            else:
+                s3_clients[bucket] = client('s3', **keys)
         return s3_clients
 
     def get_s3_client(self, bucket):

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -19,7 +19,7 @@ class BotoManager(object):
 
     def __init__(self, config, logger):
         self.sts_client = client("sts", **config)
-        self.s3_client = client("s3", **config)
+        self.s3_client = client("s3", endpoint_url='TODO', **config)
         self.logger = logger
         self.ec2 = None
         self.iam = None

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -76,7 +76,7 @@ class BotoManager(object):
                 self.logger.error("multiple files found with prefix {}".format(prefix))
                 return ("Multiple files found matching this prefix. Backing off.", 400)
             key = s3_objects["Contents"][0]["Key"]
-            self.s3_client.delete_object(Bucket=bucket, Key=key)
+            s3_client.delete_object(Bucket=bucket, Key=key)
             self.logger.info(
                 "deleted file for prefix {} in bucket {}".format(prefix, bucket)
             )

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -27,14 +27,12 @@ class BotoManager(object):
         self.iam = None
 
     def create_s3_clients(self, config, buckets):
-        s3_clients = {'default': self.s3_client}
-
+        s3_clients = {}
         for bucket in buckets:
             cred_name = buckets[bucket]['cred']
             creds = {}
             if cred_name != '*':
                 creds = config[cred_name]
-
             if 'endpoint_url' in buckets[bucket]:
                 endpoint_url = buckets[bucket]['endpoint_url']
                 s3_clients[bucket] = client('s3', **creds, endpoint_url=endpoint_url)
@@ -44,7 +42,7 @@ class BotoManager(object):
 
     def get_s3_client(self, bucket):
         if self.s3_clients.get(bucket) is None:
-            return self.s3_clients['default']
+            return self.s3_clients[0]
         return self.s3_clients[bucket]
 
     def delete_data_file(self, bucket, prefix):

--- a/fence/resources/aws/boto_manager.py
+++ b/fence/resources/aws/boto_manager.py
@@ -30,9 +30,8 @@ class BotoManager(object):
             'default': client('s3', **config)
         }
         for bucket in buckets:
-            print(f"DEBUG bucket: {bucket}")
-            if buckets[bucket]['endpoint_url'] is not None:
-                print(f"DEBUG endpoint_url: {endpoint_url}")
+            if 'endpoint_url' in buckets[bucket]:
+                endpoint_url = buckets[bucket]['endpoint_url']
                 endpoint_url = buckets[bucket]['endpoint_url']
                 s3_clients[bucket] = client('s3', **config, endpoint_url=endpoint_url)
         return s3_clients

--- a/tests/data/test_boto_manager.py
+++ b/tests/data/test_boto_manager.py
@@ -42,7 +42,7 @@ def test_create_s3_client_single(mock_client):
     s3_clients = boto_manager.create_s3_clients(config, buckets)
 
     # Assert that the correct call was made to the client function
-    mock_client.assert_any_call('s3', access_key='key1', secret_key='key1', endpoint_url='https://example.com')
+    mock_client.assert_any_call('s3', access_key='key1', secret_key='secret1', endpoint_url='https://example.com')
 
     # Assert that the returned dictionary contains the correct client
     assert len(s3_clients) == 1

--- a/tests/data/test_boto_manager.py
+++ b/tests/data/test_boto_manager.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fence.resources.aws.boto_manager import BotoManager
+
+
+class TestData:
+    """Generate bucket test data that aims to mirror the default example Fence config file."""
+    def __init__(self):
+        self.config = {}
+        self.buckets = {}
+
+    def single_bucket(self):
+        self.config = {
+            'CRED1': {'access_key': 'key1', 'secret_key': 'secret1'},
+        }
+        self.buckets = {
+            'bucket1': {'cred': 'CRED1', 'region': 'us-east-1', 'endpoint_url': 'https://example.com'},
+        }
+        return self
+
+    def multiple_buckets(self):
+        single_bucket = self.single_bucket()
+        self.config = single_bucket.config | {
+            'CRED2': {'access_key': 'key2', 'secret_key': 'secret2'},
+        }
+        self.buckets = single_bucket.buckets | {
+            'bucket2': {'cred': 'CRED2', 'region': 'us-east-1'},
+            'bucket3': {'cred': '*'},
+            'bucket4': {'cred': 'CRED1', 'region': 'us-east-1', 'role-arn': 'arn:aws:iam::role1'}
+        }
+        return self
+
+
+@patch('fence.resources.aws.boto_manager.client')
+def test_create_s3_client_single(mock_client):
+    test_data = TestData().single_bucket()
+    config = test_data.config
+    buckets = test_data.buckets
+    logger = MagicMock()
+    boto_manager = BotoManager(config, buckets, logger)
+
+    s3_clients = boto_manager.create_s3_clients(config, buckets)
+
+    # Assert that the correct call was made to the client function
+    mock_client.assert_any_call('s3', access_key='key1', secret_key='key1', endpoint_url='https://example.com')
+
+    # Assert that the returned dictionary contains the correct client
+    assert len(s3_clients) == 1
+    assert 'bucket1' in s3_clients
+
+
+@patch('fence.resources.aws.boto_manager.client')
+def test_create_s3_clients_multiple(mock_client):
+    test_data = TestData().multiple_buckets()
+    config = test_data.config
+    buckets = test_data.buckets
+    logger = MagicMock()
+    boto_manager = BotoManager(config, buckets, logger)
+
+    # Call the method under test
+    s3_clients = boto_manager.create_s3_clients(config, buckets)
+
+    # Assert that the correct calls were made to the client function
+    mock_client.assert_any_call('s3', access_key='key1', secret_key='secret1', endpoint_url='https://example.com')
+    mock_client.assert_any_call('s3', access_key='key2', secret_key='secret2')
+    mock_client.assert_any_call('s3')
+    mock_client.assert_any_call('s3', access_key='key1', secret_key='secret1')
+
+    # Assert that the returned dictionary contains the correct clients
+    assert len(s3_clients) == 4
+    assert 'bucket1' in s3_clients
+    assert 'bucket2' in s3_clients
+    assert 'bucket3' in s3_clients
+    assert 'bucket4' in s3_clients
+
+
+@pytest.mark.parametrize("bucket", ['bucket1', 'bucket2', 'bucket3', 'bucket4'])
+@patch('fence.resources.aws.boto_manager.client')
+def test_delete_data_file(mock_client, bucket):
+    test_data = TestData().multiple_buckets()
+    config = test_data.config
+    buckets = test_data.buckets
+    logger = MagicMock()
+    boto_manager = BotoManager(config, buckets, logger)
+
+    # Mock the response of list_objects_v2 to include the desired key
+    prefix = 'data/file.txt'
+    mock_list_objects_v2_response = {
+        'Contents': [{'Key': prefix}]
+    }
+    # Set up the mock S3 client and its list_objects_v2 and delete_object methods
+    mock_s3_client = mock_client.return_value
+    mock_s3_client.list_objects_v2.return_value = mock_list_objects_v2_response
+
+    result = boto_manager.delete_data_file(bucket, prefix)
+
+    # Create S3 clients for each of the buckets
+    _ = boto_manager.create_s3_clients(config, buckets)
+    s3_client = boto_manager.get_s3_client(bucket)
+    s3_client.list_objects_v2.assert_called_once_with(
+        Bucket=bucket, Prefix=prefix, Delimiter="/"
+    )
+    s3_client.delete_object.assert_called_once_with(Bucket=bucket, Key='data/file.txt')
+
+    # Assert the expected result
+    assert result == ("", 204)


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

### New Features

- Adds support for deleting files from non-AWS S3-compatible endpoints (e.g. MinIO, Wasabi, Ceph).

### Breaking Changes

- None

### Bug Fixes

- Fixes the "The AWS Access Key Id you provided does not exist" error when attempting to delete a file from a non-AWS bucket.

### Improvements

- Allows for Gen3 administrators to have greater flexibility in choosing their preferred data storage, while keeping the AWS S3 endpoint as the "default" storage option.

### Dependency updates

- None

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->

- None

### Initial Bug Report

#### Issue

When attempting to delete an indexd record using the [delete_file_locations() ](https://uc-cdis.github.io/gen3sdk-python/_build/html/file.html#gen3.file.Gen3File.delete_file_locations)method in the Gen3 SDK, we encounter a “The AWS Access Key Id you provided does not exist” error. The indexd record is in non-AWS S3 bucket (MinIO endpoint), which is specified by the endpoint_url of the bucket in the Fence config.
 
#### Expected Behavior

The [delete_file_locations() ](https://uc-cdis.github.io/gen3sdk-python/_build/html/file.html#gen3.file.Gen3File.delete_file_locations)method should delete both the file and the indexd record for both AWS and non-AWS S3-compatible buckets.

#### Error Message

```
[2023-11-17 21:33:45,499][fence.blueprints.data.blueprint][   INFO] Deleting record and files for <EXAMPLE>

[2023-11-17 21:33:45,504][fence.blueprints.data.indexd][   INFO] Attempting to delete file named <EXAMPLE> from bucket example-production.

[2023-11-17 21:33:45,803][fence.blueprints.data.indexd][  ERROR] An error occurred (InvalidAccessKeyId) when calling the ListObjectsV2 operation: The AWS Access Key Id you provided does not exist in our records.  <--- AWS Access Key Error
```
 
#### Possible Cause

It might be possible the the endpoint_url of the bucket isn’t being passed to the Boto client in the Fence code?
 
**fence-config.yaml:**
```yaml
      example-bucket:
        cred: 'EXAMPLE-USER'
        programs:
        - example_program
        endpoint_url: https://minio-storage.example.edu/  <-- Endpoint URL of the MinIO S3 Bucket
```