### PR TITLE
(Fix): Usersync ccdecrypt output not parsing

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       SERVICE_TO_TEST: fence
-      TEST_REPO_BRANCH: chore/custom_cloud_auto_branch
+      TEST_REPO_BRANCH: chore/fix_usersync_fence_image_during_tests
     secrets:
       CI_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
       CI_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       SERVICE_TO_TEST: fence
+      TEST_REPO_BRANCH: chore/custom_cloud_auto_branch
     secrets:
       CI_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
       CI_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,7 +12,6 @@ jobs:
     uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       SERVICE_TO_TEST: fence
-      TEST_REPO_BRANCH: chore/fix_usersync_fence_image_during_tests
     secrets:
       CI_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
       CI_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -113,9 +113,9 @@ def _read_file(filepath, encrypted=True, key=None, logger=None):
             print("--------read_file--------------------------------")
             print(p)
             print(p.communicate())
-            print(p.communicate()[0])
+            yield (p.communicate())
             print("----end read file--------------------------------")
-            yield StringIO(p.communicate()[0])
+            # yield StringIO(p.communicate()[0])
         except UnicodeDecodeError:
             logger.error("Could not decode file. Check the decryption key.")
     else:

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -549,8 +549,18 @@ class UserSyncer(object):
             with _read_file(
                 filepath, encrypted=encrypted, key=dbgap_key, logger=self.logger
             ) as f:
+                print("--------printing f-------")
+                print
+                print(f.read())
+
                 csv = DictReader(f, quotechar='"', skipinitialspace=True)
+
+                print("----csv----")
+                print(csv)
+
                 for row in csv:
+                    print("-----row-----")
+                    print(row)
                     username = row.get("login") or ""
                     if username == "":
                         continue

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -552,15 +552,9 @@ class UserSyncer(object):
             with _read_file(
                 filepath, encrypted=encrypted, key=dbgap_key, logger=self.logger
             ) as f:
-                print("--------printing f-------")
                 csv = DictReader(f, quotechar='"', skipinitialspace=True)
 
-                print("----csv----")
-                print(csv)
-
                 for row in csv:
-                    print("-----row-----")
-                    print(row)
                     username = row.get("login") or ""
                     if username == "":
                         continue

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -110,6 +110,11 @@ def _read_file(filepath, encrypted=True, key=None, logger=None):
             ]
         )
         try:
+            print("--------read_file--------------------------------")
+            print(p)
+            print(p.communicate())
+            print(p.communicate()[0])
+            print("----end read file--------------------------------")
             yield StringIO(p.communicate()[0])
         except UnicodeDecodeError:
             logger.error("Could not decode file. Check the decryption key.")

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -107,15 +107,13 @@ def _read_file(filepath, encrypted=True, key=None, logger=None):
                 "-K",
                 key,
                 filepath,
-            ]
+            ],
+            stdout=sp.PIPE,
+            stderr=open(os.devnull, "w"),
+            universal_newlines=True,
         )
         try:
-            print("--------read_file--------------------------------")
-            print(p)
-            print(p.communicate())
-            yield (p.communicate())
-            print("----end read file--------------------------------")
-            # yield StringIO(p.communicate()[0])
+            yield StringIO(p.communicate()[0])
         except UnicodeDecodeError:
             logger.error("Could not decode file. Check the decryption key.")
     else:

--- a/fence/sync/sync_users.py
+++ b/fence/sync/sync_users.py
@@ -555,9 +555,6 @@ class UserSyncer(object):
                 filepath, encrypted=encrypted, key=dbgap_key, logger=self.logger
             ) as f:
                 print("--------printing f-------")
-                print
-                print(f.read())
-
                 csv = DictReader(f, quotechar='"', skipinitialspace=True)
 
                 print("----csv----")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "11.0.1"
+version = "11.1.0"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "11.0.0"
+version = "11.0.1"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
While changing from mcrypt to ccrypt, we didn't add `stdout` for the result of `ccdecrypt`. So we would decrypt the file but not output the file to somewhere its readable. 


### Bug Fixes
- Fixed usersync decrypted result not parsing 

