### PR TITLE
Fix bulk_google_group_update for RAS Visa Sync

### DIFF
--- a/fence/resources/google/access_utils.py
+++ b/fence/resources/google/access_utils.py
@@ -42,7 +42,7 @@ class GoogleUpdateException(Exception):
     pass
 
 
-def bulk_update_google_groups(google_bulk_mapping):
+def bulk_update_google_groups(google_bulk_mapping, keep_existing=False):
     """
     Update Google Groups based on mapping provided from Group -> Users.
 
@@ -103,21 +103,22 @@ def bulk_update_google_groups(google_bulk_mapping):
                     google_update_failures = True
 
             # do remove
-            for member_email in to_delete:
-                logger.info(f"Removing from group {group}: {member_email}")
+            if not keep_existing:
+                for member_email in to_delete:
+                    logger.info(f"Removing from group {group}: {member_email}")
 
-                try:
-                    _remove_member_from_google_group(gcm, member_email, group)
-                except Exception as exc:
-                    logger.error(
-                        f"ERROR: FAILED TO REMOVE MEMBER {member_email} FROM "
-                        f"GOOGLE GROUP {group}! This sync will SKIP "
-                        f"the above user to try and update other authorization "
-                        f"(rather than failing early). The error will be re-raised "
-                        f"after attempting to update all other users. Exc: "
-                        f"{traceback.format_exc()}"
-                    )
-                    google_update_failures = True
+                    try:
+                        _remove_member_from_google_group(gcm, member_email, group)
+                    except Exception as exc:
+                        logger.error(
+                            f"ERROR: FAILED TO REMOVE MEMBER {member_email} FROM "
+                            f"GOOGLE GROUP {group}! This sync will SKIP "
+                            f"the above user to try and update other authorization "
+                            f"(rather than failing early). The error will be re-raised "
+                            f"after attempting to update all other users. Exc: "
+                            f"{traceback.format_exc()}"
+                        )
+                        google_update_failures = True
 
             if google_update_failures:
                 raise GoogleUpdateException(

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -999,7 +999,7 @@ class UserSyncer(object):
 
         if config["GOOGLE_BULK_UPDATES"]:
             self.logger.info("Doing bulk Google update...")
-            bulk_update_google_groups(google_bulk_mapping)
+            bulk_update_google_groups(google_bulk_mapping, keep_existing=True)
             self.logger.info("Bulk Google update done!")
 
         sess.commit()


### PR DESCRIPTION
Updates sync_single_user_visas to stop dropping existing google group membership. This preserves group access when a user with a visa logs in.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Updates sync_single_user_visas to stop dropping existing google group membership. This preserves group access when a user with a visa logs in.
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
