### PR TITLE
Fix `/login` providers cache

### DIFF
--- a/fence/blueprints/login/__init__.py
+++ b/fence/blueprints/login/__init__.py
@@ -198,7 +198,7 @@ def get_provider_info(login_details):
     ), f"Unable to get list of {login_details['idp']} IdPs: 'OPENID_CONNECT.{login_details['idp']}.idp_discovery.format' not configured"
     cache_key = f"all_{login_details['idp']}_upstream_idps"
     if not UPSTREAM_IDP_CACHE.has(cache_key):
-        UPSTREAM_IDP_CACHE.add(
+        UPSTREAM_IDP_CACHE.set(
             cache_key,
             get_all_upstream_idps(
                 login_details["idp"],

--- a/fence/blueprints/privacy.py
+++ b/fence/blueprints/privacy.py
@@ -45,7 +45,7 @@ def privacy_policy():
         )
         if not file_contents:
             raise NotFound("this endpoint is not configured")
-        cache.add("privacy-policy-md", file_contents)
+        cache.set("privacy-policy-md", file_contents)
 
     if "text/markdown" in str(flask.request.accept_mimetypes).lower():
         return flask.Response(cache.get("privacy-policy-md"), mimetype="text/markdown")
@@ -54,5 +54,5 @@ def privacy_policy():
             html = Markdown().convert(cache.get("privacy-policy-md"))
             if not html:
                 raise NotFound("this endpoint is not configured")
-            cache.add("privacy-policy-html", html)
+            cache.set("privacy-policy-html", html)
         return flask.Response(cache.get("privacy-policy-html"), mimetype="text/html")


### PR DESCRIPTION
After the cache expires, `cache.add()` does nothing, because the key still technically exists, it's just expired. Need to use `cache.set()` instead.
```
from cachelib import SimpleCache
CACHE = SimpleCache(default_timeout=1)
cache_key = "abc"

if not CACHE.has(cache_key):
    CACHE.add(cache_key, 123)

import time; time.sleep(2)

if not CACHE.has(cache_key):
    CACHE.add(cache_key, 123)
    print(CACHE.get(cache_key))  # ==> prints "None"

if not CACHE.has(cache_key):
    CACHE.set(cache_key, 123)
    print(CACHE.get(cache_key))  # ==> prints "123"
```

Fix this error:
```
  File "/fence/fence/blueprints/login/__init__.py", line 298, in get_login_providers_info
    all_provider_info = [
  File "/fence/fence/blueprints/login/__init__.py", line 299, in <listcomp>
    get_provider_info(login_details) for login_details in login_options
  File "/fence/fence/blueprints/login/__init__.py", line 217, in get_provider_info
    (
TypeError: 'NoneType' object is not iterable
```

### Bug Fixes
- Fix the `/login` endpoint to set the providers cache correctly after it expires
