### PR TITLE
fix: add a note in the migrations folder alerting about the manual migration possibility

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -2,4 +2,4 @@
 
 :warning: When adding any new migration logic, **please make sure** to also include
 a note in your PR and/or release notes about the new migration, since Fence can
-also be configured to have migrations executed manually by a sysadmin.
+be configured to have migrations executed manually by a sysadmin instead of automatically.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,5 @@
+# README
+
+:warning: When adding any new migration logic, **please make sure** to also include
+a note in your PR and/or release notes about the new migration, since Fence can
+also be configured to have migrations executed manually by a sysadmin.


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/CADC-1795


### Improvements
- The assumption that all migrations are executed automatically on startup is not correct, and therefore it is crucial that the README of a PR in Fence that adds a migration, ALWAYS contains a “Deployment changes” section. 
   - This PR adds a warning README in the /migrations folder to warn future developers about this.

