### PR TITLE
Don't google group sync on non-GS access

### DIFF
--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -99,7 +99,8 @@ def get_signed_url_for_file(
 
     users_from_passports = {}
     if ga4gh_passports:
-        # users_from_passports = {"username": Fence.User}
+        # Note: We don't need to check for None requested_protocol here, as using a ga4gh_passport requires specifying
+        # a protocol
         users_from_passports = sync_gen3_users_authz_from_ga4gh_passports(
             ga4gh_passports,
             db_session=db_session,

--- a/fence/blueprints/data/indexd.py
+++ b/fence/blueprints/data/indexd.py
@@ -6,7 +6,6 @@ from botocore.client import Config
 from urllib.parse import urlparse, ParseResult, urlunparse
 from datetime import datetime, timedelta, UTC
 from sqlalchemy import text
-from sqlalchemy.sql.functions import user
 from cached_property import cached_property
 import gen3cirrus
 from gen3cirrus import GoogleCloudManager
@@ -23,7 +22,6 @@ from azure.storage.blob import (
     generate_blob_sas,
 )
 
-from fence import auth
 from fence.auth import (
     get_ip_information_string,
     get_jwt,
@@ -54,7 +52,7 @@ from fence.utils import get_valid_expiration_from_request
 from fence.metrics import metrics
 
 from . import multipart_upload
-from ...models import AssumeRoleCacheAWS, query_for_user, query_for_user_by_id
+from ...models import AssumeRoleCacheAWS, query_for_user
 from ...models import AssumeRoleCacheGCP
 
 logger = get_logger(__name__)
@@ -66,6 +64,7 @@ ACTION_DICT = {
 }
 
 SUPPORTED_PROTOCOLS = ["s3", "http", "ftp", "https", "gs", "az"]
+PROTOCOLS_REQUIRING_GOOGLE_SYNC = {"gs"}
 SUPPORTED_ACTIONS = ["upload", "download"]
 ANONYMOUS_USER_ID = "-1"
 ANONYMOUS_USERNAME = "anonymous"
@@ -102,7 +101,10 @@ def get_signed_url_for_file(
     if ga4gh_passports:
         # users_from_passports = {"username": Fence.User}
         users_from_passports = sync_gen3_users_authz_from_ga4gh_passports(
-            ga4gh_passports, db_session=db_session
+            ga4gh_passports,
+            db_session=db_session,
+            skip_google_updates=requested_protocol
+            not in PROTOCOLS_REQUIRING_GOOGLE_SYNC,
         )
 
     # Collect X-Forwarded headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fence"
-version = "13.1.0"
+version = "13.1.1"
 description = "Gen3 AuthN/AuthZ OIDC Service"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -6,6 +6,11 @@ import jwt
 import pytest
 import requests
 import responses
+
+from fence.blueprints.data.indexd import (
+    SUPPORTED_PROTOCOLS,
+    PROTOCOLS_REQUIRING_GOOGLE_SYNC,
+)
 from tests import utils
 from tests.conftest import NoAsyncMagicMock
 import time
@@ -1765,3 +1770,131 @@ def test_get_presigned_url_with_client_token(
 
     signed_url = response.json.get("url")
     assert signed_url
+
+
+@pytest.mark.parametrize("access_id", SUPPORTED_PROTOCOLS)
+@responses.activate
+@patch("httpx.get")
+@patch("fence.resources.google.utils._create_proxy_group")
+@patch("fence.scripting.fence_create.ArboristClient")
+@patch("fence.blueprints.data.indexd.sync_gen3_users_authz_from_ga4gh_passports")
+def test_get_presigned_url_with_passport_sets_skip_google_updates_by_protocol(
+    mock_sync_gen3_users_authz_from_ga4gh_passports,
+    mock_arborist,
+    mock_google_proxy_group,
+    mock_httpx_get,
+    access_id,
+    client,
+    kid,
+    rsa_private_key,
+    rsa_public_key,
+    indexd_client_accepting_record,
+    mock_arborist_requests,
+    google_proxy_group,
+    primary_google_service_account,
+    cloud_manager,
+    google_signed_url,
+):
+    config["GA4GH_PASSPORTS_TO_DRS_ENABLED"] = True
+
+    test_guid = "1"
+    indexd_record = {
+        "did": test_guid,
+        "baseid": "",
+        "rev": "",
+        "size": 10,
+        "file_name": "file1",
+        "urls": [
+            "s3://bucket1/key",
+            "gs://bucket1/key",
+            "http://example.com/bucket1/key",
+            "https://example.com/bucket1/key",
+            "ftp://example.com/bucket1/key",
+            "az://bucket1/key",
+        ],
+        "hashes": {},
+        "metadata": {},
+        "authz": ["/orgA/programs/phs000991.c1"],
+        "acl": ["*"],
+        "form": "",
+        "created_date": "",
+        "updated_date": "",
+    }
+    indexd_client_accepting_record(indexd_record)
+
+    mock_arborist_requests({"arborist/auth/request": {"POST": ({"auth": True}, 200)}})
+    mock_arborist.return_value = NoAsyncMagicMock(ArboristClient)
+    mock_google_proxy_group.return_value = google_proxy_group
+
+    current_time = int(time.time())
+    headers = {"kid": kid}
+    decoded_visa = {
+        "iss": "https://stsstg.nih.gov",
+        "sub": TEST_RAS_SUB,
+        "iat": current_time,
+        "exp": current_time + 1000,
+        "scope": "openid ga4gh_passport_v1 email profile",
+        "jti": "jtiajoidasndokmasdl",
+        "txn": "sapidjspa.asipidja",
+        "name": "",
+        "ga4gh_visa_v1": {
+            "type": "https://ras.nih.gov/visas/v1.1",
+            "asserted": current_time,
+            "value": "https://stsstg.nih.gov/passport/dbgap/v1.1",
+            "source": "https://ncbi.nlm.nih.gov/gap",
+        },
+        "ras_dbgap_permissions": [
+            {
+                "consent_name": "Health/Medical/Biomedical",
+                "phs_id": "phs000991",
+                "version": "v1",
+                "participant_set": "p1",
+                "consent_group": "c1",
+                "role": "designated user",
+                "expiration": current_time + 1000,
+            }
+        ],
+    }
+    encoded_visa = jwt.encode(
+        decoded_visa, key=rsa_private_key, headers=headers, algorithm="RS256"
+    )
+
+    passport_header = {
+        "type": "JWT",
+        "alg": "RS256",
+        "kid": kid,
+    }
+    passport = {
+        "iss": "https://stsstg.nih.gov",
+        "sub": TEST_RAS_SUB,
+        "iat": current_time,
+        "scope": "openid ga4gh_passport_v1 email profile",
+        "exp": current_time + 1000,
+        "ga4gh_passport_v1": [encoded_visa],
+    }
+    encoded_passport = jwt.encode(
+        passport, key=rsa_private_key, headers=passport_header, algorithm="RS256"
+    )
+
+    keys = [keypair.public_key_to_jwk() for keypair in flask.current_app.keypairs]
+    mock_httpx_get.return_value = httpx.Response(200, json={"keys": keys})
+
+    res = client.post(
+        "/ga4gh/drs/v1/objects/" + test_guid + "/access/" + access_id,
+        headers={
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"passports": [encoded_passport]}),
+    )
+
+    assert res.status_code in [200, 401, 404, 500]
+    assert mock_sync_gen3_users_authz_from_ga4gh_passports.called
+
+    expected_skip_google_updates = access_id not in PROTOCOLS_REQUIRING_GOOGLE_SYNC
+
+    assert (
+        mock_sync_gen3_users_authz_from_ga4gh_passports.call_args.kwargs[
+            "skip_google_updates"
+        ]
+        == expected_skip_google_updates
+    )

--- a/tests/test_drs.py
+++ b/tests/test_drs.py
@@ -1795,6 +1795,10 @@ def test_get_presigned_url_with_passport_sets_skip_google_updates_by_protocol(
     cloud_manager,
     google_signed_url,
 ):
+    """
+    Tests that google group sync is skipped for protocols that don't require google groups for data access, always in
+    the case where passports are used to access data.
+    """
     config["GA4GH_PASSPORTS_TO_DRS_ENABLED"] = True
 
     test_guid = "1"


### PR DESCRIPTION
Update passport flow for DRS to skip google group sync when accessing files stored in non-GS locations

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
- DRS with passport no longer hangs waiting for google group sync for non-GS access
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
