### PR TITLE
PXP-11364 handle csv ordering with userinfo

### DIFF
--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -507,7 +507,7 @@ class UserSyncer(object):
 
         """
         user_projects = dict()
-        user_info = dict()
+        user_info = defaultdict(dict)
 
         # parse dbGaP sftp server information
         dbgap_key = dbgap_config.get("decrypt_key", None)
@@ -658,9 +658,9 @@ class UserSyncer(object):
                         tags["pi"] = row["downloader for names"]
 
                     user_info[username] = {
-                        "email": row.get("email") or "",
+                        "email": row.get("email") or user_info[username].get('email') or "",
                         "display_name": display_name,
-                        "phone_number": row.get("phone") or "",
+                        "phone_number": row.get("phone") or user_info[username].get('phone_number') or "",
                         "tags": tags,
                     }
 
@@ -1571,6 +1571,8 @@ class UserSyncer(object):
             local_csv_file_list = glob.glob(
                 os.path.join(self.sync_from_local_csv_dir, "*")
             )
+            # Sort the list so the order of of files is consistent across platforms
+            local_csv_file_list.sort()
 
         user_projects_csv, user_info_csv = self._merge_multiple_local_csv_files(
             local_csv_file_list,

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -542,6 +542,7 @@ class UserSyncer(object):
             ]  # when converting the YAML from fence-config, python reads it as Python string literal. So "\" turns into "\\" which messes with the regex match
             project_id_patterns += patterns
 
+        self.logger.info(f"Using these file paths: {file_dict.items()}")
         for filepath, privileges in file_dict.items():
             self.logger.info("Reading file {}".format(filepath))
             if os.stat(filepath).st_size == 0:


### PR DESCRIPTION

Link to JIRA ticket if there is one:  [PXP-11364](https://ctds-planx.atlassian.net/browse/PXP-11364)

### New Features

### Breaking Changes

### Bug Fixes
- Fix so local csvs file are processed in consistent order, regardless of os
- Updates user_info overwrite logic to preserve data when processing CSVs without some attributes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-11364]: https://ctds-planx.atlassian.net/browse/PXP-11364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ