### PR TITLE
Comment out parent_to_child_studies_mapping in config-default.yaml

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -564,7 +564,7 @@ dbGaP:
     #
     # If `parse_consent_code` is true, then a user will be given access to the exact
     # same consent codes in the child studies
-    parent_to_child_studies_mapping:
+    # parent_to_child_studies_mapping:
       # 'phs001194': ['phs000571', 'phs001843']
     # A consent of "c999" can indicate access to that study's "exchange area data"
     # and when a user has access to one study's exchange area data, they


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
- When using helm, the empty config gets mapped to the string "None" when providing values.yaml overrides for a helm deployment. This causes config validation to break as a dict or None is expected, not a string that says "None"

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
