### PR TITLE
Fix/presigned url addressing style

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -1101,7 +1101,7 @@ class S3IndexedFileLocation(IndexedFileLocation):
             aws_secret_access_key=credential["aws_secret_access_key"],
             aws_session_token=credential.get("aws_session_token", None),
             region_name=region,
-            config=Config(s3={"addressing_style": "path"}, signature_version="s3v4"),
+            config=Config(signature_version="s3v4"),
         )
 
         cirrus_aws = AwsService(s3client)

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -1095,12 +1095,14 @@ class S3IndexedFileLocation(IndexedFileLocation):
             region = flask.current_app.boto.get_bucket_region(
                 self.parsed_url.netloc, credential
             )
+        endpoint_url = bucket.get("endpoint_url", None)
         s3client = boto3.client(
             "s3",
             aws_access_key_id=credential["aws_access_key_id"],
             aws_secret_access_key=credential["aws_secret_access_key"],
             aws_session_token=credential.get("aws_session_token", None),
             region_name=region,
+            endpoint_url=endpoint_url,
             config=Config(signature_version="s3v4"),
         )
 

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -30,7 +30,6 @@ from fence.auth import (
     login_required,
     set_current_token,
     validate_request,
-    JWTError,
 )
 from fence.config import config
 from fence.errors import (

--- a/fence/blueprints/data/multipart_upload.py
+++ b/fence/blueprints/data/multipart_upload.py
@@ -142,12 +142,18 @@ def generate_presigned_url_for_uploading_part(
         presigned_url(str)
     """
     try:
+        s3_buckets = get_value(
+            config, "S3_BUCKETS", InternalError("S3_BUCKETS not configured")
+        )
+        bucket = s3_buckets.get(bucket_name)
+        endpoint_url = bucket.get("endpoint_url", None)
         s3client = boto3.client(
             "s3",
             aws_access_key_id=credentials["aws_access_key_id"],
             aws_secret_access_key=credentials["aws_secret_access_key"],
             aws_session_token=credentials.get("aws_session_token", None),
             region_name=region,
+            endpoint_url=endpoint_url,
             config=Config(signature_version="s3v4"),
         )
         cirrus_aws = AwsService(s3client)

--- a/fence/blueprints/data/multipart_upload.py
+++ b/fence/blueprints/data/multipart_upload.py
@@ -148,7 +148,7 @@ def generate_presigned_url_for_uploading_part(
             aws_secret_access_key=credentials["aws_secret_access_key"],
             aws_session_token=credentials.get("aws_session_token", None),
             region_name=region,
-            config=Config(s3={"addressing_style": "path"}, signature_version="s3v4"),
+            config=Config(signature_version="s3v4"),
         )
         cirrus_aws = AwsService(s3client)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "10.3.0"
+version = "10.3.1"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION

### Bug Fixes
- Use `auto` addressing style for presigned url generation (attempts to use `virtual`, but falls back to `path` if necessary)
- Pass `endpoint_url` from Fence config to boto3 client for presigned url creation


