### PR TITLE
Admin endpoints support "client_credentials" tokens again

### DIFF
--- a/fence/resources/audit/utils.py
+++ b/fence/resources/audit/utils.py
@@ -100,7 +100,8 @@ def create_log_for_request(request: Request):
     record a log entry.
     """
     claims = validate_jwt()
-    username = get_user_from_claims(claims).username
+    username = get_user_from_claims(claims).username if "sub" in claims else "None"
+    client_id = claims.get("azp", "None") or "None"
     method = request.method
     endpoint = request.path
     request_url = endpoint
@@ -109,8 +110,9 @@ def create_log_for_request(request: Request):
         request_url += f"?{request.query_string.decode('utf-8')}"
     request_url = _clean_authorization_request_url(request_url)
     logger.info(
-        f"Incoming request: user=%s, method=%s, endpoint=%s, request_url=%s",
+        f"Incoming request: user=%s, client=%s, method=%s, endpoint=%s, request_url=%s",
         username,
+        client_id,
         method,
         endpoint,
         request_url,

--- a/tests/admin/test_admin_users_endpoints.py
+++ b/tests/admin/test_admin_users_endpoints.py
@@ -234,7 +234,7 @@ def test_get_user_long_username(
     assert len(log_capture) >= 1
     # Now check for the specific message:
     messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
-    expected_log_message = f"INFO - Incoming request: user=admin_user, method=GET, endpoint=/admin/users/{username}, request_url=/admin/users/{username}"
+    expected_log_message = f"INFO - Incoming request: user=admin_user, client=None, method=GET, endpoint=/admin/users/{username}, request_url=/admin/users/{username}"
     assert expected_log_message in messages, (
         f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
         + "\n".join(messages)
@@ -330,7 +330,7 @@ def test_post_user(client, admin_user, encoded_admin_jwt, db_session, log_captur
     assert len(log_capture) >= 1
     # Now check for the specific message:
     messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
-    expected_log_message = "INFO - Incoming request: user=admin_user, method=POST, endpoint=/admin/user, request_url=/admin/user"
+    expected_log_message = "INFO - Incoming request: user=admin_user, client=None, method=POST, endpoint=/admin/user, request_url=/admin/user"
     assert expected_log_message in messages, (
         f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
         + "\n".join(messages)
@@ -763,7 +763,7 @@ def test_soft_delete_user_username(
     assert len(log_capture) >= 1
     # Now check for the specific message:
     messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
-    expected_log_message = f"INFO - Incoming request: user=admin_user, method=DELETE, endpoint=/admin/users/{username}/soft, request_url=/admin/users/{username}/soft"
+    expected_log_message = f"INFO - Incoming request: user=admin_user, client=None, method=DELETE, endpoint=/admin/users/{username}/soft, request_url=/admin/users/{username}/soft"
     assert expected_log_message in messages, (
         f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
         + "\n".join(messages)
@@ -793,7 +793,7 @@ def test_soft_delete_user_user_not_found(
     assert len(log_capture) >= 1
     # Now check for the specific message:
     messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
-    expected_log_message = f"INFO - Incoming request: user=admin_user, method=DELETE, endpoint=/admin/users/{username}/soft, request_url=/admin/users/{username}/soft"
+    expected_log_message = f"INFO - Incoming request: user=admin_user, client=None, method=DELETE, endpoint=/admin/users/{username}/soft, request_url=/admin/users/{username}/soft"
     assert expected_log_message in messages, (
         f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
         + "\n".join(messages)

--- a/tests/admin/test_admin_users_endpoints.py
+++ b/tests/admin/test_admin_users_endpoints.py
@@ -349,17 +349,16 @@ def test_post_user(client, admin_user, encoded_admin_jwt, db_session, log_captur
     )
 
 
-def test_post_user_client_jwt(client, encoded_client_jwt, log_capture):
+def test_post_user_client_jwt(client, encoded_client_jwt, db_session, log_capture):
     """Test if call to an admin endpoint (in this case POST /user: [create_user] )
     with a client jwt (instead of regular jwt) gets the right information logged,
     where we expect the username to be "None" and the client name to
     be "somevalue" (according to what is in encoded_client_jwt).
     """
-    encoded_client_jwt_str = encoded_client_jwt
     r = client.post(
         "/admin/user",
         headers={
-            "Authorization": "Bearer " + encoded_client_jwt_str,
+            "Authorization": "Bearer " + encoded_client_jwt,
             "Content-Type": "application/json",
         },
         data=json.dumps(

--- a/tests/admin/test_admin_users_endpoints.py
+++ b/tests/admin/test_admin_users_endpoints.py
@@ -62,6 +62,18 @@ def encoded_admin_jwt(kid, rsa_private_key):
     return jwt.encode(claims, key=rsa_private_key, headers=headers, algorithm="RS256")
 
 
+@pytest.fixture(scope="function")
+def encoded_client_jwt(kid, rsa_private_key):
+    """
+    Use this fixture to simulate client connection and its jwt.
+    """
+    headers = {"kid": kid}
+    claims = utils.default_claims()
+    del claims["sub"]
+    claims["azp"] = "somevalue"
+    return jwt.encode(claims, key=rsa_private_key, headers=headers, algorithm="RS256")
+
+
 # Dictionary for all these random magic numbers that the delete user
 # tests/fixtures are using
 userd_dict = {
@@ -331,6 +343,39 @@ def test_post_user(client, admin_user, encoded_admin_jwt, db_session, log_captur
     # Now check for the specific message:
     messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
     expected_log_message = "INFO - Incoming request: user=admin_user, client=None, method=POST, endpoint=/admin/user, request_url=/admin/user"
+    assert expected_log_message in messages, (
+        f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
+        + "\n".join(messages)
+    )
+
+
+def test_post_user_client_jwt(client, encoded_client_jwt, log_capture):
+    """Test if call to an admin endpoint (in this case POST /user: [create_user] )
+    with a client jwt (instead of regular jwt) gets the right information logged,
+    where we expect the username to be "None" and the client name to
+    be "somevalue" (according to what is in encoded_client_jwt).
+    """
+    encoded_client_jwt_str = encoded_client_jwt
+    r = client.post(
+        "/admin/user",
+        headers={
+            "Authorization": "Bearer " + encoded_client_jwt_str,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(
+            {
+                "username": "new_test_user",
+                "role": "user",
+                "email": "new_test_user@fake.com",
+            }
+        ),
+    )
+    assert r.status_code == 200
+    # also assert that the logs were recorded:
+    assert len(log_capture) >= 1
+    # Now check for the specific message:
+    messages = [f"{r.levelname} - {r.getMessage()}" for r in log_capture]
+    expected_log_message = "INFO - Incoming request: user=None, client=somevalue, method=POST, endpoint=/admin/user, request_url=/admin/user"
     assert expected_log_message in messages, (
         f"\n{expected_log_message} -> not found in INFO logs. Actual messages:\n"
         + "\n".join(messages)


### PR DESCRIPTION
Fix bug introduced in #1234 when using client_credentials tokens to hit admin endpoints:
```
Traceback: Traceback (most recent call last):
  File "/fence/.venv/lib/python3.9/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/fence/.venv/lib/python3.9/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/fence/fence/authz/auth.py", line 91, in wrapper
    return f(*f_args, **f_kwargs)
  File "/fence/fence/resources/audit/utils.py", line 128, in wrapper
    create_log_for_request(flask.request)
  File "/fence/fence/resources/audit/utils.py", line 103, in create_log_for_request
    username = get_user_from_claims(claims).username
  File "/fence/fence/auth.py", line 306, in get_user_from_claims
    .filter(User.id == claims["sub"])
KeyError: 'sub'
```

### Bug Fixes
- Admin endpoints support "client_credentials" tokens again

### Improvements
- Request logs now include the client ID, if any