### PR TITLE
Unit tests: check that Prometheus is configured correctly

### DIFF
--- a/tests/ci_commands_script.sh
+++ b/tests/ci_commands_script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p /var/tmp/uwsgi_flask_metrics/ || true
-export PROMETHEUS_MULTIPROC_DIR="/var/tmp/uwsgi_flask_metrics/"
+export PROMETHEUS_CONFIGURED_FOR_TESTS=1; export PROMETHEUS_MULTIPROC_DIR="/var/tmp/uwsgi_flask_metrics/"
 poetry run pytest -vv --cov=fence --cov=migrations/versions --cov-report xml tests

--- a/tests/utils/metrics.py
+++ b/tests/utils/metrics.py
@@ -29,7 +29,7 @@ def reset_prometheus_metrics():
     logic? Because it doesn't work, the prometheus client also keeps the state, and the mismatch
     causes errors. This only works when the client is reset too (new process)
     """
-    assert os.environ.get("PROMETHEUS_CONFIGURED_FOR_TESTS"), "Prometheus is not configured correctly. Make sure to the tests using `tests/ci_commands_script.sh`."
+    assert os.environ.get("PROMETHEUS_CONFIGURED_FOR_TESTS"), "Prometheus is not configured correctly. Make sure to run the tests using `tests/ci_commands_script.sh`."
 
     yield
 

--- a/tests/utils/metrics.py
+++ b/tests/utils/metrics.py
@@ -29,6 +29,8 @@ def reset_prometheus_metrics():
     logic? Because it doesn't work, the prometheus client also keeps the state, and the mismatch
     causes errors. This only works when the client is reset too (new process)
     """
+    assert os.environ.get("PROMETHEUS_CONFIGURED_FOR_TESTS"), "Prometheus is not configured correctly. Make sure to the tests using `tests/ci_commands_script.sh`."
+
     yield
 
     folder = os.environ["PROMETHEUS_MULTIPROC_DIR"]


### PR DESCRIPTION
Before any prometheus unit test runs, check that prometheus is configured correctly, instead of getting hard to debug errors when it's not.

I added a new env var `PROMETHEUS_CONFIGURED_FOR_TESTS` because we can't rely on the existing `PROMETHEUS_MULTIPROC_DIR`; the tests can fail even when it's set ([here](https://github.com/uc-cdis/fence/blob/7b0aa60/fence/metrics.py#L45)) if it hasn't been set _before_ the tests started running.